### PR TITLE
Refactored most of the ILogger parameters to be passed through constructors

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.UnitTests/ProcessRunnerTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.UnitTests/ProcessRunnerTests.cs
@@ -39,7 +39,7 @@ namespace SonarScanner.MSBuild.Common.UnitTests
         public void Execute_WhenRunnerArgsIsNull_ThrowsArgumentNullException()
         {
             // Arrange
-            Action action = () => new ProcessRunner().Execute(null);
+            Action action = () => new ProcessRunner(new TestLogger()).Execute(null);
 
             // Act & Assert
             action.ShouldThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("runnerArgs");
@@ -52,8 +52,8 @@ namespace SonarScanner.MSBuild.Common.UnitTests
             var exeName = TestUtils.WriteBatchFileForTest(TestContext, "exit -2");
 
             var logger = new TestLogger();
-            var args = new ProcessRunnerArguments(exeName, true, logger);
-            var runner = new ProcessRunner();
+            var args = new ProcessRunnerArguments(exeName, true);
+            var runner = new ProcessRunner(logger);
 
             // Act
             var success = runner.Execute(args);
@@ -74,8 +74,8 @@ xxx yyy
 ");
 
             var logger = new TestLogger();
-            var args = new ProcessRunnerArguments(exeName, true, logger);
-            var runner = new ProcessRunner();
+            var args = new ProcessRunnerArguments(exeName, true);
+            var runner = new ProcessRunner(logger);
 
             // Act
             var success = runner.Execute(args);
@@ -103,11 +103,11 @@ xxx yyy
 ");
 
             var logger = new TestLogger();
-            var args = new ProcessRunnerArguments(exeName, true, logger)
+            var args = new ProcessRunnerArguments(exeName, true)
             {
                 TimeoutInMilliseconds = 100
             };
-            var runner = new ProcessRunner();
+            var runner = new ProcessRunner(logger);
 
             var timer = Stopwatch.StartNew();
 
@@ -132,7 +132,7 @@ xxx yyy
         {
             // Arrange
             var logger = new TestLogger();
-            var runner = new ProcessRunner();
+            var runner = new ProcessRunner(logger);
 
             var exeName = TestUtils.WriteBatchFileForTest(TestContext,
 @"echo %PROCESS_VAR%
@@ -144,7 +144,7 @@ xxx yyy
                 { "PROCESS_VAR2", "PROCESS_VAR2 value" },
                 { "PROCESS_VAR3", "PROCESS_VAR3 value" } };
 
-            var args = new ProcessRunnerArguments(exeName, true, logger)
+            var args = new ProcessRunnerArguments(exeName, true)
             {
                 EnvironmentVariables = envVariables
             };
@@ -168,7 +168,7 @@ xxx yyy
 
             // Arrange
             var logger = new TestLogger();
-            var runner = new ProcessRunner();
+            var runner = new ProcessRunner(logger);
 
             try
             {
@@ -189,7 +189,7 @@ xxx yyy
                     { "proc.runner.test.process", "process override" },
                     { "proc.runner.test.user", "user override" } };
 
-                var args = new ProcessRunnerArguments(exeName, true, logger)
+                var args = new ProcessRunnerArguments(exeName, true)
                 {
                     EnvironmentVariables = envVariables
                 };
@@ -226,8 +226,8 @@ xxx yyy
 
             // Arrange
             var logger = new TestLogger();
-            var args = new ProcessRunnerArguments("missingExe.foo", false, logger);
-            var runner = new ProcessRunner();
+            var args = new ProcessRunnerArguments("missingExe.foo", false);
+            var runner = new ProcessRunner(logger);
 
             // Act
             var success = runner.Execute(args);
@@ -249,7 +249,7 @@ xxx yyy
             var exeName = DummyExeHelper.CreateDummyPostProcessor(testDir, 0);
 
             var logger = new TestLogger();
-            var args = new ProcessRunnerArguments(exeName, false, logger);
+            var args = new ProcessRunnerArguments(exeName, false);
 
             var expected = new[] {
                 "unquoted",
@@ -269,7 +269,7 @@ xxx yyy
 
             args.CmdLineArgs = expected;
 
-            var runner = new ProcessRunner();
+            var runner = new ProcessRunner(logger);
 
             // Act
             var success = runner.Execute(args);
@@ -296,7 +296,7 @@ xxx yyy
             var batchName = TestUtils.WriteBatchFileForTest(TestContext, "\"" + exeName + "\" %*");
 
             var logger = new TestLogger();
-            var args = new ProcessRunnerArguments(batchName, true, logger);
+            var args = new ProcessRunnerArguments(batchName, true);
 
             var expected = new[] {
                 "unquoted",
@@ -316,7 +316,7 @@ xxx yyy
 
             args.CmdLineArgs = expected;
 
-            var runner = new ProcessRunner();
+            var runner = new ProcessRunner(logger);
 
             // Act
             var success = runner.Execute(args);
@@ -370,11 +370,11 @@ xxx yyy
 
             var allArgs = sensitiveArgs.Union(publicArgs).ToArray();
 
-            var runnerArgs = new ProcessRunnerArguments(exeName, false, logger)
+            var runnerArgs = new ProcessRunnerArguments(exeName, false)
             {
                 CmdLineArgs = allArgs
             };
-            var runner = new ProcessRunner();
+            var runner = new ProcessRunner(logger);
 
             // Act
             var success = runner.Execute(runnerArgs);

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Tests/Infrastructure/MockCodeCoverageProcessor.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Tests/Infrastructure/MockCodeCoverageProcessor.cs
@@ -39,7 +39,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
 
         #region ICoverageReportProcessor interface
 
-        public bool Initialise(AnalysisConfig context, ITeamBuildSettings settings, ILogger logger)
+        public bool Initialise(AnalysisConfig context, ITeamBuildSettings settings)
         {
             Assert.IsFalse(initalisedCalled, "Expecting Initialize to be called only once");
             initalisedCalled = true;

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Tests/Infrastructure/MockSonarScanner.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Tests/Infrastructure/MockSonarScanner.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarScanner.MSBuild.Common;
@@ -28,6 +29,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
     internal class MockSonarScanner : ISonarScanner
     {
         private bool methodCalled;
+        private readonly ILogger logger;
 
         #region Test Helpers
 
@@ -39,9 +41,14 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
 
         #endregion Test Helpers
 
+        public MockSonarScanner(ILogger logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
         #region ISonarScanner interface
 
-        public ProjectInfoAnalysisResult Execute(AnalysisConfig config, IEnumerable<string> userCmdLineArguments, ILogger logger)
+        public ProjectInfoAnalysisResult Execute(AnalysisConfig config, IEnumerable<string> userCmdLineArguments)
         {
             Assert.IsFalse(methodCalled, "Scanner should only be called once");
             methodCalled = true;

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Tests/Infrastructure/MockSummaryReportBuilder.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Tests/Infrastructure/MockSummaryReportBuilder.cs
@@ -31,7 +31,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
 
         #region ISummaryReportBuilder interface
 
-        public void GenerateReports(ITeamBuildSettings settings, AnalysisConfig config, ProjectInfoAnalysisResult result, ILogger logger)
+        public void GenerateReports(ITeamBuildSettings settings, AnalysisConfig config, ProjectInfoAnalysisResult result)
         {
             Assert.IsFalse(methodCalled, "Generate reports has already been called");
 

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
@@ -399,7 +399,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
 
                 logger = new TestLogger();
                 codeCoverage = new MockCodeCoverageProcessor();
-                scanner = new MockSonarScanner();
+                scanner = new MockSonarScanner(logger);
                 reportBuilder = new MockSummaryReportBuilder();
                 TargetsUninstaller = new Mock<ITargetsUninstaller>();
                 var callCount = 0;

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
@@ -63,7 +63,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Logger.AssertWarningsLogged(0);
 
             // Verify that the method was called at least once
-            context.TargetsUninstaller.Verify(m => m.UninstallTargets(context.Logger));
+            context.TargetsUninstaller.Verify(m => m.UninstallTargets());
         }
 
         [TestMethod]
@@ -90,7 +90,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Logger.AssertWarningsLogged(0);
 
             // Verify that the method was called at least once
-            context.TargetsUninstaller.Verify(m => m.UninstallTargets(context.Logger));
+            context.TargetsUninstaller.Verify(m => m.UninstallTargets());
         }
 
         [TestMethod]
@@ -123,7 +123,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Logger.AssertWarningsLogged(0);
 
             // Verify that the method was called at least once
-            context.TargetsUninstaller.Verify(m => m.UninstallTargets(context.Logger));
+            context.TargetsUninstaller.Verify(m => m.UninstallTargets());
         }
 
         [TestMethod]
@@ -157,7 +157,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Logger.AssertWarningsLogged(0);
 
             // Verify that the method was called at least once
-            context.TargetsUninstaller.Verify(m => m.UninstallTargets(context.Logger));
+            context.TargetsUninstaller.Verify(m => m.UninstallTargets());
         }
 
         [TestMethod]
@@ -191,7 +191,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Logger.AssertWarningsLogged(0);
 
             // Verify that the method was called at least once
-            context.TargetsUninstaller.Verify(m => m.UninstallTargets(context.Logger));
+            context.TargetsUninstaller.Verify(m => m.UninstallTargets());
         }
 
         [TestMethod]
@@ -215,7 +215,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Logger.AssertWarningsLogged(0);
 
             // Verify that the method was called at least once
-            context.TargetsUninstaller.Verify(m => m.UninstallTargets(context.Logger));
+            context.TargetsUninstaller.Verify(m => m.UninstallTargets());
         }
 
         [TestMethod]
@@ -266,7 +266,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Logger.AssertWarningsLogged(0);
 
             // Verify that the method was called at least once
-            context.TargetsUninstaller.Verify(m => m.UninstallTargets(context.Logger));
+            context.TargetsUninstaller.Verify(m => m.UninstallTargets());
         }
 
         [TestMethod]
@@ -288,7 +288,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Scanner.AssertNotExecuted();
             context.ReportBuilder.AssertNotExecuted();
 
-            context.TargetsUninstaller.Verify(m => m.UninstallTargets(context.Logger));
+            context.TargetsUninstaller.Verify(m => m.UninstallTargets());
         }
 
         [TestMethod]
@@ -314,7 +314,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Scanner.AssertNotExecuted();
             context.ReportBuilder.AssertNotExecuted();
 
-            context.TargetsUninstaller.Verify(m => m.UninstallTargets(context.Logger));
+            context.TargetsUninstaller.Verify(m => m.UninstallTargets());
         }
 
         [TestMethod]
@@ -404,7 +404,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
                 TargetsUninstaller = new Mock<ITargetsUninstaller>();
                 var callCount = 0;
                 TargetsUninstaller
-                    .Setup(m => m.UninstallTargets(Logger))
+                    .Setup(m => m.UninstallTargets())
                     .Callback(() =>
                     {
                         // Verify that the method was called maximum once

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Tests/SummaryReportBuilderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Tests/SummaryReportBuilderTests.cs
@@ -164,7 +164,7 @@ namespace SonarScanner.MSBuild.PostProcessorTests
             var expectedReportPath = Path.Combine(TestContext.TestDeploymentDir, SummaryReportBuilder.SummaryMdFilename);
 
             // Act
-            var builder = new SummaryReportBuilder(new LegacyTeamBuildFactory());
+            var builder = new SummaryReportBuilder(new LegacyTeamBuildFactory(new TestLogger()));
             builder.GenerateReports(settings, config, result, new TestLogger());
 
             // Assert

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/MockObjectFactory.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/MockObjectFactory.cs
@@ -19,7 +19,6 @@
  */
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild.PreProcessor.Tests
 {
@@ -43,24 +42,20 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
         #region PreprocessorObjectFactory methods
 
-        public IAnalyzerProvider CreateRoslynAnalyzerProvider(ILogger logger)
+        public IAnalyzerProvider CreateRoslynAnalyzerProvider()
         {
-            Assert.IsNotNull(logger);
             return analyzerProvider;
         }
 
-        public ISonarQubeServer CreateSonarQubeServer(ProcessedArgs args, ILogger logger)
+        public ISonarQubeServer CreateSonarQubeServer(ProcessedArgs args)
         {
             Assert.IsNotNull(args);
-            Assert.IsNotNull(logger);
 
             return server;
         }
 
-        public ITargetsInstaller CreateTargetInstaller(ILogger logger)
+        public ITargetsInstaller CreateTargetInstaller()
         {
-            Assert.IsNotNull(logger);
-
             return targetsInstaller;
         }
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/PreprocessorObjectFactoryTests.cs
@@ -38,14 +38,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             // Arrange
             var logger = new TestLogger();
             var validArgs = CreateValidArguments();
-            IPreprocessorObjectFactory testSubject = new PreprocessorObjectFactory();
+            IPreprocessorObjectFactory testSubject = new PreprocessorObjectFactory(logger);
+
+            // 1. Ctor
+            AssertException.Expects<ArgumentNullException>(() => new PreprocessorObjectFactory(null));
 
             // 1. CreateSonarQubeServer method
-            AssertException.Expects<ArgumentNullException>(() => testSubject.CreateSonarQubeServer(null, logger));
-            AssertException.Expects<ArgumentNullException>(() => testSubject.CreateSonarQubeServer(validArgs, null));
-
-            // 2. CreateAnalyzerProvider method
-            AssertException.Expects<ArgumentNullException>(() => testSubject.CreateRoslynAnalyzerProvider(null));
+            AssertException.Expects<ArgumentNullException>(() => testSubject.CreateSonarQubeServer(null));
         }
 
         [TestMethod]
@@ -54,18 +53,18 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             // Arrange
             var logger = new TestLogger();
             var validArgs = CreateValidArguments();
-            IPreprocessorObjectFactory testSubject = new PreprocessorObjectFactory();
+            IPreprocessorObjectFactory testSubject = new PreprocessorObjectFactory(logger);
 
             // 1. Create the SonarQube server...
-            object actual = testSubject.CreateSonarQubeServer(validArgs, logger);
+            object actual = testSubject.CreateSonarQubeServer(validArgs);
             Assert.IsNotNull(actual);
 
             // 2. Now create the targets provider
-            actual = testSubject.CreateTargetInstaller(logger);
+            actual = testSubject.CreateTargetInstaller();
             Assert.IsNotNull(actual);
 
             // 3. Now create the analyzer provider
-            actual = testSubject.CreateRoslynAnalyzerProvider(logger);
+            actual = testSubject.CreateRoslynAnalyzerProvider();
             Assert.IsNotNull(actual);
         }
 
@@ -74,10 +73,10 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         {
             // Arrange
             var logger = new TestLogger();
-            IPreprocessorObjectFactory testSubject = new PreprocessorObjectFactory();
+            IPreprocessorObjectFactory testSubject = new PreprocessorObjectFactory(logger);
 
             // 2. Act and assert
-            AssertException.Expects<InvalidOperationException>(() => testSubject.CreateRoslynAnalyzerProvider(logger));
+            AssertException.Expects<InvalidOperationException>(() => testSubject.CreateRoslynAnalyzerProvider());
         }
 
         #endregion Tests

--- a/Tests/SonarScanner.MSBuild.Shim.Tests/MockRoslynV1SarifFixer.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Tests/MockRoslynV1SarifFixer.cs
@@ -24,8 +24,6 @@ namespace SonarScanner.MSBuild.Shim.Tests
 {
     internal class MockRoslynV1SarifFixer : IRoslynV1SarifFixer
     {
-        #region Test Hooks
-
         public string ReturnVal { get; set; }
 
         public int CallCount { get; set; }
@@ -38,17 +36,11 @@ namespace SonarScanner.MSBuild.Shim.Tests
             CallCount = 0;
         }
 
-        #endregion Test Hooks
-
-        #region IRoslynV1SarifFixer
-
-        public string LoadAndFixFile(string sarifPath, string language, ILogger logger)
+        public string LoadAndFixFile(string sarifPath, string language)
         {
             CallCount++;
             LastLanguage = language;
             return ReturnVal;
         }
-
-        #endregion IRoslynV1SarifFixer
     }
 }

--- a/Tests/SonarScanner.MSBuild.Shim.Tests/RoslynV1SarifFixerTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Tests/RoslynV1SarifFixerTests.cs
@@ -76,7 +76,7 @@ namespace SonarQube.Shim.Tests
             var originalWriteTime = new FileInfo(testSarifPath).LastWriteTime;
 
             // Act
-            var returnedSarifPath = new RoslynV1SarifFixer().LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage, logger);
+            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage);
 
             // Assert
             // already valid -> no change to file, same file path returned
@@ -125,7 +125,7 @@ namespace SonarQube.Shim.Tests
             var originalWriteTime = new FileInfo(testSarifPath).LastWriteTime;
 
             // Act
-            var returnedSarifPath = new RoslynV1SarifFixer().LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage, logger);
+            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage);
 
             // Assert
             // unfixable -> no change to file, null return
@@ -171,7 +171,7 @@ It features ""quoted text""."",
             var originalWriteTime = new FileInfo(testSarifPath).LastWriteTime;
 
             // Act
-            var returnedSarifPath = new RoslynV1SarifFixer().LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage, logger);
+            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage);
 
             // Assert
             // unfixable -> no change to file, null return
@@ -213,7 +213,7 @@ It features ""quoted text""."",
             var originalWriteTime = new FileInfo(testSarifPath).LastWriteTime;
 
             // Act
-            var returnedSarifPath = new RoslynV1SarifFixer().LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage, logger);
+            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage);
 
             // Assert
             // fixable -> no change to file, file path in return value, file contents as expected
@@ -275,7 +275,7 @@ It features ""quoted text""."",
             var originalWriteTime = new FileInfo(testSarifPath).LastWriteTime;
 
             // Act
-            var returnedSarifPath = new RoslynV1SarifFixer().LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage, logger);
+            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage);
 
             // Assert
             // fixable -> no change to file, file path in return value, file contents as expected
@@ -344,7 +344,7 @@ It features ""quoted text""."",
             var originalWriteTime = new FileInfo(testSarifPath).LastWriteTime;
 
             // Act
-            var returnedSarifPath = new RoslynV1SarifFixer().LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage, logger);
+            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage);
 
             // Assert
             // fixable -> no change to file, file path in return value, file contents as expected
@@ -417,7 +417,7 @@ It features ""quoted text""."",
             var originalWriteTime = new FileInfo(testSarifPath).LastWriteTime;
 
             // Act
-            var returnedSarifPath = new RoslynV1SarifFixer().LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.VBNetLanguage, logger);
+            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage);
 
             // Assert
             // fixable -> no change to file, file path in return value, file contents as expected
@@ -486,7 +486,7 @@ It features ""quoted text""."",
             var originalWriteTime = new FileInfo(testSarifPath).LastWriteTime;
 
             // Act
-            var returnedSarifPath = new RoslynV1SarifFixer().LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.VBNetLanguage, logger);
+            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage);
             Assert.IsNull(returnedSarifPath);
         }
 

--- a/Tests/SonarScanner.MSBuild.Shim.Tests/RoslynV1SarifFixerTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Tests/RoslynV1SarifFixerTests.cs
@@ -417,7 +417,7 @@ It features ""quoted text""."",
             var originalWriteTime = new FileInfo(testSarifPath).LastWriteTime;
 
             // Act
-            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage);
+            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.VBNetLanguage);
 
             // Assert
             // fixable -> no change to file, file path in return value, file contents as expected
@@ -486,7 +486,7 @@ It features ""quoted text""."",
             var originalWriteTime = new FileInfo(testSarifPath).LastWriteTime;
 
             // Act
-            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.CSharpLanguage);
+            var returnedSarifPath = new RoslynV1SarifFixer(logger).LoadAndFixFile(testSarifPath, RoslynV1SarifFixer.VBNetLanguage);
             Assert.IsNull(returnedSarifPath);
         }
 

--- a/Tests/SonarScanner.MSBuild.Shim.Tests/SonarScannerWrapperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Tests/SonarScannerWrapperTests.cs
@@ -45,8 +45,8 @@ namespace SonarScanner.MSBuild.Shim.Tests
         public void Execute_WhenConfigIsNull_Throws()
         {
             // Arrange
-            var testSubject = new SonarScannerWrapper();
-            Action act = () => testSubject.Execute(null, new string[] { }, new TestLogger());
+            var testSubject = new SonarScannerWrapper(new TestLogger());
+            Action act = () => testSubject.Execute(null, new string[] { });
 
             // Act & Assert
             act.ShouldThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("config");
@@ -56,19 +56,18 @@ namespace SonarScanner.MSBuild.Shim.Tests
         public void Execute_WhenUserCmdLineArgumentsIsNull_Throws()
         {
             // Arrange
-            var testSubject = new SonarScannerWrapper();
-            Action act = () => testSubject.Execute(new AnalysisConfig(), null, new TestLogger());
+            var testSubject = new SonarScannerWrapper(new TestLogger());
+            Action act = () => testSubject.Execute(new AnalysisConfig(), null);
 
             // Act & Assert
             act.ShouldThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("userCmdLineArguments");
         }
 
         [TestMethod]
-        public void Execute_WhenLoggerIsNull_Throws()
+        public void Ctor_WhenLoggerIsNull_Throws()
         {
             // Arrange
-            var testSubject = new SonarScannerWrapper();
-            Action act = () => testSubject.Execute(new AnalysisConfig(), new string[] { }, null);
+            Action act = () => new SonarScannerWrapper(null);
 
             // Act & Assert
             act.ShouldThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("logger");

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/Classic/BinaryToXmlCoverageReportConverterTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/Classic/BinaryToXmlCoverageReportConverterTests.cs
@@ -38,10 +38,9 @@ namespace SonarScanner.MSBuild.TFS.Tests
         #region Tests
 
         [TestMethod]
-        public void Conv_Initialize_InvalidArgs_Throws()
+        public void Conv_Ctor_InvalidArgs_Throws()
         {
-            var testSubject = new BinaryToXmlCoverageReportConverter();
-            Action op = () => testSubject.Initialize(null);
+            Action op = () => new BinaryToXmlCoverageReportConverter(null);
 
             op.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("logger");
         }
@@ -50,25 +49,21 @@ namespace SonarScanner.MSBuild.TFS.Tests
         public void Conv_ConvertToXml_InvalidArgs_Throws()
         {
             ILogger loggerMock = new Mock<ILogger>().Object;
-            var testSubject = new BinaryToXmlCoverageReportConverter();
+            var testSubject = new BinaryToXmlCoverageReportConverter(loggerMock);
 
             // 1. Null input path
-            Action op = () => testSubject.ConvertToXml(null, "dummypath", loggerMock);
+            Action op = () => testSubject.ConvertToXml(null, "dummypath");
             op.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("inputFilePath");
 
-            op = () => testSubject.ConvertToXml("\t\n", "dummypath", loggerMock);
+            op = () => testSubject.ConvertToXml("\t\n", "dummypath");
             op.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("inputFilePath");
 
             // 2. Null output path
-            op = () => testSubject.ConvertToXml("dummypath", null, loggerMock);
+            op = () => testSubject.ConvertToXml("dummypath", null);
             op.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outputFilePath");
 
-            op = () => testSubject.ConvertToXml("dummypath", "   ", loggerMock);
+            op = () => testSubject.ConvertToXml("dummypath", "   ");
             op.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("outputFilePath");
-
-            // 3. Null logger
-            op = () => testSubject.ConvertToXml("dummyInput", "dummyOutput", null);
-            op.ShouldThrow<ArgumentNullException>().And.ParamName.Should().Be("logger");
         }
 
         [TestMethod]
@@ -197,10 +192,10 @@ echo success > """ + outputFilePath + @"""");
 
             var factory = CreateVisualStudioSetupConfigurationFactory("Microsoft.VisualStudio.TestTools.CodeCoverage");
 
-            var reporter = new BinaryToXmlCoverageReportConverter(factory);
+            var reporter = new BinaryToXmlCoverageReportConverter(factory, logger);
 
             // Act
-            var result = reporter.Initialize(logger);
+            var result = reporter.Initialize();
 
             // Assert
             Assert.IsTrue(result);
@@ -216,10 +211,10 @@ echo success > """ + outputFilePath + @"""");
 
             var factory = CreateVisualStudioSetupConfigurationFactory("Microsoft.VisualStudio.TestTools.CodeCoverage.Msi");
 
-            var reporter = new BinaryToXmlCoverageReportConverter(factory);
+            var reporter = new BinaryToXmlCoverageReportConverter(factory, logger);
 
             // Act
-            var result = reporter.Initialize(logger);
+            var result = reporter.Initialize();
 
             // Assert
             Assert.IsTrue(result);

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/Classic/TfsLegacyCoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/Classic/TfsLegacyCoverageReportProcessorTests.cs
@@ -62,10 +62,10 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var settings = CreateValidSettings();
             var logger = new TestLogger();
 
-            var processor = new TfsLegacyCoverageReportProcessor(urlProvider, downloader, converter);
+            var processor = new TfsLegacyCoverageReportProcessor(urlProvider, downloader, converter, logger);
 
             // Act
-            var initResult = processor.Initialise(context, settings, logger);
+            var initResult = processor.Initialise(context, settings);
 
             // Assert
             Assert.IsFalse(initResult, "Expecting false: processor should not have been initialized successfully");
@@ -90,10 +90,10 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var settings = CreateValidSettings();
             var logger = new TestLogger();
 
-            var processor = new TfsLegacyCoverageReportProcessor(urlProvider, downloader, converter);
+            var processor = new TfsLegacyCoverageReportProcessor(urlProvider, downloader, converter, logger);
 
             // Act
-            var initResult = processor.Initialise(context, settings, logger);
+            var initResult = processor.Initialise(context, settings);
             Assert.IsTrue(initResult, "Expecting true: processor should have been initialized successfully");
             var result = processor.ProcessCoverageReports();
 
@@ -120,10 +120,10 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var settings = CreateValidSettings();
             var logger = new TestLogger();
 
-            var processor = new TfsLegacyCoverageReportProcessor(urlProvider, downloader, converter);
+            var processor = new TfsLegacyCoverageReportProcessor(urlProvider, downloader, converter, logger);
 
             // Act
-            var initResult = processor.Initialise(context, settings, logger);
+            var initResult = processor.Initialise(context, settings);
             Assert.IsTrue(initResult, "Expecting true: processor should have been initialized successfully");
             var result = processor.ProcessCoverageReports();
 
@@ -149,10 +149,10 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var settings = CreateValidSettings();
             var logger = new TestLogger();
 
-            var processor = new TfsLegacyCoverageReportProcessor(urlProvider, downloader, converter);
+            var processor = new TfsLegacyCoverageReportProcessor(urlProvider, downloader, converter, logger);
 
             // Act
-            var initResult = processor.Initialise(context, settings, logger);
+            var initResult = processor.Initialise(context, settings);
             Assert.IsTrue(initResult, "Expecting true: processor should have been initialized successfully");
             var result = processor.ProcessCoverageReports();
 
@@ -183,10 +183,10 @@ namespace SonarScanner.MSBuild.TFS.Tests
 
             downloader.CreateFileOnDownloadRequest = true;
 
-            var processor = new TfsLegacyCoverageReportProcessor(urlProvider, downloader, converter);
+            var processor = new TfsLegacyCoverageReportProcessor(urlProvider, downloader, converter, logger);
 
             // Act
-            var initResult = processor.Initialise(context, settings, logger);
+            var initResult = processor.Initialise(context, settings);
             Assert.IsTrue(initResult, "Expecting true: processor should have been initialized successfully");
             var result = processor.ProcessCoverageReports();
 

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockReportConverter.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockReportConverter.cs
@@ -32,8 +32,6 @@ namespace SonarScanner.MSBuild.TFS.Tests.Infrastructure
 
         public bool CanConvert { get; set; }
 
-        public Func<string, string, ILogger, bool> ConversionOp { get; set; }
-
         public bool ConversionResult { get; set; }
 
         #endregion Test helpers
@@ -54,23 +52,11 @@ namespace SonarScanner.MSBuild.TFS.Tests.Infrastructure
 
         #region ICoverageReportConverter interface
 
-        bool ICoverageReportConverter.Initialize(ILogger logger)
+        bool ICoverageReportConverter.Initialize() => CanConvert;
+
+        bool ICoverageReportConverter.ConvertToXml(string fullBinaryFileName, string fullXmlFileName)
         {
-            Assert.IsNotNull(logger, "Supplied logger should not be null");
-
-            return CanConvert;
-        }
-
-        bool ICoverageReportConverter.ConvertToXml(string fullBinaryFileName, string fullXmlFileName, ILogger logger)
-        {
-            Assert.IsNotNull(logger, "Supplied logger should not be null");
-
             convertCallCount++;
-
-            if (ConversionOp != null)
-            {
-                return ConversionOp(fullBinaryFileName, fullBinaryFileName, logger);
-            }
 
             return true;
         }

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockReportDownloader.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockReportDownloader.cs
@@ -65,7 +65,7 @@ namespace SonarScanner.MSBuild.TFS.Tests.Infrastructure
 
         #region ICoverageReportDownloader interface
 
-        bool ICoverageReportDownloader.DownloadReport(string tfsUri, string reportUrl, string newFullFileName, ILogger logger)
+        bool ICoverageReportDownloader.DownloadReport(string tfsUri, string reportUrl, string newFullFileName)
         {
             callCount++;
             requestedUrls.Add(reportUrl);

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockReportUrlProvider.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockReportUrlProvider.cs
@@ -50,7 +50,7 @@ namespace SonarScanner.MSBuild.TFS.Tests.Infrastructure
 
         #region ICoverageUrlProvider interface
 
-        public IEnumerable<string> GetCodeCoverageReportUrls(string tfsUri, string buildUri, ILogger logger)
+        public IEnumerable<string> GetCodeCoverageReportUrls(string tfsUri, string buildUri)
         {
             getUrlsCalled = true;
             return UrlsToReturn;

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/TrxFileReaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/TrxFileReaderTests.cs
@@ -39,7 +39,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var logger = new TestLogger();
 
             // Act
-            var coverageFilePath = TrxFileReader.LocateCodeCoverageFile(testDir, logger);
+            var coverageFilePath = new TrxFileReader(logger).LocateCodeCoverageFile(testDir);
 
             // Assert
             Assert.AreEqual(null, coverageFilePath);
@@ -59,7 +59,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var logger = new TestLogger();
 
             // Act
-            var coverageFilePath = TrxFileReader.LocateCodeCoverageFile(testDir, logger);
+            var coverageFilePath = new TrxFileReader(logger).LocateCodeCoverageFile(testDir);
 
             // Assert
             Assert.AreEqual(null, coverageFilePath);
@@ -79,7 +79,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var logger = new TestLogger();
 
             // Act
-            var coverageFilePath = TrxFileReader.LocateCodeCoverageFile(testDir, logger);
+            var coverageFilePath = new TrxFileReader(logger).LocateCodeCoverageFile(testDir);
 
             // Assert
             Assert.AreEqual(null, coverageFilePath);
@@ -109,7 +109,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var logger = new TestLogger();
 
             // Act
-            var coverageFilePath = TrxFileReader.LocateCodeCoverageFile(testDir, logger);
+            var coverageFilePath = new TrxFileReader(logger).LocateCodeCoverageFile(testDir);
 
             // Assert
             Assert.AreEqual(null, coverageFilePath);
@@ -141,7 +141,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var logger = new TestLogger();
 
             // Act
-            var coverageFilePath = TrxFileReader.LocateCodeCoverageFile(testDir, logger);
+            var coverageFilePath = new TrxFileReader(logger).LocateCodeCoverageFile(testDir);
 
             // Assert
             Assert.AreEqual(null, coverageFilePath);
@@ -192,7 +192,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var logger = new TestLogger();
 
             // Act
-            var coverageFilePath = TrxFileReader.LocateCodeCoverageFile(testDir, logger);
+            var coverageFilePath = new TrxFileReader(logger).LocateCodeCoverageFile(testDir);
 
             // Assert
             Assert.AreEqual(null, coverageFilePath);
@@ -235,7 +235,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var logger = new TestLogger();
 
             // Act
-            var coverageFilePath = TrxFileReader.LocateCodeCoverageFile(testDir, logger);
+            var coverageFilePath = new TrxFileReader(logger).LocateCodeCoverageFile(testDir);
 
             // Assert
             Assert.AreEqual(null, coverageFilePath);
@@ -281,7 +281,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             File.Create(expectedFilePath);
 
             // Act
-            var coverageFilePath = TrxFileReader.LocateCodeCoverageFile(testDir, logger);
+            var coverageFilePath = new TrxFileReader(logger).LocateCodeCoverageFile(testDir);
 
             // Assert
             Assert.AreEqual(expectedFilePath, coverageFilePath);
@@ -327,7 +327,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             File.Create(expectedFilePath);
 
             // Act
-            var coverageFilePath = TrxFileReader.LocateCodeCoverageFile(testDir, logger);
+            var coverageFilePath = new TrxFileReader(logger).LocateCodeCoverageFile(testDir);
 
             // Assert
             Assert.AreEqual(expectedFilePath, coverageFilePath);
@@ -369,7 +369,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var logger = new TestLogger();
 
             // Act
-            var coverageFilePath = TrxFileReader.LocateCodeCoverageFile(testDir, logger);
+            var coverageFilePath = new TrxFileReader(logger).LocateCodeCoverageFile(testDir);
 
             // Assert
             Assert.AreEqual(coverageFilePath, coverageFilePath);

--- a/src/SonarScanner.MSBuild.Common/ProcessRunnerArguments.cs
+++ b/src/SonarScanner.MSBuild.Common/ProcessRunnerArguments.cs
@@ -44,7 +44,7 @@ namespace SonarScanner.MSBuild.Common
             SonarProperties.DbUserName
         };
 
-        public ProcessRunnerArguments(string exeName, bool isBatchScript, ILogger logger)
+        public ProcessRunnerArguments(string exeName, bool isBatchScript)
         {
             if (string.IsNullOrWhiteSpace(exeName))
             {
@@ -52,7 +52,6 @@ namespace SonarScanner.MSBuild.Common
             }
 
             ExeName = exeName;
-            Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             IsBatchScript = isBatchScript;
 
             TimeoutInMilliseconds = Timeout.Infinite;
@@ -77,8 +76,6 @@ namespace SonarScanner.MSBuild.Common
         /// Additional environments variables that should be set/overridden for the process. Can be null.
         /// </summary>
         public IDictionary<string, string> EnvironmentVariables { get; set; }
-
-        public ILogger Logger { get; }
 
         public string GetEscapedArguments()
         {

--- a/src/SonarScanner.MSBuild.PostProcessor/CoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/CoverageReportProcessor.cs
@@ -33,17 +33,19 @@ namespace SonarScanner.MSBuild.PostProcessor
 
         private readonly ILegacyTeamBuildFactory legacyTeamBuildFactory;
         private readonly ICoverageReportConverter coverageReportConverter;
+        private readonly ILogger logger;
 
         public CoverageReportProcessor(ILegacyTeamBuildFactory legacyTeamBuildFactory,
-            ICoverageReportConverter coverageReportConverter)
+            ICoverageReportConverter coverageReportConverter, ILogger logger)
         {
             this.legacyTeamBuildFactory
                 = legacyTeamBuildFactory ?? throw new ArgumentNullException(nameof(legacyTeamBuildFactory));
             this.coverageReportConverter
                 = coverageReportConverter ?? throw new ArgumentNullException(nameof(coverageReportConverter));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
-        public bool Initialise(AnalysisConfig config, ITeamBuildSettings settings, ILogger logger)
+        public bool Initialise(AnalysisConfig config, ITeamBuildSettings settings)
         {
             if (settings == null)
             {
@@ -52,7 +54,7 @@ namespace SonarScanner.MSBuild.PostProcessor
 
             TryCreateCoverageReportProcessor(settings);
 
-            initialisedSuccesfully = (processor != null && processor.Initialise(config, settings, logger));
+            initialisedSuccesfully = (processor != null && processor.Initialise(config, settings));
             return initialisedSuccesfully;
         }
 
@@ -71,7 +73,7 @@ namespace SonarScanner.MSBuild.PostProcessor
         {
             if (settings.BuildEnvironment == BuildEnvironment.TeamBuild)
             {
-                processor = new BuildVNextCoverageReportProcessor(coverageReportConverter);
+                processor = new BuildVNextCoverageReportProcessor(coverageReportConverter, logger);
             }
             else if (settings.BuildEnvironment == BuildEnvironment.LegacyTeamBuild
                 && !TeamBuildSettings.SkipLegacyCodeCoverageProcessing)

--- a/src/SonarScanner.MSBuild.PostProcessor/Interfaces/ISummaryReportBuilder.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/Interfaces/ISummaryReportBuilder.cs
@@ -30,6 +30,6 @@ namespace SonarScanner.MSBuild.PostProcessor
     /// <remarks>Interface added for testability</remarks>
     public interface ISummaryReportBuilder
     {
-        void GenerateReports(ITeamBuildSettings settings, AnalysisConfig config, ProjectInfoAnalysisResult result, ILogger logger);
+        void GenerateReports(ITeamBuildSettings settings, AnalysisConfig config, ProjectInfoAnalysisResult result);
     }
 }

--- a/src/SonarScanner.MSBuild.PostProcessor/Interfaces/ITargetsUninstaller.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/Interfaces/ITargetsUninstaller.cs
@@ -27,6 +27,6 @@ namespace SonarScanner.MSBuild.PostProcessor
     /// </summary>
     public interface ITargetsUninstaller
     {
-        void UninstallTargets(ILogger logger);
+        void UninstallTargets();
     }
 }

--- a/src/SonarScanner.MSBuild.PostProcessor/MSBuildPostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/MSBuildPostProcessor.cs
@@ -184,7 +184,7 @@ namespace SonarScanner.MSBuild.PostProcessor
             var args = GetSonarScannerArgs(cmdLineArgs);
 
             logger.IncludeTimestamp = false;
-            var result = sonarScanner.Execute(config, args, logger);
+            var result = sonarScanner.Execute(config, args);
             logger.IncludeTimestamp = true;
             return result;
         }

--- a/src/SonarScanner.MSBuild.PostProcessor/MSBuildPostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/MSBuildPostProcessor.cs
@@ -86,7 +86,7 @@ namespace SonarScanner.MSBuild.PostProcessor
             }
 
             // if initialization fails a warning will have been logged at the source of the failure
-            var initialised = codeCoverageProcessor.Initialise(config, settings, logger);
+            var initialised = codeCoverageProcessor.Initialise(config, settings);
 
             if (initialised && !codeCoverageProcessor.ProcessCoverageReports())
             {

--- a/src/SonarScanner.MSBuild.PostProcessor/MSBuildPostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/MSBuildPostProcessor.cs
@@ -63,7 +63,7 @@ namespace SonarScanner.MSBuild.PostProcessor
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            targetUninstaller.UninstallTargets(logger);
+            targetUninstaller.UninstallTargets();
 
             logger.SuspendOutput();
 
@@ -95,7 +95,7 @@ namespace SonarScanner.MSBuild.PostProcessor
             }
 
             var result = InvokeSonarScanner(provider, config);
-            reportBuilder.GenerateReports(settings, config, result, logger);
+            reportBuilder.GenerateReports(settings, config, result);
             return result.RanToCompletion;
         }
 

--- a/src/SonarScanner.MSBuild.PostProcessor/SummaryReportBuilder.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/SummaryReportBuilder.cs
@@ -57,10 +57,11 @@ namespace SonarScanner.MSBuild.PostProcessor
 
         private readonly ILegacyTeamBuildFactory legacyTeamBuildFactory;
 
-        public SummaryReportBuilder(ILegacyTeamBuildFactory legacyTeamBuildFactory)
+        public SummaryReportBuilder(ILegacyTeamBuildFactory legacyTeamBuildFactory, ILogger logger)
         {
             this.legacyTeamBuildFactory
                 = legacyTeamBuildFactory ?? throw new ArgumentNullException(nameof(legacyTeamBuildFactory));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         #region IReportBuilder interface methods
@@ -68,12 +69,11 @@ namespace SonarScanner.MSBuild.PostProcessor
         /// <summary>
         /// Generates summary reports for LegacyTeamBuild and for Build Vnext
         /// </summary>
-        public void GenerateReports(ITeamBuildSettings settings, AnalysisConfig config, ProjectInfoAnalysisResult result, ILogger logger)
+        public void GenerateReports(ITeamBuildSettings settings, AnalysisConfig config, ProjectInfoAnalysisResult result)
         {
             this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
             this.config = config ?? throw new ArgumentNullException(nameof(config));
             this.result = result ?? throw new ArgumentNullException(nameof(result));
-            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
             GenerateReports();
         }

--- a/src/SonarScanner.MSBuild.PostProcessor/SummaryReportBuilder.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/SummaryReportBuilder.cs
@@ -50,12 +50,13 @@ namespace SonarScanner.MSBuild.PostProcessor
         public /* for test purposes */ const string DashboardUrlFormatWithBranch = "{0}/dashboard/index/{1}:{2}";
         public /* for test purposes */ const string SummaryMdFilename = "summary.md";
 
+        private readonly ILegacyTeamBuildFactory legacyTeamBuildFactory;
+        private readonly ILogger logger;
+
         private AnalysisConfig config;
-        private ILogger logger;
         private ProjectInfoAnalysisResult result;
         private ITeamBuildSettings settings;
 
-        private readonly ILegacyTeamBuildFactory legacyTeamBuildFactory;
 
         public SummaryReportBuilder(ILegacyTeamBuildFactory legacyTeamBuildFactory, ILogger logger)
         {

--- a/src/SonarScanner.MSBuild.PostProcessor/TargetsUninstaller.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/TargetsUninstaller.cs
@@ -30,8 +30,14 @@ namespace SonarScanner.MSBuild.PostProcessor
     public class TargetsUninstaller : ITargetsUninstaller
     {
         private readonly IMsBuildPathsSettings msBuildPathsSettings = new MsBuildPathSettings();
+        private readonly ILogger logger;
 
-        public void UninstallTargets(ILogger logger)
+        public TargetsUninstaller(ILogger logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public void UninstallTargets()
         {
             foreach (var directoryPath in msBuildPathsSettings.GetImportBeforePaths())
             {

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IPreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IPreprocessorObjectFactory.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarScanner.MSBuild.Common;
-
 namespace SonarScanner.MSBuild.PreProcessor
 {
     /// <summary>
@@ -32,16 +30,16 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// </summary>
         /// <param name="args">Validated arguments</param>
         /// <remarks>It is the responsibility of the caller to dispose of the server, if necessary</remarks>
-        ISonarQubeServer CreateSonarQubeServer(ProcessedArgs args, ILogger logger);
+        ISonarQubeServer CreateSonarQubeServer(ProcessedArgs args);
 
         /// <summary>
         /// Creates and returns the component to install the MSBuild targets
         /// </summary>
-        ITargetsInstaller CreateTargetInstaller(ILogger logger);
+        ITargetsInstaller CreateTargetInstaller();
 
         /// <summary>
         /// Creates and returns the component that provisions the Roslyn analyzers
         /// </summary>
-        IAnalyzerProvider CreateRoslynAnalyzerProvider(ILogger logger);
+        IAnalyzerProvider CreateRoslynAnalyzerProvider();
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -40,18 +40,20 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// Once it has been created, it is stored so the factory can use the same instance when
         /// constructing the analyzer provider</remarks>
         private ISonarQubeServer server;
+        private readonly ILogger logger;
+
+        public PreprocessorObjectFactory(ILogger logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
 
         #region IPreprocessorObjectFactory methods
 
-        public ISonarQubeServer CreateSonarQubeServer(ProcessedArgs args, ILogger logger)
+        public ISonarQubeServer CreateSonarQubeServer(ProcessedArgs args)
         {
             if (args == null)
             {
                 throw new ArgumentNullException(nameof(args));
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
             }
 
             var username = args.GetSetting(SonarProperties.SonarUserName, null);
@@ -62,18 +64,13 @@ namespace SonarScanner.MSBuild.PreProcessor
             return server;
         }
 
-        public ITargetsInstaller CreateTargetInstaller(ILogger logger)
+        public ITargetsInstaller CreateTargetInstaller()
         {
             return new TargetsInstaller(logger);
         }
 
-        public IAnalyzerProvider CreateRoslynAnalyzerProvider(ILogger logger)
+        public IAnalyzerProvider CreateRoslynAnalyzerProvider()
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
             if (server == null)
             {
                 throw new InvalidOperationException(Resources.FACTORY_InternalError_MissingServer);

--- a/src/SonarScanner.MSBuild.PreProcessor/TeamBuildPreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/TeamBuildPreProcessor.cs
@@ -121,7 +121,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                 return false;
             }
 
-            var server = factory.CreateSonarQubeServer(localSettings, logger);
+            var server = factory.CreateSonarQubeServer(localSettings);
             if (!FetchArgumentsAndRulesets(server, localSettings, teamBuildSettings, out IDictionary<string, string> serverSettings, out List<AnalyzerSettings> analyzersSettings))
             {
                 return false;
@@ -142,7 +142,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         {
             if (args.InstallLoaderTargets)
             {
-                var installer = factory.CreateTargetInstaller(logger);
+                var installer = factory.CreateTargetInstaller();
                 Debug.Assert(installer != null, "Factory should not return null");
                 installer.InstallLoaderTargets(Directory.GetCurrentDirectory());
             }
@@ -196,7 +196,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                     var inactiveRules = server.GetInactiveRules(qualityProfile, plugin.Language);
 
                     // Generate Roslyn analyzers settings and rulesets
-                    var analyzerProvider = factory.CreateRoslynAnalyzerProvider(logger);
+                    var analyzerProvider = factory.CreateRoslynAnalyzerProvider();
                     Debug.Assert(analyzerProvider != null, "Factory should not return null");
 
                     // Will be null if the processing of server settings and active rules resulted in an empty ruleset

--- a/src/SonarScanner.MSBuild.Shim/IRoslynV1SarifFixer.cs
+++ b/src/SonarScanner.MSBuild.Shim/IRoslynV1SarifFixer.cs
@@ -29,6 +29,6 @@ namespace SonarScanner.MSBuild.Shim
         /// Returns a string representing a path to a valid JSON file suitable for upload to server,
         /// or null if this is not possible.
         /// </summary>
-        string LoadAndFixFile(string sarifFilePath, string language, ILogger logger);
+        string LoadAndFixFile(string sarifFilePath, string language);
     }
 }

--- a/src/SonarScanner.MSBuild.Shim/ISonarScanner.cs
+++ b/src/SonarScanner.MSBuild.Shim/ISonarScanner.cs
@@ -30,6 +30,6 @@ namespace SonarScanner.MSBuild.Shim
     /// file from them, then executes the Java sonar-scanner</remarks>
     public interface ISonarScanner
     {
-        ProjectInfoAnalysisResult Execute(AnalysisConfig config, IEnumerable<string> userCmdLineArguments, ILogger logger);
+        ProjectInfoAnalysisResult Execute(AnalysisConfig config, IEnumerable<string> userCmdLineArguments);
     }
 }

--- a/src/SonarScanner.MSBuild.Shim/ProjectInfoReportBuilder.cs
+++ b/src/SonarScanner.MSBuild.Shim/ProjectInfoReportBuilder.cs
@@ -36,7 +36,7 @@ namespace SonarScanner.MSBuild.Shim
         internal const string ReportFileName = "ProjectInfo.log";
 
         private readonly AnalysisConfig config;
-        private readonly ProjectInfoAnalysisResult analysisResult;
+        private readonly ProjectInfoAnalysisResult result;
         private readonly ILogger logger;
 
         private readonly StringBuilder sb;
@@ -53,17 +53,17 @@ namespace SonarScanner.MSBuild.Shim
 
         #region Private methods
 
-        private ProjectInfoReportBuilder(AnalysisConfig config, ProjectInfoAnalysisResult analysisResult, ILogger logger)
+        private ProjectInfoReportBuilder(AnalysisConfig config, ProjectInfoAnalysisResult result, ILogger logger)
         {
             this.config = config ?? throw new ArgumentNullException(nameof(config));
-            this.analysisResult = analysisResult ?? throw new ArgumentNullException(nameof(analysisResult));
+            this.result = result ?? throw new ArgumentNullException(nameof(result));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             sb = new StringBuilder();
         }
 
         private void Generate()
         {
-            IEnumerable<ProjectInfo> validProjects = analysisResult.GetProjectsByStatus(ProjectInfoValidity.Valid);
+            IEnumerable<ProjectInfo> validProjects = result.GetProjectsByStatus(ProjectInfoValidity.Valid);
 
             WriteTitle(Resources.REPORT_ProductProjectsTitle);
             WriteFileList(validProjects.Where(p => p.ProjectType == ProjectType.Product));
@@ -108,7 +108,7 @@ namespace SonarScanner.MSBuild.Shim
 
             foreach (var status in statuses)
             {
-                projects = projects.Concat(analysisResult.GetProjectsByStatus(status));
+                projects = projects.Concat(result.GetProjectsByStatus(status));
             }
 
             if (!projects.Any())

--- a/src/SonarScanner.MSBuild.Shim/ProjectInfoReportBuilder.cs
+++ b/src/SonarScanner.MSBuild.Shim/ProjectInfoReportBuilder.cs
@@ -45,19 +45,6 @@ namespace SonarScanner.MSBuild.Shim
 
         public static void WriteSummaryReport(AnalysisConfig config, ProjectInfoAnalysisResult result, ILogger logger)
         {
-            if (config == null)
-            {
-                throw new ArgumentNullException(nameof(config));
-            }
-            if (result == null)
-            {
-                throw new ArgumentNullException(nameof(result));
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
             var builder = new ProjectInfoReportBuilder(config, result, logger);
             builder.Generate();
         }
@@ -66,11 +53,11 @@ namespace SonarScanner.MSBuild.Shim
 
         #region Private methods
 
-        private ProjectInfoReportBuilder(AnalysisConfig config, ProjectInfoAnalysisResult result, ILogger logger)
+        private ProjectInfoReportBuilder(AnalysisConfig config, ProjectInfoAnalysisResult analysisResult, ILogger logger)
         {
-            this.config = config;
-            analysisResult = result;
-            this.logger = logger;
+            this.config = config ?? throw new ArgumentNullException(nameof(config));
+            this.analysisResult = analysisResult ?? throw new ArgumentNullException(nameof(analysisResult));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             sb = new StringBuilder();
         }
 

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -49,7 +49,7 @@ namespace SonarScanner.MSBuild.Shim
         }
 
         public PropertiesFileGenerator(AnalysisConfig analysisConfig, ILogger logger)
-            : this(analysisConfig, logger, new RoslynV1SarifFixer())
+            : this(analysisConfig, logger, new RoslynV1SarifFixer(logger))
         {
         }
 
@@ -396,7 +396,7 @@ namespace SonarScanner.MSBuild.Shim
             if (tryResult)
             {
                 var reportPath = reportPathProperty.Value;
-                var fixedPath = fixer.LoadAndFixFile(reportPath, language, logger);
+                var fixedPath = fixer.LoadAndFixFile(reportPath, language);
 
                 if (!reportPath.Equals(fixedPath)) // only need to alter the property if there was no change
                 {

--- a/src/SonarScanner.MSBuild.Shim/RoslynV1SarifFixer.cs
+++ b/src/SonarScanner.MSBuild.Shim/RoslynV1SarifFixer.cs
@@ -33,7 +33,12 @@ namespace SonarScanner.MSBuild.Shim
         public const string CSharpLanguage = "cs";
         public const string VBNetLanguage = "vbnet";
 
-        #region Private Methods
+        private readonly ILogger logger;
+
+        public RoslynV1SarifFixer(ILogger logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
 
         /// <summary>
         /// Returns true if the given SARIF came from the VS 2015 RTM Roslyn, which does not provide correct output.
@@ -114,11 +119,7 @@ namespace SonarScanner.MSBuild.Shim
             return string.Join(Environment.NewLine, inputLines);
         }
 
-        #endregion Private Methods
-
-        #region IRoslynV1SarifFixer
-
-        public string LoadAndFixFile(string sarifFilePath, string language, ILogger logger)
+        public string LoadAndFixFile(string sarifFilePath, string language)
         {
             if (!File.Exists(sarifFilePath))
             {
@@ -166,7 +167,5 @@ namespace SonarScanner.MSBuild.Shim
                 return newSarifFilePath;
             }
         }
-
-    #endregion IRoslynV1SarifFixer
     }
 }

--- a/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
@@ -138,14 +138,14 @@ namespace SonarScanner.MSBuild.Shim
             Debug.Assert(!string.IsNullOrWhiteSpace(config.SonarScannerWorkingDirectory), "The working dir should have been set in the analysis config");
             Debug.Assert(Directory.Exists(config.SonarScannerWorkingDirectory), "The working dir should exist");
 
-            var scannerArgs = new ProcessRunnerArguments(exeFileName, PlatformHelper.IsWindows(), logger)
+            var scannerArgs = new ProcessRunnerArguments(exeFileName, PlatformHelper.IsWindows())
             {
                 CmdLineArgs = allCmdLineArgs,
                 WorkingDirectory = config.SonarScannerWorkingDirectory,
                 EnvironmentVariables = envVarsDictionary
             };
 
-            var runner = new ProcessRunner();
+            var runner = new ProcessRunner(logger);
 
             // SONARMSBRU-202 Note that the Sonar Scanner may write warnings to stderr so
             // we should only rely on the exit code when deciding if it ran successfully

--- a/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
@@ -57,9 +57,16 @@ namespace SonarScanner.MSBuild.Shim
         // This version needs to be in sync with version in src/Packaging/Directory.Build.props.
         private const string SonarScannerVersion = "3.1.0.1141";
 
+        private readonly ILogger logger;
+
+        public SonarScannerWrapper(ILogger logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
         #region ISonarScanner interface
 
-        public ProjectInfoAnalysisResult Execute(AnalysisConfig config, IEnumerable<string> userCmdLineArguments, ILogger logger)
+        public ProjectInfoAnalysisResult Execute(AnalysisConfig config, IEnumerable<string> userCmdLineArguments)
         {
             if (config == null)
             {
@@ -68,10 +75,6 @@ namespace SonarScanner.MSBuild.Shim
             if (userCmdLineArguments == null)
             {
                 throw new ArgumentNullException(nameof(userCmdLineArguments));
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
             }
 
             var result = new PropertiesFileGenerator(config, logger).GenerateFile();

--- a/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
@@ -104,10 +104,6 @@ namespace SonarScanner.MSBuild.TFS.Classic
             {
                 throw new ArgumentNullException(nameof(outputFilePath));
             }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
 
             return ConvertBinaryToXml(conversionToolPath, inputFilePath, outputFilePath, logger);
         }

--- a/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
@@ -313,14 +313,14 @@ namespace SonarScanner.MSBuild.TFS.Classic
                 inputBinaryFilePath
             };
 
-            var scannerArgs = new ProcessRunnerArguments(converterExeFilePath, false, logger)
+            var scannerArgs = new ProcessRunnerArguments(converterExeFilePath, false)
             {
                 WorkingDirectory = Path.GetDirectoryName(outputXmlFilePath),
                 CmdLineArgs = args,
                 TimeoutInMilliseconds = ConversionTimeoutInMs
             };
 
-            var runner = new ProcessRunner();
+            var runner = new ProcessRunner(logger);
             var success = runner.Execute(scannerArgs);
 
             if (success)

--- a/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
@@ -35,6 +35,7 @@ namespace SonarScanner.MSBuild.TFS.Classic
     {
         private const int ConversionTimeoutInMs = 60000;
         private readonly IVisualStudioSetupConfigurationFactory setupConfigurationFactory;
+        private readonly ILogger logger;
 
         /// <summary>
         /// Registry containing information about installed VS versions
@@ -59,26 +60,23 @@ namespace SonarScanner.MSBuild.TFS.Classic
 
         #region Public methods
 
-        public BinaryToXmlCoverageReportConverter()
-            : this(new VisualStudioSetupConfigurationFactory())
+        public BinaryToXmlCoverageReportConverter(ILogger logger)
+            : this(new VisualStudioSetupConfigurationFactory(), logger)
         { }
 
-        public BinaryToXmlCoverageReportConverter(IVisualStudioSetupConfigurationFactory setupConfigurationFactory)
+        public BinaryToXmlCoverageReportConverter(IVisualStudioSetupConfigurationFactory setupConfigurationFactory,
+            ILogger logger)
         {
             this.setupConfigurationFactory = setupConfigurationFactory;
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         #endregion Public methods
 
         #region IReportConverter interface
 
-        public bool Initialize(ILogger logger)
+        public bool Initialize()
         {
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
             bool success;
 
             conversionToolPath = GetExeToolPath(logger);
@@ -96,7 +94,7 @@ namespace SonarScanner.MSBuild.TFS.Classic
             return success;
         }
 
-        public bool ConvertToXml(string inputFilePath, string outputFilePath, ILogger logger)
+        public bool ConvertToXml(string inputFilePath, string outputFilePath)
         {
             if (string.IsNullOrWhiteSpace(inputFilePath))
             {

--- a/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
@@ -79,7 +79,7 @@ namespace SonarScanner.MSBuild.TFS.Classic
         {
             bool success;
 
-            conversionToolPath = GetExeToolPath(logger);
+            conversionToolPath = GetExeToolPath();
 
             if (conversionToolPath == null)
             {
@@ -116,16 +116,17 @@ namespace SonarScanner.MSBuild.TFS.Classic
 
         #region Private methods
 
-        private string GetExeToolPath(ILogger logger)
+        private string GetExeToolPath()
         {
             logger.LogDebug(Resources.CONV_DIAG_LocatingCodeCoverageTool);
-            return GetExeToolPathFromSetupConfiguration(logger) ??
-                   GetExeToolPathFromRegistry(logger);
+
+            return GetExeToolPathFromSetupConfiguration()
+                ?? GetExeToolPathFromRegistry();
         }
 
         #region Code Coverage Tool path from setup configuration
 
-        private string GetExeToolPathFromSetupConfiguration(ILogger logger)
+        private string GetExeToolPathFromSetupConfiguration()
         {
             string toolPath = null;
 
@@ -182,7 +183,7 @@ namespace SonarScanner.MSBuild.TFS.Classic
 
         #region Code Coverage Tool path from registry
 
-        private static string GetExeToolPathFromRegistry(ILogger logger)
+        private string GetExeToolPathFromRegistry()
         {
             string toolPath = null;
 

--- a/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/CoverageReportDownloader.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/CoverageReportDownloader.cs
@@ -30,7 +30,14 @@ namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
 {
     internal class CoverageReportDownloader : ICoverageReportDownloader
     {
-        public bool DownloadReport(string tfsUri, string reportUrl, string newFullFileName, ILogger logger)
+        private readonly ILogger logger;
+
+        public CoverageReportDownloader(ILogger logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public bool DownloadReport(string tfsUri, string reportUrl, string newFullFileName)
         {
             if (string.IsNullOrWhiteSpace(tfsUri))
             {
@@ -44,22 +51,18 @@ namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
             {
                 throw new ArgumentNullException(nameof(newFullFileName));
             }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
 
             var downloadDir = Path.GetDirectoryName(newFullFileName);
             Utilities.EnsureDirectoryExists(downloadDir, logger);
 
-            InternalDownloadReport(tfsUri, reportUrl, newFullFileName, logger);
+            InternalDownloadReport(tfsUri, reportUrl, newFullFileName);
 
             return true;
         }
 
-        private void InternalDownloadReport(string tfsUri, string reportUrl, string reportDestinationPath, ILogger logger)
+        private void InternalDownloadReport(string tfsUri, string reportUrl, string reportDestinationPath)
         {
-            var vssHttpMessageHandler = GetHttpHandler(tfsUri, logger);
+            var vssHttpMessageHandler = GetHttpHandler(tfsUri);
 
             logger.LogInfo(Resources.DOWN_DIAG_DownloadCoverageReportFromTo, reportUrl, reportDestinationPath);
 
@@ -80,7 +83,7 @@ namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
             }
         }
 
-        private VssHttpMessageHandler GetHttpHandler(string tfsUri, ILogger logger)
+        private VssHttpMessageHandler GetHttpHandler(string tfsUri)
         {
             VssCredentials vssCreds;
             var tfsCollectionUri = new Uri(tfsUri);

--- a/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/CoverageReportUrlProvider.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/CoverageReportUrlProvider.cs
@@ -41,10 +41,17 @@ namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
         /// </summary>
         private const int RetryPeriodInMs = 2000;
 
+        private readonly ILogger logger;
+
+        public CoverageReportUrlProvider(ILogger logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
         /// <summary>
         /// Builds and returns the download URLs for all code coverage reports for the specified build
         /// </summary>
-        public IEnumerable<string> GetCodeCoverageReportUrls(string tfsUri, string buildUri, ILogger logger)
+        public IEnumerable<string> GetCodeCoverageReportUrls(string tfsUri, string buildUri)
         {
             if (string.IsNullOrWhiteSpace(tfsUri))
             {
@@ -53,10 +60,6 @@ namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
             if (string.IsNullOrWhiteSpace(buildUri))
             {
                 throw new ArgumentNullException(nameof(buildUri));
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
             }
 
             var urls = new List<string>();

--- a/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/ICoverageReportDownloader.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/ICoverageReportDownloader.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarScanner.MSBuild.Common;
-
 namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
 {
     public interface ICoverageReportDownloader // was internal
@@ -29,9 +27,8 @@ namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
         /// </summary>
         /// <param name="tfsUri">The project collection URI</param>
         /// <param name="reportUrl">The file to be downloaded</param>
-        /// <param name="downloadDir">The directory into which the files should be downloaded</param>
         /// <param name="newFileName">The name of the new file</param>
         /// <returns>True if the file was downloaded successfully, otherwise false</returns>
-        bool DownloadReport(string tfsUri, string reportUrl, string newFullFileName, ILogger logger);
+        bool DownloadReport(string tfsUri, string reportUrl, string newFullFileName);
     }
 }

--- a/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/LegacyTeamBuildFactory.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/LegacyTeamBuildFactory.cs
@@ -18,14 +18,24 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
+using SonarQube.Common;
+
 namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
 {
     public class LegacyTeamBuildFactory : ILegacyTeamBuildFactory
     {
+        private readonly ILogger logger;
+
+        public LegacyTeamBuildFactory(ILogger logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
         public ILegacyBuildSummaryLogger BuildLegacyBuildSummaryLogger(string tfsUri, string buildUri)
             => new LegacyBuildSummaryLogger(tfsUri, buildUri);
 
         public ICoverageReportProcessor BuildTfsLegacyCoverageReportProcessor()
-            => new TfsLegacyCoverageReportProcessor();
+            => new TfsLegacyCoverageReportProcessor(logger);
     }
 }

--- a/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/LegacyTeamBuildFactory.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/LegacyTeamBuildFactory.cs
@@ -19,7 +19,7 @@
  */
 
 using System;
-using SonarQube.Common;
+using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
 {

--- a/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/TfsLegacyCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/TfsLegacyCoverageReportProcessor.cs
@@ -35,7 +35,7 @@ namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
         private readonly ICoverageReportDownloader downloader;
 
         public TfsLegacyCoverageReportProcessor(ILogger logger)
-            : this(new CoverageReportUrlProvider(), new CoverageReportDownloader(logger),
+            : this(new CoverageReportUrlProvider(logger), new CoverageReportDownloader(logger),
                   new BinaryToXmlCoverageReportConverter(logger), logger)
         {
         }
@@ -52,7 +52,7 @@ namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
 
         protected override bool TryGetBinaryReportFile(AnalysisConfig config, ITeamBuildSettings settings, out string binaryFilePath)
         {
-            var urls = urlProvider.GetCodeCoverageReportUrls(config.GetTfsUri(), config.GetBuildUri(), Logger);
+            var urls = urlProvider.GetCodeCoverageReportUrls(config.GetTfsUri(), config.GetBuildUri());
             Debug.Assert(urls != null, "Not expecting the returned list of urls to be null");
 
             var continueProcessing = true;

--- a/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/TfsLegacyCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/XamlBuild/TfsLegacyCoverageReportProcessor.cs
@@ -35,7 +35,7 @@ namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
         private readonly ICoverageReportDownloader downloader;
 
         public TfsLegacyCoverageReportProcessor(ILogger logger)
-            : this(new CoverageReportUrlProvider(), new CoverageReportDownloader(),
+            : this(new CoverageReportUrlProvider(), new CoverageReportDownloader(logger),
                   new BinaryToXmlCoverageReportConverter(logger), logger)
         {
         }
@@ -68,7 +68,7 @@ namespace SonarScanner.MSBuild.TFS.Classic.XamlBuild
                     var url = urls.First();
 
                     var targetFileName = Path.Combine(config.SonarOutputDir, DownloadFileName);
-                    var result = downloader.DownloadReport(config.GetTfsUri(), url, targetFileName, Logger);
+                    var result = downloader.DownloadReport(config.GetTfsUri(), url, targetFileName);
 
                     if (result)
                     {

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -25,21 +25,21 @@ namespace SonarScanner.MSBuild.TFS
 {
     public class BuildVNextCoverageReportProcessor : CoverageReportProcessorBase
     {
-        public BuildVNextCoverageReportProcessor(ICoverageReportConverter converter)
-            : base(converter)
+        public BuildVNextCoverageReportProcessor(ICoverageReportConverter converter, ILogger logger)
+            : base(converter, logger)
         {
         }
 
-        protected override bool TryGetBinaryReportFile(AnalysisConfig config, ITeamBuildSettings settings, ILogger logger, out string binaryFilePath)
+        protected override bool TryGetBinaryReportFile(AnalysisConfig config, ITeamBuildSettings settings, out string binaryFilePath)
         {
-            binaryFilePath = TrxFileReader.LocateCodeCoverageFile(settings.BuildDirectory, logger);
+            binaryFilePath = TrxFileReader.LocateCodeCoverageFile(settings.BuildDirectory, Logger);
 
             return true; // there aren't currently any conditions under which we'd want to stop processing
         }
 
-        protected override bool TryGetTrxFile(AnalysisConfig config, ITeamBuildSettings settings, ILogger logger, out string trxFilePath)
+        protected override bool TryGetTrxFile(AnalysisConfig config, ITeamBuildSettings settings, out string trxFilePath)
         {
-            trxFilePath = TrxFileReader.FindTrxFile(settings.BuildDirectory, logger);
+            trxFilePath = TrxFileReader.FindTrxFile(settings.BuildDirectory, Logger);
 
             return true;
         }

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -32,14 +32,14 @@ namespace SonarScanner.MSBuild.TFS
 
         protected override bool TryGetBinaryReportFile(AnalysisConfig config, ITeamBuildSettings settings, out string binaryFilePath)
         {
-            binaryFilePath = TrxFileReader.LocateCodeCoverageFile(settings.BuildDirectory, Logger);
+            binaryFilePath = new TrxFileReader(Logger).LocateCodeCoverageFile(settings.BuildDirectory);
 
             return true; // there aren't currently any conditions under which we'd want to stop processing
         }
 
         protected override bool TryGetTrxFile(AnalysisConfig config, ITeamBuildSettings settings, out string trxFilePath)
         {
-            trxFilePath = TrxFileReader.FindTrxFile(settings.BuildDirectory, Logger);
+            trxFilePath = new TrxFileReader(Logger).FindTrxFile(settings.BuildDirectory);
 
             return true;
         }

--- a/src/SonarScanner.MSBuild.TFS/Interfaces/ICoverageReportConverter.cs
+++ b/src/SonarScanner.MSBuild.TFS/Interfaces/ICoverageReportConverter.cs
@@ -28,7 +28,7 @@ namespace SonarScanner.MSBuild.TFS
         /// Initializes the converter
         /// </summary>
         /// <returns>True if the converter was initialized successfully, otherwise false</returns>
-        bool Initialize(ILogger logger);
+        bool Initialize();
 
         /// <summary>
         /// Converts the supplied binary code coverage report file to XML
@@ -36,6 +36,6 @@ namespace SonarScanner.MSBuild.TFS
         /// <param name="inputFilePath">The full path to the binary file to be converted</param>
         /// <param name="outputFilePath">The name of the XML file to be created</param>
         /// <returns>True if the conversion was successful, otherwise false</returns>
-        bool ConvertToXml(string inputFilePath, string outputFilePath, ILogger logger);
+        bool ConvertToXml(string inputFilePath, string outputFilePath);
     }
 }

--- a/src/SonarScanner.MSBuild.TFS/Interfaces/ICoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/Interfaces/ICoverageReportProcessor.cs
@@ -29,7 +29,7 @@ namespace SonarScanner.MSBuild.TFS
         /// Initializes the converter
         /// </summary>
         /// <returns>Operation success</returns>
-        bool Initialise(AnalysisConfig config, ITeamBuildSettings settings, ILogger logger);
+        bool Initialise(AnalysisConfig config, ITeamBuildSettings settings);
 
         /// <summary>
         /// Locate, download and convert the code coverage report

--- a/src/SonarScanner.MSBuild.TFS/Interfaces/ICoverageUrlProvider.cs
+++ b/src/SonarScanner.MSBuild.TFS/Interfaces/ICoverageUrlProvider.cs
@@ -30,6 +30,6 @@ namespace SonarScanner.MSBuild.TFS
         /// </summary>
         /// <param name="tfsUri">The URI of the TFS collection</param>
         /// <parparam name="buildUri">The URI of the build for which data should be retrieved</parparam>
-        IEnumerable<string> GetCodeCoverageReportUrls(string tfsUri, string buildUri, ILogger logger);
+        IEnumerable<string> GetCodeCoverageReportUrls(string tfsUri, string buildUri);
     }
 }

--- a/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
+++ b/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
@@ -57,8 +57,7 @@ namespace SonarScanner.MSBuild
 
         public ITeamBuildPreProcessor CreatePreProcessor()
         {
-            IPreprocessorObjectFactory factory = new PreprocessorObjectFactory();
-            return new TeamBuildPreProcessor(factory, logger);
+            return new TeamBuildPreProcessor(new PreprocessorObjectFactory(logger), logger);
         }
     }
 }

--- a/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
+++ b/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
@@ -49,7 +49,7 @@ namespace SonarScanner.MSBuild
         {
             return new MSBuildPostProcessor(
                 new CoverageReportProcessor(legacyTeamBuildFactory, coverageReportConverter),
-                new SonarScannerWrapper(),
+                new SonarScannerWrapper(logger),
                 new SummaryReportBuilder(legacyTeamBuildFactory),
                 logger,
                 new TargetsUninstaller());

--- a/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
+++ b/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
@@ -48,7 +48,7 @@ namespace SonarScanner.MSBuild
         public IMSBuildPostProcessor CreatePostProcessor()
         {
             return new MSBuildPostProcessor(
-                new CoverageReportProcessor(legacyTeamBuildFactory, coverageReportConverter),
+                new CoverageReportProcessor(legacyTeamBuildFactory, coverageReportConverter, logger),
                 new SonarScannerWrapper(logger),
                 new SummaryReportBuilder(legacyTeamBuildFactory),
                 logger,

--- a/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
+++ b/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
@@ -50,9 +50,9 @@ namespace SonarScanner.MSBuild
             return new MSBuildPostProcessor(
                 new CoverageReportProcessor(legacyTeamBuildFactory, coverageReportConverter, logger),
                 new SonarScannerWrapper(logger),
-                new SummaryReportBuilder(legacyTeamBuildFactory),
+                new SummaryReportBuilder(legacyTeamBuildFactory, logger),
                 logger,
-                new TargetsUninstaller());
+                new TargetsUninstaller(logger));
         }
 
         public ITeamBuildPreProcessor CreatePreProcessor()

--- a/src/SonarScanner.MSBuild/NullCoverageReportConverter.cs
+++ b/src/SonarScanner.MSBuild/NullCoverageReportConverter.cs
@@ -26,9 +26,9 @@ namespace SonarScanner.MSBuild
 {
     public class NullCoverageReportConverter : ICoverageReportConverter
     {
-        public bool ConvertToXml(string inputFilePath, string outputFilePath, ILogger logger)
+        public bool ConvertToXml(string inputFilePath, string outputFilePath)
             => false;
 
-        public bool Initialize(ILogger logger) => true;
+        public bool Initialize() => true;
     }
 }

--- a/src/SonarScanner.MSBuild/Program.cs
+++ b/src/SonarScanner.MSBuild/Program.cs
@@ -82,8 +82,8 @@ namespace SonarScanner.MSBuild
                     return ErrorCode;
                 }
 
-                var processorFactory = new DefaultProcessorFactory(logger, GetLegacyTeamBuildFactory(),
-                    GetCoverageReportConverter());
+                var processorFactory = new DefaultProcessorFactory(logger, GetLegacyTeamBuildFactory(logger),
+                    GetCoverageReportConverter(logger));
                 var bootstrapper = new BootstrapperClass(processorFactory, settings, logger);
                 var exitCode = bootstrapper.Execute();
                 Environment.ExitCode = exitCode;
@@ -97,19 +97,19 @@ namespace SonarScanner.MSBuild
             }
         }
 
-        private static ICoverageReportConverter GetCoverageReportConverter()
+        private static ICoverageReportConverter GetCoverageReportConverter(ILogger logger)
         {
 #if IS_NET_FRAMEWORK
-            return new SonarScanner.MSBuild.TFS.Classic.BinaryToXmlCoverageReportConverter();
+            return new SonarScanner.MSBuild.TFS.Classic.BinaryToXmlCoverageReportConverter(logger);
 #else
             return new NullCoverageReportConverter();
 #endif
         }
 
-        private static ILegacyTeamBuildFactory GetLegacyTeamBuildFactory()
+        private static ILegacyTeamBuildFactory GetLegacyTeamBuildFactory(ILogger logger)
         {
 #if IS_NET_FRAMEWORK
-            return new SonarScanner.MSBuild.TFS.Classic.XamlBuild.LegacyTeamBuildFactory();
+            return new SonarScanner.MSBuild.TFS.Classic.XamlBuild.LegacyTeamBuildFactory(logger);
 #else
             return new NotSupportedLegacyTeamBuildFactory();
 #endif


### PR DESCRIPTION
There were a lot of methods that accepted ILogger instance, which was making them less readable and refactorable.