### PR TITLE
Fix #359: don't clean project before every build

### DIFF
--- a/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/SonarQube.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -206,7 +206,7 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="CleanProjectFolders" AfterTargets="Clean" BeforeTargets="CreateProjectSpecificDirs" Condition=" $(SonarQubeTempPath) != '' ">
+  <Target Name="CleanProjectFolders" AfterTargets="Clean" Condition=" $(SonarQubeTempPath) != '' ">
     <ItemGroup>
       <ProjectSpecificOutFiles Include="$(SonarQubeOutputPath)\$(MSBuildProjectName)_*\*.*"/>
       <ProjectSpecificOutDirs Include="@(ProjectSpecificOutFiles->'%(RootDir)%(Directory)'->Distinct())" />


### PR DESCRIPTION
Fixes SONARMSBRU-359: _Multi-platform builds only analyse one platform unless /t:rebuild is specified_
https://jira.sonarsource.com/browse/SONARMSBRU-359