### PR TITLE
Fix FormatException

### DIFF
--- a/SonarScanner.Shim/RoslynV1SarifFixer.cs
+++ b/SonarScanner.Shim/RoslynV1SarifFixer.cs
@@ -64,6 +64,10 @@ namespace SonarScanner.Shim
             {
                 return false;
             }
+            catch (FormatException) // we expect invalid JSON
+            {
+                return false;
+            }
             return true;
         }
 


### PR DESCRIPTION
When call "MSBuild.SonarQube.Runner.exe  end"
With version 2.2 I get:

E:\jenkinsDir\jobs\Framework\workspace>E:\jenkinsDir\tools\hudson.plugins.sonar.MsBuildSQRunnerInstallation\sonarQubeScannerMSBuild14_2.2\MSBuild.SonarQube.Runner.exe  end
SonarQube Scanner for MSBuild 2.2
Default properties file was found at E:\jenkinsDir\tools\hudson.plugins.sonar.MsBuildSQRunnerInstallation\sonarQubeScannerMSBuild14_2.2\SonarQube.Analysis.xml
Loading analysis properties from E:\jenkinsDir\tools\hudson.plugins.sonar.MsBuildSQRunnerInstallation\sonarQubeScannerMSBuild14_2.2\SonarQube.Analysis.xml
Post-processing started.
SonarQube Scanner for MSBuild 2.2
17:36:20.067  Loading the SonarQube analysis config from E:\jenkinsDir\jobs\Framework\workspace\.sonarqube\conf\SonarQubeAnalysisConfig.xml
17:36:20.068  Not running under TeamBuild
17:36:20.069  Analysis base directory: E:\jenkinsDir\jobs\Framework\workspace\.sonarqube
Build directory:
Bin directory: E:\jenkinsDir\jobs\Framework\workspace\.sonarqube\bin
Config directory: E:\jenkinsDir\jobs\Framework\workspace\.sonarqube\conf
Output directory: E:\jenkinsDir\jobs\Framework\workspace\.sonarqube\out
Config file: E:\jenkinsDir\jobs\Framework\workspace\.sonarqube\conf\SonarQubeAnalysisConfig.xml
Generating SonarQube project properties file to E:\jenkinsDir\jobs\Framework\workspace\.sonarqube\out\sonar-project.properties

Exception non gérée : System.FormatException: Le format de la chaîne d'entrée est incorrect.
   à System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
   à System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
   à Newtonsoft.Json.JsonTextReader.ParseUnicode()
   à Newtonsoft.Json.JsonTextReader.ReadStringIntoBuffer(Char quote)
   à Newtonsoft.Json.JsonTextReader.ParseString(Char quote)
   à Newtonsoft.Json.JsonTextReader.ParseValue()
   à Newtonsoft.Json.JsonTextReader.ReadInternal()
   à Newtonsoft.Json.JsonTextReader.Read()
   à Newtonsoft.Json.Linq.JContainer.ReadContentFrom(JsonReader r)
   à Newtonsoft.Json.Linq.JContainer.ReadTokenFrom(JsonReader reader)
   à Newtonsoft.Json.Linq.JObject.Load(JsonReader reader)
   à Newtonsoft.Json.Linq.JObject.Parse(String json)
   à SonarScanner.Shim.RoslynV1SarifFixer.IsValidJson(String input)
   à SonarScanner.Shim.RoslynV1SarifFixer.LoadAndFixFile(String sarifFilePath, String language, ILogger logger)
   à SonarScanner.Shim.PropertiesFileGenerator.TryFixSarifReport(ILogger logger, ProjectInfo project, IRoslynV1SarifFixer fixer, String language, String reportFilePropertyKey)
   à SonarScanner.Shim.PropertiesFileGenerator.TryFixSarifReports(ILogger logger, IEnumerable`1 projects, IRoslynV1SarifFixer fixer)
   à SonarScanner.Shim.PropertiesFileGenerator.GenerateFile(AnalysisConfig config, ILogger logger, IRoslynV1SarifFixer fixer)
   à SonarScanner.Shim.SonarScannerWrapper.Execute(AnalysisConfig config, IEnumerable`1 userCmdLineArguments, ILogger logger)
   à SonarQube.TeamBuild.PostProcessor.MSBuildPostProcessor.InvokeSonarScanner(IAnalysisPropertyProvider cmdLineArgs, AnalysisConfig config)
   à SonarQube.TeamBuild.PostProcessor.MSBuildPostProcessor.Execute(String[] args, AnalysisConfig config, ITeamBuildSettings settings)
   à SonarQube.Bootstrapper.BootstrapperClass.PostProcess()
   à SonarQube.Bootstrapper.BootstrapperClass.Execute()
   à SonarQube.Bootstrapper.Program.Main(String[] args)
   à SonarQube.Old.Bootstrapper.Program.Main(String[] args)

This modification fix this error.