### PR TITLE
Removed unnecessary NuGet refs from Classic project

### DIFF
--- a/src/SonarQube.TeamBuild.Integration.Classic/SonarQube.TeamBuild.Integration.Classic.csproj
+++ b/src/SonarQube.TeamBuild.Integration.Classic/SonarQube.TeamBuild.Integration.Classic.csproj
@@ -38,9 +38,8 @@
   <!-- ***************************************************************** -->
 
   <ItemGroup>
+    <Reference Include="System.Net.Http" />
     <PackageReference Include="Newtonsoft.Json" version="10.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.14.114" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The Classic project is Net4.6 only so if a class is available in the .Net Framework then it should use the .NetFx version rather than referencing a NuGet package