### PR TITLE
Fix ITs: use long paths in test, not DOS (8.3)

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -93,7 +93,7 @@ public class TestUtils {
   public static Path projectDir(TemporaryFolder temp, String projectName) throws IOException {
     Path projectDir = Paths.get("projects").resolve(projectName);
     FileUtils.deleteDirectory(new File(temp.getRoot(), projectName));
-    Path tmpProjectDir = temp.newFolder(projectName).toPath();
+    Path tmpProjectDir = Paths.get(temp.newFolder(projectName).getCanonicalPath());
     FileUtils.copyDirectory(projectDir.toFile(), tmpProjectDir.toFile());
     return tmpProjectDir;
   }


### PR DESCRIPTION
There is a ticket to fix the scanner to handle that case: https://jira.sonarsource.com/browse/SONARMSBRU-375

For now, just fixing the tests.