### PR TITLE
Converted failing MSBuild integration tests to execute msbuild.exe

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
@@ -94,21 +94,19 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
 
             var projectRoot = BuildUtilities.CreateInitializedProjectRoot(TestContext, descriptor, preImportProperties);
 
-            var logger = new BuildLogger();
-
             // Act
-            var result = BuildUtilities.BuildTargets(projectRoot, logger);
+            var result = BuildRunner.BuildTargets(TestContext, descriptor.FullFilePath);
 
             // Assert
-            BuildAssertions.AssertTargetSucceeded(result, TargetConstants.DefaultBuildTarget); // Build should succeed with warnings
+            result.AssertTargetSucceeded(TargetConstants.DefaultBuildTarget); // Build should succeed with warnings
             ProjectInfoAssertions.AssertProjectInfoExists(rootOutputFolder, Path.Combine(rootInputFolder,
                 descriptor.ProjectFolderName, descriptor.ProjectFileName));
 
-            logger.AssertExpectedErrorCount(0);
-            logger.AssertExpectedWarningCount(1);
+            result.AssertExpectedErrorCount(0);
+            result.AssertExpectedWarningCount(1);
 
-            var warning = logger.Warnings[0];
-            Assert.IsTrue(warning.Message.Contains(descriptor.FullFilePath),
+            var warning = result.Warnings[0];
+            Assert.IsTrue(warning.Contains(descriptor.FullFilePath),
                 "Expecting the warning to contain the full path to the bad project file");
         }
 
@@ -139,21 +137,24 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
             var projectRoot = BuildUtilities.CreateInitializedProjectRoot(TestContext, descriptor, preImportProperties);
             projectRoot.AddProperty("ProjectGuid", "Invalid guid");
 
-            var logger = new BuildLogger();
+            string projectFilePath = Path.Combine(rootInputFolder,
+                descriptor.ProjectFolderName, descriptor.ProjectFileName);
+
+            projectRoot.Save(projectFilePath);
+            TestContext.AddResultFile(projectFilePath);
 
             // Act
-            var result = BuildUtilities.BuildTargets(projectRoot, logger);
+            var buildLog = BuildRunner.BuildTargets(TestContext, projectFilePath);
 
             // Assert
-            BuildAssertions.AssertTargetSucceeded(result, TargetConstants.DefaultBuildTarget); // Build should succeed with warnings
-            ProjectInfoAssertions.AssertProjectInfoExists(rootOutputFolder, Path.Combine(rootInputFolder,
-                descriptor.ProjectFolderName, descriptor.ProjectFileName));
+            buildLog.AssertTargetSucceeded(TargetConstants.DefaultBuildTarget); // Build should succeed with warnings
+            ProjectInfoAssertions.AssertProjectInfoExists(rootOutputFolder, projectFilePath);
 
-            logger.AssertExpectedErrorCount(0);
-            logger.AssertExpectedWarningCount(1);
+            buildLog.AssertExpectedErrorCount(0);
+            buildLog.AssertExpectedWarningCount(1);
 
-            var warning = logger.Warnings[0];
-            Assert.IsTrue(warning.Message.Contains(descriptor.FullFilePath),
+            var warning = buildLog.Warnings[0];
+            Assert.IsTrue(warning.Contains(descriptor.FullFilePath),
                 "Expecting the warning to contain the full path to the bad project file");
         }
 
@@ -601,20 +602,19 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
         {
             var projectRoot = BuildUtilities.CreateInitializedProjectRoot(TestContext, descriptor, preImportProperties);
 
-            var logger = new BuildLogger();
-
             // Act
-            var result = BuildUtilities.BuildTargets(projectRoot, logger);
+            var result = BuildRunner.BuildTargets(TestContext, descriptor.FullFilePath);
+            TestContext.AddResultFile(result.FilePath);
 
             // Assert
-            BuildAssertions.AssertTargetSucceeded(result, TargetConstants.DefaultBuildTarget);
+            result.AssertTargetSucceeded(TargetConstants.DefaultBuildTarget);
 
             // We expect the compiler to warn if there are no compiler inputs
             var expectedWarnings = (descriptor.ManagedSourceFiles.Any()) ? 0 : 1;
-            logger.AssertExpectedErrorCount(0);
-            logger.AssertExpectedWarningCount(expectedWarnings);
+            result.AssertExpectedErrorCount(0);
+            result.AssertExpectedWarningCount(expectedWarnings);
 
-            logger.AssertExpectedTargetOrdering(
+            result.AssertExpectedTargetOrdering(
                 TargetConstants.CategoriseProjectTarget,
                 TargetConstants.DefaultBuildTarget,
                 TargetConstants.CalculateFilesToAnalyzeTarget,
@@ -625,7 +625,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
 
             // Check expected project outputs
             Assert.AreEqual(1, Directory.EnumerateDirectories(rootOutputFolder).Count(), "Only expecting one child directory to exist under the root analysis output folder");
-            ProjectInfoAssertions.AssertProjectInfoExists(rootOutputFolder, projectRoot.FullPath);
+            ProjectInfoAssertions.AssertProjectInfoExists(rootOutputFolder, descriptor.FullFilePath);
 
             return Directory.EnumerateDirectories(rootOutputFolder).Single();
         }

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarScanner.MSBuild.Common;
 using TestUtilities;
@@ -393,8 +394,6 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
             var rootInputFolder = TestUtils.CreateTestSpecificFolder(TestContext, "Inputs");
             var rootOutputFolder = TestUtils.CreateTestSpecificFolder(TestContext, "Outputs");
 
-            var logger = new BuildLogger();
-
             var sqTargetFile = TestUtils.EnsureAnalysisTargetsExists(TestContext);
             var projectFilePath = Path.Combine(rootInputFolder, "project.txt");
             var projectGuid = Guid.NewGuid();
@@ -444,13 +443,13 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
                 );
 
             // Act
-            var result = BuildUtilities.BuildTargets(projectRoot, logger,
+            var result = BuildRunner.BuildTargets(TestContext, projectRoot.FullPath,
                 TargetConstants.DefaultBuildTarget);
 
             // Assert
-            BuildAssertions.AssertTargetSucceeded(result, TargetConstants.DefaultBuildTarget);
+            result.BuildSucceeded.Should().BeTrue();
 
-            logger.AssertExpectedTargetOrdering(
+            result.AssertExpectedTargetOrdering(
                 TargetConstants.DefaultBuildTarget,
                 TargetConstants.CategoriseProjectTarget,
                 TargetConstants.CalculateFilesToAnalyzeTarget,
@@ -481,8 +480,6 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
             // Arrange
             var rootInputFolder = TestUtils.CreateTestSpecificFolder(TestContext, "Inputs");
             var rootOutputFolder = TestUtils.CreateTestSpecificFolder(TestContext, "Outputs");
-
-            var logger = new BuildLogger();
 
             var sqTargetFile = TestUtils.EnsureAnalysisTargetsExists(TestContext);
             var projectFilePath = Path.Combine(rootInputFolder, "project.txt");
@@ -524,13 +521,13 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
                 );
 
             // Act
-            var result = BuildUtilities.BuildTargets(projectRoot, logger,
+            var result = BuildRunner.BuildTargets(TestContext, projectRoot.FullPath,
                 TargetConstants.DefaultBuildTarget);
 
             // Assert
-            BuildAssertions.AssertTargetSucceeded(result, TargetConstants.DefaultBuildTarget);
+            result.BuildSucceeded.Should().BeTrue();
 
-            logger.AssertExpectedTargetOrdering(
+            result.AssertExpectedTargetOrdering(
                 TargetConstants.DefaultBuildTarget,
                 TargetConstants.CategoriseProjectTarget,
                 TargetConstants.CalculateFilesToAnalyzeTarget,

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildLogAssertions.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildLogAssertions.cs
@@ -1,0 +1,138 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SonarScanner.MSBuild.Tasks.IntegrationTests
+{
+    /// <summary>
+    /// Assertion methods that check the content of the custom XML build log
+    /// </summary>
+    internal static class BuildLogAssertions
+    {
+        /// <summary>
+        /// Checks that building the specified target succeeded.
+        /// </summary>
+        public static void AssertTargetSucceeded(this BuildLog log, string target)
+        {
+            AssertTargetExecuted(log, target);
+            log.BuildSucceeded.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Checks that building the specified target failed.
+        /// </summary>
+        public static void AssertTargetFailed(this BuildLog log, string target)
+        {
+            AssertTargetExecuted(log, target);
+            log.BuildSucceeded.Should().BeFalse();
+        }
+
+        public static void AssertExpectedPropertyValue(this BuildLog log, string propertyName, string expectedValue)
+        {
+            if (expectedValue == null)
+            {
+                AssertPropertyDoesNotExist(log, propertyName);
+            }
+            else
+            {
+                var propertyValue = AssertPropertyExists(log, propertyName);
+                propertyValue.Should().Be(expectedValue, "Property '{0}' does not have the expected value", propertyName);
+            }
+        }
+
+        public static string AssertPropertyExists(this BuildLog log, string propertyName)
+        {
+            var exists = log.TryGetPropertyValue(propertyName, out var propertyValue);
+            exists.Should().BeTrue(
+                "Expecting the property to exist. Property: {0}, Value: {1}", propertyName, propertyValue);
+
+            return propertyValue;
+        }
+
+        public static void AssertPropertyDoesNotExist(this BuildLog log, string propertyName)
+        {
+            var exists = log.TryGetPropertyValue(propertyName, out var propertyValue);
+            exists.Should().BeFalse(
+                "Not expecting the property to exist. Property: {0}, Value: {1}", propertyName, propertyValue);
+        }
+
+        public static void AssertTargetExecuted(this BuildLog log, string targetName)
+        {
+            var found = log.Targets.FirstOrDefault(t => t.Equals(targetName, StringComparison.InvariantCulture));
+            found.Should().NotBeNull("Specified target was not executed: {0}", targetName);
+        }
+
+        public static void AssertTargetNotExecuted(this BuildLog log, string targetName)
+        {
+            var found = log.Targets.FirstOrDefault(t => t.Equals(targetName, StringComparison.InvariantCulture));
+            found.Should().BeNull("Not expecting the target to have been executed: {0}", targetName);
+        }
+
+        public static void AssertTaskExecuted(this BuildLog log, string taskName)
+        {
+            var found = log.Tasks.FirstOrDefault(t => t.Equals(taskName, StringComparison.InvariantCulture));
+            found.Should().NotBeNull("Specified task was not executed: {0}", taskName);
+        }
+
+        public static void AssertTaskNotExecuted(this BuildLog log, string taskName)
+        {
+            var found = log.Tasks.FirstOrDefault(t => t.Equals(taskName, StringComparison.InvariantCulture));
+            found.Should().BeNull("Not expecting the task to have been executed: {0}", taskName);
+        }
+
+        /// <summary>
+        /// Checks that the expected tasks were executed in the specified order
+        /// </summary>
+        public static void AssertExpectedTargetOrdering(this BuildLog log, params string[] expected)
+        {
+            foreach (var target in expected)
+            {
+                AssertTargetExecuted(log,target);
+            }
+
+            var actual = log.Targets.Where(t => expected.Contains(t, StringComparer.Ordinal)).ToArray();
+
+            Console.WriteLine("Expected target order: {0}", string.Join(", ", expected));
+            Console.WriteLine("Actual target order: {0}", string.Join(", ", actual));
+
+            CollectionAssert.AreEqual(expected, actual, "Targets were not executed in the expected order");
+        }
+
+        public static void AssertNoWarningsOrErrors(this BuildLog log)
+        {
+            AssertExpectedErrorCount(log, 0);
+            AssertExpectedWarningCount(log, 0);
+        }
+
+        public static void AssertExpectedErrorCount(this BuildLog log, int expected)
+        {
+            log.Errors.Count.Should().Be(expected);
+        }
+
+        public static void AssertExpectedWarningCount(this BuildLog log, int expected)
+        {
+            log.Warnings.Count.Should().Be(expected);
+        }
+    }
+}

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildRunner.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildRunner.cs
@@ -46,6 +46,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
             // Expecting a path like "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
             var exePath = MSBuildLocator.GetMSBuildPath(msBuildVersion, testContext);
             exePath.Should().NotBeNull($"Test setup failure - failed to locate MSBuild.exe for version {msBuildVersion}");
+            File.Exists(exePath).Should().BeTrue($"expecting the returned msbuild.exe file to exist. File path: {exePath}");
 
             // The build is being run in a separate process so we can't directly
             // capture the property values or which tasks/targets were executed.

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildRunner.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildRunner.cs
@@ -1,0 +1,80 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarScanner.MSBuild.Common;
+
+namespace SonarScanner.MSBuild.Tasks.IntegrationTests
+{
+    /// <summary>
+    /// Utility classes that handles executing msbuild.exe and return a log
+    /// describing the build
+    /// </summary>
+    public static class BuildRunner
+    {
+        public static BuildLog BuildTargets(TestContext testContext, string projectFile, params string[] targets)
+        {
+            return BuildTargets(testContext, projectFile, buildShouldSucceed: true, targets: targets);
+        }
+
+        public static BuildLog BuildTargets(TestContext testContext, string projectFile, bool buildShouldSucceed, params string[] targets)
+        {
+            // TODO: support 14.0?
+            const string msBuildVersion = "15.0";
+
+            // Expecting a path like "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
+            var exePath = MSBuildLocator.GetMSBuildPath(msBuildVersion, testContext);
+            exePath.Should().NotBeNull($"Test setup failure - failed to locate MSBuild.exe for version {msBuildVersion}");
+
+            // The build is being run in a separate process so we can't directly
+            // capture the property values or which tasks/targets were executed.
+            // Instead, we add a custom logger that will record that information
+            // in a structured form that we can check later.
+            var logPath = projectFile + ".log";
+            var msbuildArgs = new List<string>();
+            var loggerType = typeof(SimpleXmlLogger);
+            msbuildArgs.Add($"/logger:{loggerType.FullName},{loggerType.Assembly.Location};{logPath}");
+            msbuildArgs.Add(projectFile);
+
+            // Specify the targets to be executed, if any
+            if (targets?.Length > 0)
+            {
+                msbuildArgs.Add($"/t:" + string.Join(";", targets.ToArray()));
+            }
+
+            // Run the build
+            var args = new ProcessRunnerArguments(exePath, false, new ConsoleLogger(true));
+            args.CmdLineArgs = msbuildArgs;
+            var runner = new ProcessRunner();
+            var success = runner.Execute(args);
+
+            File.Exists(logPath).Should().BeTrue();
+            testContext.AddResultFile(logPath);
+
+            success.Should().Be(buildShouldSucceed);
+
+            return BuildLog.Load(logPath);
+        }
+    }
+}

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/MSBuildLocator.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/MSBuildLocator.cs
@@ -1,0 +1,73 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.IO;
+using Microsoft.VisualStudio.Setup.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SonarScanner.MSBuild.Tasks.IntegrationTests
+{
+    /// <summary>
+    /// Utility class that locates MSBuild executables
+    /// </summary>
+    internal class MSBuildLocator
+    {
+        /// <summary>
+        /// Returns the path to the specified version of msbuild.exe or
+        /// null if it could not be found
+        /// </summary>
+        /// <param name="msBuildMajorVersion">MSBuild major version number e.g. 15.0</param>
+        public static string GetMSBuildPath(string msBuildMajorVersion, TestContext testContext)
+        {
+            testContext.WriteLine($"Test setup: attempting to location MSBuild instance. Version: {msBuildMajorVersion}");
+            ISetupConfiguration config = new SetupConfiguration();
+
+            string partialExePath = Path.Combine("MSBuild", msBuildMajorVersion, "Bin", "msbuild.exe");
+
+            var enumerator = config.EnumInstances();
+
+            var instances = new ISetupInstance[100];
+            enumerator.Next(100, instances, out int fetched);
+
+            if (fetched == 0)
+            {
+                throw new InvalidOperationException("Test setup error: no instances of Visual Studio could be located on this machine");
+            }
+            
+            for(int i = 0; i < fetched; i++)
+            {
+                var instance = instances[i];
+                testContext.WriteLine($"\t\tVS instance: {instance.GetDisplayName()}, {instance.GetInstallationVersion()}, {instance.GetInstallationPath()}");
+
+                var candidateExePath = instance.ResolvePath(partialExePath);
+
+                if (File.Exists(candidateExePath))
+                {
+                    testContext.WriteLine($"\tMSBuild exe located: {candidateExePath}");
+                    return candidateExePath;
+                }
+            }
+
+            testContext.WriteLine($"Test setup: MSBuild exe could not be located");
+            return null;
+        }
+    }
+}

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/MSBuildLocator.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/MSBuildLocator.cs
@@ -28,7 +28,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
     /// <summary>
     /// Utility class that locates MSBuild executables
     /// </summary>
-    internal class MSBuildLocator
+    internal static class MSBuildLocator
     {
         /// <summary>
         /// Returns the path to the specified version of msbuild.exe or
@@ -40,19 +40,18 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
             testContext.WriteLine($"Test setup: attempting to location MSBuild instance. Version: {msBuildMajorVersion}");
             ISetupConfiguration config = new SetupConfiguration();
 
-            string partialExePath = Path.Combine("MSBuild", msBuildMajorVersion, "Bin", "msbuild.exe");
-
-            var enumerator = config.EnumInstances();
-
             var instances = new ISetupInstance[100];
+            var enumerator = config.EnumInstances();
             enumerator.Next(100, instances, out int fetched);
 
             if (fetched == 0)
             {
                 throw new InvalidOperationException("Test setup error: no instances of Visual Studio could be located on this machine");
             }
-            
-            for(int i = 0; i < fetched; i++)
+
+            string partialExePath = Path.Combine("MSBuild", msBuildMajorVersion, "Bin", "msbuild.exe");
+
+            for (int i = 0; i < fetched; i++)
             {
                 var instance = instances[i];
                 testContext.WriteLine($"\t\tVS instance: {instance.GetDisplayName()}, {instance.GetInstallationVersion()}, {instance.GetInstallationPath()}");

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/SimpleXmlLogger.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/SimpleXmlLogger.cs
@@ -1,0 +1,117 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+
+// See MSDN for an example: https://msdn.microsoft.com/en-us/library/ms171471#Anchor_5
+// Example usage: msbuild x.csproj /logger:SonarScanner.MSBuild.Tasks.IntegrationTests.SimpleXmkLogger,..\SonarScanner.MSBuild.Tasks.IntegrationTests\bin\Debug\Logger.dll;log1.txt /noconsolelogger
+
+namespace SonarScanner.MSBuild.Tasks.IntegrationTests
+{
+    public class SimpleXmlLogger : ILogger
+    {
+        private IEventSource eventSource;
+
+        private BuildLog log;
+
+        private string fileName;
+
+        public LoggerVerbosity Verbosity { get; set; }
+
+        public string Parameters { get; set; }
+
+        public void Initialize(IEventSource eventSource)
+        {
+            // The name of the log file should be passed as the first item in the
+            // "parameters" specification in the /logger switch.  It is required
+            // to pass a log file to this logger. Other loggers may have zero or more than 
+            // one parameters.
+            if (null == Parameters)
+            {
+                throw new LoggerException("Log file was not set.");
+            }
+            var parameters = Parameters.Split(';');
+
+            var logFile = parameters[0];
+            if (string.IsNullOrEmpty(logFile))
+            {
+                throw new LoggerException("Log file was not set.");
+            }
+
+            if (parameters.Length > 1)
+            {
+                throw new LoggerException("Too many parameters passed.");
+            }
+
+            fileName = logFile;
+
+            this.eventSource = eventSource;
+
+            eventSource.BuildFinished += EventSource_BuildFinished;
+            eventSource.BuildStarted += EventSource_BuildStarted;
+
+            eventSource.TargetStarted += EventSource_TargetStarted;
+            eventSource.TaskStarted += EventSource_TaskStarted;
+
+            eventSource.WarningRaised += EventSource_WarningRaised;
+            eventSource.ErrorRaised += EventSource_ErrorRaised;
+
+            log = new BuildLog();
+        }
+
+        private void EventSource_BuildStarted(object sender, BuildStartedEventArgs e)
+        {
+            foreach(KeyValuePair<string, string> kvp in e.BuildEnvironment)
+            {
+                log.BuildProperties.Add(new BuildProperty() { Name = kvp.Key, Value = kvp.Value });
+            }
+        }
+
+        private void EventSource_BuildFinished(object sender, BuildFinishedEventArgs e)
+        {
+            log.BuildSucceeded = e.Succeeded;
+        }
+
+        private void EventSource_TaskStarted(object sender, TaskStartedEventArgs e)
+        {
+            log.Tasks.Add(e.TaskName);
+        }
+
+        private void EventSource_TargetStarted(object sender, TargetStartedEventArgs e)
+        {
+            log.Targets.Add(e.TargetName);
+        }
+        private void EventSource_ErrorRaised(object sender, BuildErrorEventArgs e)
+        {
+            log.Errors.Add(e.Message);
+        }
+
+        private void EventSource_WarningRaised(object sender, BuildWarningEventArgs e)
+        {
+            log.Warnings.Add(e.Message);
+        }
+
+        public void Shutdown()
+        {
+            log.Save(fileName);
+        }
+    }
+}

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/SimpleXmlLogger.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/SimpleXmlLogger.cs
@@ -64,7 +64,12 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
             fileName = logFile;
 
             this.eventSource = eventSource;
+            RegisterEvents();
+            log = new BuildLog();
+        }
 
+        private void RegisterEvents()
+        {
             eventSource.BuildFinished += EventSource_BuildFinished;
             eventSource.BuildStarted += EventSource_BuildStarted;
 
@@ -73,15 +78,25 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
 
             eventSource.WarningRaised += EventSource_WarningRaised;
             eventSource.ErrorRaised += EventSource_ErrorRaised;
+        }
 
-            log = new BuildLog();
+        private void UnregisterEvents()
+        {
+            eventSource.BuildFinished -= EventSource_BuildFinished;
+            eventSource.BuildStarted -= EventSource_BuildStarted;
+
+            eventSource.TargetStarted -= EventSource_TargetStarted;
+            eventSource.TaskStarted += EventSource_TaskStarted;
+
+            eventSource.WarningRaised -= EventSource_WarningRaised;
+            eventSource.ErrorRaised -= EventSource_ErrorRaised;
         }
 
         private void EventSource_BuildStarted(object sender, BuildStartedEventArgs e)
         {
-            foreach(KeyValuePair<string, string> kvp in e.BuildEnvironment)
+            foreach (KeyValuePair<string, string> kvp in e.BuildEnvironment)
             {
-                log.BuildProperties.Add(new BuildProperty() { Name = kvp.Key, Value = kvp.Value });
+                log.BuildProperties.Add(new BuildProperty { Name = kvp.Key, Value = kvp.Value });
             }
         }
 
@@ -112,6 +127,8 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
         public void Shutdown()
         {
             log.Save(fileName);
+            UnregisterEvents();
+            eventSource = null;
         }
     }
 }

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/SonarScanner.MSBuild.Tasks.IntegrationTests.csproj
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/SonarScanner.MSBuild.Tasks.IntegrationTests.csproj
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '14.0' or '$(VisualStudioVersion)' == '10.0'">
@@ -105,11 +106,24 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Reference Include="FluentAssertions, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentAssertions.Core, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="..\..\AssemblyInfo.Shared.cs">
       <Link>Properties\AssemblyInfo.Shared.cs</Link>
     </Compile>
     <Compile Include="HackForVs2017Update3.cs" />
     <Compile Include="Infrastructure\BuildAssertions.cs" />
+    <Compile Include="MSBuildExecution\BuildLog.cs" />
+    <Compile Include="MSBuildExecution\BuildLogAssertions.cs" />
+    <Compile Include="MSBuildExecution\BuildRunner.cs" />
+    <Compile Include="MSBuildExecution\MSBuildLocator.cs" />
+    <Compile Include="MSBuildExecution\SimpleXmlLogger.cs" />
     <Compile Include="Infrastructure\BuildUtilities.cs" />
     <Compile Include="E2ETests\E2EAnalysisTests.cs" />
     <Compile Include="Infrastructure\BuildLogger.cs" />

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -461,17 +461,15 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
             AddAnalysisSetting("sonar.other.setting", "other value", projectRoot);
             projectRoot.Save();
 
-            var logger = new BuildLogger();
-
             // Act
-            var result = BuildUtilities.BuildTargets(projectRoot, logger, TargetConstants.DefaultBuildTarget);
+            var result = BuildRunner.BuildTargets(TestContext, projectRoot.FullPath, TargetConstants.DefaultBuildTarget);
 
             // Assert
             // Checks that should succeed irrespective of the MSBuild version
-            BuildAssertions.AssertTargetSucceeded(result, TargetConstants.DefaultBuildTarget);
-            logger.AssertTargetExecuted(TargetConstants.OverrideRoslynAnalysisTarget);
+            result.AssertTargetSucceeded(TargetConstants.DefaultBuildTarget);
+            result.AssertTargetExecuted(TargetConstants.OverrideRoslynAnalysisTarget);
 
-            logger.AssertExpectedTargetOrdering(
+            result.AssertExpectedTargetOrdering(
                 TargetConstants.ResolveCodeAnalysisRuleSet,
                 TargetConstants.CategoriseProjectTarget,
                 TargetConstants.OverrideRoslynAnalysisTarget,

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
@@ -605,8 +605,6 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
             var rootInputFolder = TestUtils.CreateTestSpecificFolder(TestContext, "Inputs");
             var rootOutputFolder = TestUtils.CreateTestSpecificFolder(TestContext, "Outputs");
 
-            var logger = new BuildLogger();
-
             var sqTargetFile = TestUtils.EnsureAnalysisTargetsExists(TestContext);
             var projectFilePath = Path.Combine(rootInputFolder, "project.txt");
             var projectGuid = Guid.NewGuid();
@@ -632,11 +630,11 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
                 sqTargetFile);
 
             // Act
-            var result = BuildUtilities.BuildTargets(projectRoot, logger,
+            var result = BuildRunner.BuildTargets(TestContext, projectRoot.FullPath,
                 TargetConstants.WriteProjectDataTarget);
 
             // Assert
-            BuildAssertions.AssertTargetSucceeded(result, TargetConstants.WriteProjectDataTarget);
+            result.AssertTargetSucceeded(TargetConstants.WriteProjectDataTarget);
 
             var projectInfo = ProjectInfoAssertions.AssertProjectInfoExists(rootOutputFolder, projectRoot.FullPath);
 
@@ -655,8 +653,6 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
             // Arrange
             var rootInputFolder = TestUtils.CreateTestSpecificFolder(TestContext, "Inputs");
             var rootOutputFolder = TestUtils.CreateTestSpecificFolder(TestContext, "Outputs");
-
-            var logger = new BuildLogger();
 
             var sqTargetFile = TestUtils.EnsureAnalysisTargetsExists(TestContext);
             var projectFilePath = Path.Combine(rootInputFolder, "unrecognisedLanguage.proj.txt");
@@ -682,11 +678,11 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
                 sqTargetFile);
 
             // Act
-            var result = BuildUtilities.BuildTargets(projectRoot, logger,
+            var result = BuildRunner.BuildTargets(TestContext, projectRoot.FullPath,
                 TargetConstants.WriteProjectDataTarget);
 
             // Assert
-            BuildAssertions.AssertTargetSucceeded(result, TargetConstants.WriteProjectDataTarget);
+            result.AssertTargetSucceeded(TargetConstants.WriteProjectDataTarget);
 
             var projectInfo = ProjectInfoAssertions.AssertProjectInfoExists(rootOutputFolder, projectRoot.FullPath);
 
@@ -744,10 +740,8 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
         private ProjectInfo ExecuteWriteProjectInfo(ProjectRootElement projectRoot, string rootOutputFolder, bool noWarningOrErrors = true)
         {
             projectRoot.Save();
-            var logger = new BuildLogger();
-
             // Act
-            var result = BuildUtilities.BuildTargets(projectRoot, logger,
+            var result = BuildRunner.BuildTargets(TestContext, projectRoot.FullPath,
                 // The "write" target depends on a couple of other targets having executed first to set properties appropriately
                 TargetConstants.CategoriseProjectTarget,
                 TargetConstants.CalculateFilesToAnalyzeTarget,
@@ -755,15 +749,15 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
                 TargetConstants.WriteProjectDataTarget);
 
             // Assert
-            BuildAssertions.AssertTargetSucceeded(result, TargetConstants.CalculateFilesToAnalyzeTarget);
-            BuildAssertions.AssertTargetSucceeded(result, TargetConstants.CreateProjectSpecificDirs);
-            BuildAssertions.AssertTargetSucceeded(result, TargetConstants.WriteProjectDataTarget);
+            result.AssertTargetSucceeded(TargetConstants.CalculateFilesToAnalyzeTarget);
+            result.AssertTargetSucceeded(TargetConstants.CreateProjectSpecificDirs);
+            result.AssertTargetSucceeded(TargetConstants.WriteProjectDataTarget);
 
-            logger.AssertTargetExecuted(TargetConstants.WriteProjectDataTarget);
+            result.AssertTargetExecuted(TargetConstants.WriteProjectDataTarget);
 
             if (noWarningOrErrors)
             {
-                logger.AssertNoWarningsOrErrors();
+                result.AssertNoWarningsOrErrors();
             }
 
             // Check expected project outputs

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/packages.config
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/packages.config
@@ -19,4 +19,5 @@
   <package id="System.Threading" version="4.0.11" targetFramework="net46" />
   <package id="System.Threading.Tasks.Parallel" version="4.0.1" targetFramework="net46" />
   <package id="System.Threading.Thread" version="4.0.0" targetFramework="net46" />
+  <package id="FluentAssertions" version="4.19.0" targetFramework="net461" />
 </packages>

--- a/tests/SonarScanner.MSBuild.Tasks.Integrationtests/MSBuildExecution/BuildLog.cs
+++ b/tests/SonarScanner.MSBuild.Tasks.Integrationtests/MSBuildExecution/BuildLog.cs
@@ -1,0 +1,131 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace SonarScanner.MSBuild.Tasks.IntegrationTests
+{
+    /// <summary>
+    /// XML-serializable data class used to record which targets and tasks
+    /// were executed during the build
+    /// </summary>
+    public class BuildLog
+    {
+        public BuildLog()
+        {
+            Targets = new List<string>();
+            Tasks = new List<string>();
+            Warnings = new List<string>();
+            Errors = new List<string>();
+            BuildProperties = new List<BuildProperty>();
+        }
+
+        public List<BuildProperty> BuildProperties { get; set; }
+
+        public List<string> Targets { get; set; }
+
+        public List<string> Tasks { get; set; }
+
+        public List<string> Warnings { get; set; }
+
+        public List<string> Errors { get; set; }
+
+        public bool BuildSucceeded { get; set; }
+
+        public string GetPropertyValue(string propertyName)
+        {
+            TryGetPropertyValue(propertyName, out var propertyValue);
+            return propertyValue;
+        }
+
+        public bool TryGetPropertyValue(string propertyName, out string value)
+        {
+            var property = BuildProperties.FirstOrDefault(
+                p => p.Name.Equals(propertyName, System.StringComparison.OrdinalIgnoreCase));
+
+            if (property == null)
+            {
+                value = null;
+                return false;
+            }
+
+            value = property.Value;
+            return true;
+        }
+
+        [XmlIgnore]
+        public string FilePath { get; private set; }
+
+        public void Save(string filePath)
+        {
+            SerializeObjectToFile(filePath, this);
+            FilePath = filePath;
+        }
+
+        public static BuildLog Load(string filePath)
+        {
+            BuildLog log = null;
+
+            using (var streamReader = new StreamReader(filePath))
+            using (var reader = XmlReader.Create(streamReader))
+            {
+                var serializer = new XmlSerializer(typeof(BuildLog));
+                log = (BuildLog)serializer.Deserialize(reader);
+            }
+            log.FilePath = filePath;
+
+            return log;
+        }
+
+        private static void SerializeObjectToFile(string filePath, object objectToSerialize)
+        {
+            var settings = new XmlWriterSettings
+            {
+                Indent = true,
+                Encoding = Encoding.UTF8,
+                IndentChars = "  "
+            };
+
+            using (var stream = new MemoryStream())
+            using (var writer = XmlWriter.Create(stream, settings))
+            {
+                var serializer = new XmlSerializer(objectToSerialize.GetType());
+                serializer.Serialize(writer, objectToSerialize, new XmlSerializerNamespaces(new[] { XmlQualifiedName.Empty }));
+                var xml = Encoding.UTF8.GetString(stream.ToArray());
+                File.WriteAllText(filePath, xml);
+            }
+        }
+    }
+
+    public class BuildProperty
+    {
+        [XmlAttribute]
+        public string Name { get; set; }
+
+        [XmlAttribute]
+        public string Value { get; set; }
+    }
+
+}

--- a/tests/SonarScanner.MSBuild.Tasks.Integrationtests/MSBuildExecution/BuildLog.cs
+++ b/tests/SonarScanner.MSBuild.Tasks.Integrationtests/MSBuildExecution/BuildLog.cs
@@ -33,24 +33,15 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
     /// </summary>
     public class BuildLog
     {
-        public BuildLog()
-        {
-            Targets = new List<string>();
-            Tasks = new List<string>();
-            Warnings = new List<string>();
-            Errors = new List<string>();
-            BuildProperties = new List<BuildProperty>();
-        }
+        public List<BuildProperty> BuildProperties { get; set; } = new List<BuildProperty>();
 
-        public List<BuildProperty> BuildProperties { get; set; }
+        public List<string> Targets { get; set; } = new List<string>();
 
-        public List<string> Targets { get; set; }
+        public List<string> Tasks { get; set; } = new List<string>();
 
-        public List<string> Tasks { get; set; }
+        public List<string> Warnings { get; set; } = new List<string>();
 
-        public List<string> Warnings { get; set; }
-
-        public List<string> Errors { get; set; }
+        public List<string> Errors { get; set; } = new List<string>();
 
         public bool BuildSucceeded { get; set; }
 


### PR DESCRIPTION
Previously the tests hosted the build engine in-memory. However, the tests have been broken several times as new VS updates are released, so this commit changes the tests to execute the build by shelling out to the msbuild.exe process.

When the build engine was hosted in-memory it was easy to check the outcome of the build (e.g. expected targets executed in a particular order). It's more complicated when the build is run out of process: we supply a custom logger that is used during the build that records the task/target execution in an XML file. The tests can then re-load the XML log file and assert against that.

TODO: so far I have only changed the tests that were failing locally. If the tests pass on CIX with this change then I'll modify the remaining tests.