### PR TITLE
Fixed ci build script

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -58,6 +58,12 @@ function deploy([string] $version) {
     new-item -path . -name qa.properties -type "file"
 }
 
+function runTests() {
+    . (Join-Path $PSScriptRoot "ci-runTests.ps1")
+    Invoke-Tests
+    Invoke-CodeCoverage
+}
+
 if ($env:IS_PULLREQUEST -eq "true") { 
     write-host -f green "in a pull request"
 
@@ -75,11 +81,8 @@ if ($env:IS_PULLREQUEST -eq "true") {
     testExitCode
     & $env:MSBUILD_PATH SonarQube.Scanner.MSBuild.sln /t:rebuild /p:Configuration=Release
     testExitCode
-
     #run tests
-    . (Join-Path $PSScriptRoot "runTests.ps1")
     runTests
-    Invoke-CodeCoverage
 
     .\SonarQube.Scanner.MSBuild end /d:sonar.login=$env:SONAR_TOKEN
     testExitCode

--- a/build/ci-runTests.ps1
+++ b/build/ci-runTests.ps1
@@ -1,4 +1,9 @@
-function runTests() {
+# Script to execute unit tests and convert the code coverage results.
+# This script is used by the CI build. However, the test execution was extracted into this script
+# to make it easier to debug and test on a local machine. See the comments at the end of the file
+# for more information on debugging locally.
+
+function Invoke-Tests() {
     Write-Host "Start tests"
     $x = ""; Get-ChildItem -path . -Recurse -Include *Tests.dll | where { $_.FullName -match "bin" } | foreach { $x += """$_"" " }; iex "& '$env:VSTEST_PATH' /EnableCodeCoverage /Logger:trx $x"
     testExitCode
@@ -125,3 +130,15 @@ function Invoke-CodeCoverage() {
         }
     }
 }
+
+# To test locally:
+# 1. Set the working directory to the repo root
+# 2. Build the solution
+# 3. Delete any existing test results
+# 4. Uncomment the code below and set $vsTestPath appropriately
+# 5. Run this script
+
+#$vsTestPath = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Extensions\TestPlatform\vstest.console.exe"
+#[environment]::SetEnvironmentVariable("VSTEST_PATH", $vsTestPath, "Process")
+#Invoke-Tests
+#Invoke-CodeCoverage


### PR DESCRIPTION
Fixed ci build break introduced by my previous commit.

The build script calls "runTests" from inside multiple branches, so I've re-instated the old _runTests_ method and made it call out to the new script.