### PR TITLE
Improve error handling with exceptions

### DIFF
--- a/SonarQube.Bootstrapper/BootstrapperClass.cs
+++ b/SonarQube.Bootstrapper/BootstrapperClass.cs
@@ -56,17 +56,25 @@ namespace SonarQube.Bootstrapper
             AnalysisPhase phase = BootstrapSettings.Phase;
             LogProcessingStarted(phase);
 
-            if (phase == AnalysisPhase.PreProcessing)
+            try
             {
-                exitCode = PreProcess();
+                if (phase == AnalysisPhase.PreProcessing)
+                {
+                    exitCode = PreProcess();
+                }
+                else
+                {
+                    exitCode = PostProcess();
+                }
+
             }
-            else
+            catch (AnalysisException ex)
             {
-                exitCode = PostProcess();
+                Logger.LogError(ex.Message);
+                exitCode = ErrorCode;
             }
 
             LogProcessingCompleted(phase, exitCode);
-
             return exitCode;
         }
 

--- a/SonarQube.Common/AnalysisException.cs
+++ b/SonarQube.Common/AnalysisException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SonarQube.Common
+{
+    /// <summary>
+    /// Thrown when a there is an error that is well handled and should cause the process to exit in a clean way. 
+    /// The message will be logged and the process will return exit code 1.
+    /// </summary>
+    public class AnalysisException : Exception
+    {
+        public AnalysisException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/SonarQube.Common/SonarQube.Common.csproj
+++ b/SonarQube.Common/SonarQube.Common.csproj
@@ -54,6 +54,7 @@
     <Compile Include="AnalysisConfig\Rule.cs" />
     <Compile Include="AnalysisConfig\Rules.cs" />
     <Compile Include="AnalysisConfig\RuleSet.cs" />
+    <Compile Include="AnalysisException.cs" />
     <Compile Include="AnalysisProperties\EmptyPropertyProvider.cs" />
     <Compile Include="AnalysisProperties\EnvScannerPropertiesProvider.cs" />
     <Compile Include="AnalysisProperties\ListSettingsProvider.cs" />

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
@@ -155,7 +155,6 @@ namespace SonarQube.TeamBuild.PreProcessor.Roslyn
             {
                 rulesetFilePath = GetRulesetFilePath(this.sqSettings, language);
                 this.logger.LogDebug(Resources.RAP_UnpackingRuleset, rulesetFilePath);
-
                 ruleSet.Save(rulesetFilePath);
             }
             return rulesetFilePath;

--- a/SonarQube.TeamBuild.PreProcessor/Roslyn/RoslynRuleSetGenerator.cs
+++ b/SonarQube.TeamBuild.PreProcessor/Roslyn/RoslynRuleSetGenerator.cs
@@ -37,6 +37,11 @@ namespace SonarQube.TeamBuild.PreProcessor.Roslyn.Model
             this.serverSettings = serverSettings;
         }
 
+        /// <summary>
+        /// Generates a RuleSet that is serializable (XML).
+        /// The ruleset can be empty if there are no active rules belonging to the repo keys "vbnet", "csharpsquid" or "roslyn.*".
+        /// </summary>
+        /// <exception cref="AnalysisException">if mandatory properties that should be associated with the repo key are missing.</exception>
         public RuleSet Generate(IEnumerable<ActiveRule> activeRules, IEnumerable<string> inactiveRules, string language)
         {
             if (activeRules == null || !activeRules.Any())
@@ -100,7 +105,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Roslyn.Model
         {
             int pos = keyWithRepo.IndexOf(':');
             repo = keyWithRepo.Substring(0, pos);
-            key = keyWithRepo.Substring(pos+1);
+            key = keyWithRepo.Substring(pos + 1);
         }
 
         private static Dictionary<string, List<ActiveRule>> ActiveRoslynRulesByPartialRepoKey(IEnumerable<ActiveRule> activeRules, string language)
@@ -126,7 +131,7 @@ namespace SonarQube.TeamBuild.PreProcessor.Roslyn.Model
         private static void AddDict<T>(Dictionary<string, List<T>> dict, string key, T value)
         {
             List<T> list;
-            if(!dict.TryGetValue(key, out list))
+            if (!dict.TryGetValue(key, out list))
             {
                 list = new List<T>();
                 dict.Add(key, list);
@@ -154,11 +159,12 @@ namespace SonarQube.TeamBuild.PreProcessor.Roslyn.Model
             {
                 if (propertyKey.StartsWith(string.Format(SONARANALYZER_PARTIAL_REPO_KEY, "vbnet")))
                 {
-                    throw new ArgumentException("Property doesn't exist: " + propertyKey + " . Check if you are using SonarVB 3.0+.");
+                    throw new AnalysisException("Property doesn't exist: " + propertyKey
+                        + ". Possible cause: this Scanner is not compatible with SonarVB 2.X. If necessary, upgrade SonarVB to 3.0+ in SonarQube.");
                 }
                 else
                 {
-                    throw new ArgumentException("key doesn't exist: " + propertyKey);
+                    throw new AnalysisException("Key doesn't exist: " + propertyKey +". This property should be set by the plugin in SonarQube.");
 
                 }
             }


### PR DESCRIPTION
Currently, throwing exceptions will cause the process to fail with an "unhandled exception" which is very ugly. This is what is happening if a old VB plugin is installed in SonarQube (see SONARMSBRU-284).
The way to stop the scanner due to a well understood problem is to propagate a boolean flag all the way to the bootstrapper, which will log that the program failed and set a return code 1.
With this P/R I introduce a new, easier way to fail programs when the error is correctly handled: to throw a custom exceptions anywhere. The bootstrapper will catch this specific exception, log it, and return error code 1.