### PR TITLE
Fix locating CodeCoverage.exe for Agents for Visual Studio 2017 

### DIFF
--- a/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
@@ -85,7 +85,6 @@ namespace SonarQube.TeamBuild.Integration
             }
             else
             {
-                Debug.Assert(File.Exists(this.conversionToolPath), "Expecting the code coverage exe to exist. Full name: " + this.conversionToolPath);
                 logger.LogDebug(Resources.CONV_DIAG_CommandLineToolInfo, this.conversionToolPath);
                 success = true;
             }

--- a/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
+++ b/SonarQube.TeamBuild.Integration/CoverageReportConverter.cs
@@ -46,9 +46,12 @@ namespace SonarQube.TeamBuild.Integration
         private const string TeamToolPathandExeName = @"Team Tools\Dynamic Code Coverage Tools\CodeCoverage.exe";
 
         /// <summary>
-        /// Code coverage package name for Visual Studio setup configuration
+        /// Code coverage package names for Visual Studio setup configuration
         /// </summary>
-        private const string CodeCoverageInstallationPackage = "Microsoft.VisualStudio.TestTools.CodeCoverage";
+        private static readonly string[] CodeCoverageInstallationPackageNames = new string[] {
+            "Microsoft.VisualStudio.TestTools.CodeCoverage",
+            "Microsoft.VisualStudio.TestTools.CodeCoverage.Msi"
+        };
 
         private string conversionToolPath;
 
@@ -143,7 +146,7 @@ namespace SonarQube.TeamBuild.Integration
                     if (fetched > 0)
                     {
                         ISetupInstance2 instance = (ISetupInstance2)tempInstance[0];
-                        if (instance.GetPackages().Any(p => p.GetId() == CodeCoverageInstallationPackage))
+                        if (instance.GetPackages().Any(p => CodeCoverageInstallationPackageNames.Contains(p.GetId())))
                         {
                             //Store instances that have code coverage package installed
                             instances.Add((ISetupInstance2)tempInstance[0]);

--- a/Tests/SonarQube.TeamBuild.Integration.Tests/CoverageReportConverterTests.cs
+++ b/Tests/SonarQube.TeamBuild.Integration.Tests/CoverageReportConverterTests.cs
@@ -171,6 +171,25 @@ echo success > """ + outputFilePath + @"""");
             logger.AssertDebugLogged("Code coverage command line tool: x:\\foo\\Team Tools\\Dynamic Code Coverage Tools\\CodeCoverage.exe");
         }
 
+        [TestMethod]
+        public void Initialize_CanGetGetExeToolPathFromSetupConfigurationForBuildAgent()
+        {
+            // Arrange
+            TestLogger logger = new TestLogger();
+
+            IVisualStudioSetupConfigurationFactory factory = CreateVisualStudioSetupConfigurationFactory("Microsoft.VisualStudio.TestTools.CodeCoverage.Msi");
+
+            CoverageReportConverter reporter = new CoverageReportConverter(factory);
+
+            // Act
+            bool result = reporter.Initialize(logger);
+
+            // Assert
+            Assert.IsTrue(result);
+
+            logger.AssertDebugLogged("Code coverage command line tool: x:\\foo\\Team Tools\\Dynamic Code Coverage Tools\\CodeCoverage.exe");
+        }
+
         private static IVisualStudioSetupConfigurationFactory CreateVisualStudioSetupConfigurationFactory(string packageId)
         {
             int calls = 0;

--- a/Tests/SonarQube.TeamBuild.Integration.Tests/SonarQube.TeamBuild.Integration.Tests.csproj
+++ b/Tests/SonarQube.TeamBuild.Integration.Tests/SonarQube.TeamBuild.Integration.Tests.csproj
@@ -37,7 +37,20 @@
     <CodeAnalysisRuleSet>SonarQube.TeamBuild.Integration.Tests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.Setup.Configuration.Interop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.VisualStudio.Setup.Configuration.Interop.1.11.2273\lib\net35\Microsoft.VisualStudio.Setup.Configuration.Interop.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Moq, Version=4.5.22.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.5.22\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -86,6 +99,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="packages.config" />
     <None Include="SonarQube.TeamBuild.Integration.Tests.ruleset" />
   </ItemGroup>
   <Choose>

--- a/Tests/SonarQube.TeamBuild.Integration.Tests/packages.config
+++ b/Tests/SonarQube.TeamBuild.Integration.Tests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.11.2273" targetFramework="net45" developmentDependency="true" />
+  <package id="Moq" version="4.5.22" targetFramework="net45" />
+</packages>

--- a/Tests/TestUtilities/TestLogger.cs
+++ b/Tests/TestUtilities/TestLogger.cs
@@ -86,6 +86,11 @@ namespace TestUtilities
             Assert.AreEqual(expectedCount, this.InfoMessages.Count, "Unexpected number of messages logged");
         }
 
+        public void AssertDebugLogged(string expected)
+        {
+            this.DebugMessages.Should().Contain(expected);
+        }
+
         public void AssertMessageLogged(string expected)
         {
             this.InfoMessages.Should().Contain(expected);


### PR DESCRIPTION
This PR fixes `CoverageReportConverter` not being able to locate `CodeCoverage.exe` when
only the Agents for Visual Studio 2017 are installed on the build agent. This patch also
searches for a package with the id `Microsoft.VisualStudio.TestTools.CodeCoverage.Msi`.
I noticed that this was also available on my Visual Studio Enterprise installation but I am
not sure if this is always available. That is why I am searching for both `Microsoft.VisualStudio.TestTools.CodeCoverage`
and `Microsoft.VisualStudio.TestTools.CodeCoverage.Msi`. This patch also removes a Debug.Assert
that checks if the executable exists because I added some unit tests for the 
`IVisualStudioSetupConfigurationFactory` implementation. The file that the factory returns does
not exist on disk and would raise an assert during the test execution.