### PR TITLE
Added support for visual studio 15 code coverage tool

### DIFF
--- a/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
- 
+
 using Microsoft.Win32;
 using SonarQube.Common;
 using System;
@@ -26,6 +26,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.Setup.Configuration;
 
 namespace SonarQube.TeamBuild.Integration
 {
@@ -43,6 +44,11 @@ namespace SonarQube.TeamBuild.Integration
         /// Partial path to the code coverage exe, from the Visual Studio shell folder
         /// </summary>
         private const string TeamToolPathandExeName = @"Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe";
+
+        /// <summary>
+        /// Code coverage package name for Visual Studio setup configuration
+        /// </summary>
+        private const string CodeCoverageInstallationPackage = "Microsoft.VisualStudio.TestTools.CodeCoverage";
 
         private string conversionToolPath;
 
@@ -108,11 +114,70 @@ namespace SonarQube.TeamBuild.Integration
 
         #region Private methods
 
-        private static string GetExeToolPath(ILogger logger)
+        private string GetExeToolPath(ILogger logger)
+        {
+            logger.LogDebug(Resources.CONV_DIAG_LocatingCodeCoverageTool);
+            return GetExeToolPathFromSetupConfiguration(logger) ??
+                   GetExeToolPathFromRegistry(logger);
+        }
+
+        #region Code Coverage Tool path from setup configuration
+
+        private string GetExeToolPathFromSetupConfiguration(ILogger logger)
         {
             string toolPath = null;
 
-            logger.LogDebug(Resources.CONV_DIAG_LocatingCodeCoverageTool);
+            logger.LogDebug(Resources.CONV_DIAG_LocatingCodeCoverageToolSetupConfiguration);
+            ISetupConfiguration configurationQuery = setupConfigurationFactory.GetSetupConfigurationQuery();
+            if (configurationQuery != null)
+            {
+                IEnumSetupInstances instanceEnumerator = configurationQuery.EnumInstances();
+
+                int fetched;
+                ISetupInstance[] tempInstance = new ISetupInstance[1];
+
+                List<ISetupInstance2> instances = new List<ISetupInstance2>();
+                //Enumerate the configuration instances
+                do
+                {
+                    instanceEnumerator.Next(1, tempInstance, out fetched);
+                    if (fetched > 0)
+                    {
+                        ISetupInstance2 instance = (ISetupInstance2)tempInstance[0];
+                        if (instance.GetPackages().Any(p => p.GetId() == CodeCoverageInstallationPackage))
+                        {
+                            //Store instances that have code coverage package installed
+                            instances.Add((ISetupInstance2)tempInstance[0]);
+                        }
+                    }
+                } while (fetched > 0);
+
+                if (instances.Count > 1)
+                {
+                    logger.LogDebug(Resources.CONV_DIAG_MultipleVsVersionsInstalled, string.Join(", ", instances.Select(i => i.GetInstallationVersion())));
+                }
+
+                toolPath = instances.OrderByDescending(i => i.GetInstallationVersion())
+                                    .Select(i => i.GetInstallationPath())
+                                    .FirstOrDefault();
+            }
+            else
+            {
+                logger.LogDebug(Resources.CONV_DIAG_SetupConfigurationNotSupported);
+            }
+
+            return toolPath;
+        }
+
+        #endregion Code Coverage Tool path from setup configuration
+
+        #region Code Coverage Tool path from registry
+
+        private static string GetExeToolPathFromRegistry(ILogger logger)
+        {
+            string toolPath = null;
+
+            logger.LogDebug(Resources.CONV_DIAG_LocatingCodeCoverageToolRegistry);
             using (RegistryKey key = Registry.LocalMachine.OpenSubKey(VisualStudioRegistryPath, false))
             {
                 // i.e. no VS installed
@@ -205,6 +270,8 @@ namespace SonarQube.TeamBuild.Integration
             }
             return result;
         }
+
+        #endregion Code Coverage Tool path from registry
 
         // was internal
         public static bool ConvertBinaryToXml(string converterExeFilePath, string inputBinaryFilePath, string outputXmlFilePath, ILogger logger)

--- a/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
@@ -157,9 +157,15 @@ namespace SonarQube.TeamBuild.Integration
                     logger.LogDebug(Resources.CONV_DIAG_MultipleVsVersionsInstalled, string.Join(", ", instances.Select(i => i.GetInstallationVersion())));
                 }
 
-                toolPath = instances.OrderByDescending(i => i.GetInstallationVersion())
-                                    .Select(i => i.GetInstallationPath())
-                                    .FirstOrDefault();
+                //Get the installation path for the latest visual studio found
+                var visualStudioPath = instances.OrderByDescending(i => i.GetInstallationVersion())
+                                                .Select(i => i.GetInstallationPath())
+                                                .FirstOrDefault();
+
+                if (visualStudioPath != null)
+                {
+                    toolPath = Path.Combine(visualStudioPath, TeamToolPathandExeName);
+                }
             }
             else
             {

--- a/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
@@ -32,6 +32,7 @@ namespace SonarQube.TeamBuild.Integration
     public class CoverageReportConverter : ICoverageReportConverter
     {
         private const int ConversionTimeoutInMs = 60000;
+        private readonly IVisualStudioSetupConfigurationFactory setupConfigurationFactory;
 
         /// <summary>
         /// Registry containing information about installed VS versions
@@ -44,6 +45,19 @@ namespace SonarQube.TeamBuild.Integration
         private const string TeamToolPathandExeName = @"Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe";
 
         private string conversionToolPath;
+
+        #region Public methods
+
+        public CoverageReportConverter()
+            : this(new VisualStudioSetupConfigurationFactory())
+        { }
+
+        public CoverageReportConverter(IVisualStudioSetupConfigurationFactory setupConfigurationFactory)
+        {
+            this.setupConfigurationFactory = setupConfigurationFactory;
+        }
+
+        #endregion Public methods
 
         #region IReportConverter interface
 

--- a/SonarQube.TeamBuild.Integration/Interfaces/IVisualStudioSetupConfigurationFactory.cs
+++ b/SonarQube.TeamBuild.Integration/Interfaces/IVisualStudioSetupConfigurationFactory.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.VisualStudio.Setup.Configuration;
+
+namespace SonarQube.TeamBuild.Integration
+{
+    public interface IVisualStudioSetupConfigurationFactory
+    {
+        /// <summary>
+        /// Attempts to instantiate a queryable setup configuration object.
+        /// </summary>
+        /// <returns></returns>
+        ISetupConfiguration GetSetupConfigurationQuery();
+    }
+}

--- a/SonarQube.TeamBuild.Integration/Resources.Designer.cs
+++ b/SonarQube.TeamBuild.Integration/Resources.Designer.cs
@@ -79,11 +79,38 @@ namespace SonarQube.TeamBuild.Integration {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Attempting to locate the CodeCoverage.exe tool using registry....
+        /// </summary>
+        internal static string CONV_DIAG_LocatingCodeCoverageToolRegistry {
+            get {
+                return ResourceManager.GetString("CONV_DIAG_LocatingCodeCoverageToolRegistry", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Attempting to locate the CodeCoverage.exe tool using setup configuration....
+        /// </summary>
+        internal static string CONV_DIAG_LocatingCodeCoverageToolSetupConfiguration {
+            get {
+                return ResourceManager.GetString("CONV_DIAG_LocatingCodeCoverageToolSetupConfiguration", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Multiple versions of VS are installed: {0}.
         /// </summary>
         internal static string CONV_DIAG_MultipleVsVersionsInstalled {
             get {
                 return ResourceManager.GetString("CONV_DIAG_MultipleVsVersionsInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Visual Studio setup configuration was not found..
+        /// </summary>
+        internal static string CONV_DIAG_SetupConfigurationNotSupported {
+            get {
+                return ResourceManager.GetString("CONV_DIAG_SetupConfigurationNotSupported", resourceCulture);
             }
         }
         

--- a/SonarQube.TeamBuild.Integration/Resources.resx
+++ b/SonarQube.TeamBuild.Integration/Resources.resx
@@ -123,9 +123,18 @@
   <data name="CONV_DIAG_LocatingCodeCoverageTool" xml:space="preserve">
     <value>Attempting to locate the CodeCoverage.exe tool...</value>
   </data>
+  <data name="CONV_DIAG_LocatingCodeCoverageToolRegistry" xml:space="preserve">
+    <value>Attempting to locate the CodeCoverage.exe tool using registry...</value>
+  </data>
+  <data name="CONV_DIAG_LocatingCodeCoverageToolSetupConfiguration" xml:space="preserve">
+    <value>Attempting to locate the CodeCoverage.exe tool using setup configuration...</value>
+  </data>
   <data name="CONV_DIAG_MultipleVsVersionsInstalled" xml:space="preserve">
     <value>Multiple versions of VS are installed: {0}</value>
     <comment>First parameter: a list of VS versions</comment>
+  </data>
+  <data name="CONV_DIAG_SetupConfigurationNotSupported" xml:space="preserve">
+    <value>Visual Studio setup configuration was not found.</value>
   </data>
   <data name="CONV_ERROR_ConversionToolFailed" xml:space="preserve">
     <value>Failed to convert the downloaded code coverage tool to XML. No code coverage information will be uploaded to SonarQube.

--- a/SonarQube.TeamBuild.Integration/SonarQube.TeamBuild.Integration.csproj
+++ b/SonarQube.TeamBuild.Integration/SonarQube.TeamBuild.Integration.csproj
@@ -80,6 +80,7 @@
     <Compile Include="CoverageReportDownloader.cs" />
     <Compile Include="CoverageReportProcessorBase.cs" />
     <Compile Include="Interfaces\ITeamBuildSettings.cs" />
+    <Compile Include="Interfaces\IVisualStudioSetupConfigurationFactory.cs" />
     <Compile Include="TfsLegacyCoverageReportProcessor.cs" />
     <Compile Include="CoverageReportUrlProvider.cs" />
     <Compile Include="Interfaces\ICoverageReportProcessor.cs" />
@@ -95,6 +96,7 @@
     <Compile Include="TeamBuildAnalysisSettings.cs" />
     <Compile Include="TeamBuildSettings.cs" />
     <Compile Include="TrxFileReader.cs" />
+    <Compile Include="VisualStudioSetupConfigurationFactory.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SonarQube.Common\SonarQube.Common.csproj">

--- a/SonarQube.TeamBuild.Integration/SonarQube.TeamBuild.Integration.csproj
+++ b/SonarQube.TeamBuild.Integration/SonarQube.TeamBuild.Integration.csproj
@@ -56,6 +56,10 @@
   <!-- End of Team Foundation references -->
   <!-- ***************************************************************** -->
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.Setup.Configuration.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Setup.Configuration.Interop.1.11.2273\lib\net35\Microsoft.VisualStudio.Setup.Configuration.Interop.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />

--- a/SonarQube.TeamBuild.Integration/VisualStudioSetupConfigurationFactory.cs
+++ b/SonarQube.TeamBuild.Integration/VisualStudioSetupConfigurationFactory.cs
@@ -16,10 +16,10 @@ namespace SonarQube.TeamBuild.Integration
 
         public ISetupConfiguration GetSetupConfigurationQuery()
         {
-            ISetupConfiguration setupConfiguration=null;
+            ISetupConfiguration setupConfiguration = null;
             try
             {
-                setupConfiguration= new SetupConfiguration();
+                setupConfiguration = new SetupConfiguration();
             }
             catch (COMException ex) when (ex.HResult == REGDB_E_CLASSNOTREG)
             {

--- a/SonarQube.TeamBuild.Integration/VisualStudioSetupConfigurationFactory.cs
+++ b/SonarQube.TeamBuild.Integration/VisualStudioSetupConfigurationFactory.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Setup.Configuration;
+
+namespace SonarQube.TeamBuild.Integration
+{
+    public class VisualStudioSetupConfigurationFactory : IVisualStudioSetupConfigurationFactory
+    {
+        /// <summary>
+        /// COM class not registered exception
+        /// </summary>
+        private const int REGDB_E_CLASSNOTREG = unchecked((int)0x80040154);
+
+        [DllImport("Microsoft.VisualStudio.Setup.Configuration.Native.dll", ExactSpelling = true, PreserveSig = true)]
+        private static extern int GetSetupConfiguration([MarshalAs(UnmanagedType.Interface), Out] out ISetupConfiguration configuration, IntPtr reserved);
+
+        public ISetupConfiguration GetSetupConfigurationQuery()
+        {
+            ISetupConfiguration setupConfiguration=null;
+            try
+            {
+                setupConfiguration= new SetupConfiguration();
+            }
+            catch (COMException ex) when (ex.HResult == REGDB_E_CLASSNOTREG)
+            {
+                //Attempt to access the native library
+                try
+                {
+                    ISetupConfiguration query;
+                    return GetSetupConfiguration(out query, IntPtr.Zero) < 0 ? null : query;
+                }
+                catch (DllNotFoundException)
+                {
+                    //Setup configuration is not supported
+                    return null;
+                }
+            }
+
+            return setupConfiguration;
+        }
+    }
+}

--- a/SonarQube.TeamBuild.Integration/packages.config
+++ b/SonarQube.TeamBuild.Integration/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.11.2273" targetFramework="net45" developmentDependency="true" />
   <package id="SonarAnalyzer.CSharp" version="1.10.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Leverages the VS setup configuration library for determining VS installation directory.
The existing registry method is still used to support installations prior to 15.