### PR TITLE
Changed RoslynTargetsTests to use msbuild.exe

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildAssertions.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildAssertions.cs
@@ -18,9 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.Build.Execution;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -29,36 +26,6 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
     public static class BuildAssertions
     {
         #region Assertions
-
-        /// <summary>
-        /// Checks that building the specified target succeeded.
-        /// </summary>
-        public static void AssertTargetSucceeded(BuildResult result, string target)
-        {
-            AssertExpectedTargetOutput(result, target, BuildResultCode.Success);
-        }
-
-        /// <summary>
-        /// Checks that building the specified target failed.
-        /// </summary>
-        public static void AssertTargetFailed(BuildResult result, string target)
-        {
-            AssertExpectedTargetOutput(result, target, BuildResultCode.Failure);
-        }
-
-        /// <summary>
-        /// Checks that building the specified target produced the expected result.
-        /// </summary>
-        public static void AssertExpectedTargetOutput(BuildResult result, string target, BuildResultCode resultCode)
-        {
-            DumpTargetResult(result, target);
-
-            if (!result.ResultsByTarget.TryGetValue(target, out TargetResult targetResult))
-            {
-                Assert.Inconclusive(@"Could not find result for target ""{0}""", target);
-            }
-            Assert.AreEqual<BuildResultCode>(resultCode, result.OverallResult, "Unexpected build result");
-        }
 
         public static void AssertExpectedPropertyValue(ProjectInstance projectInstance, string propertyName, string expectedValue)
         {
@@ -82,139 +49,6 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
             Assert.IsNull(propertyInstance, "Not expecting the property to exist. Property: {0}, Value: {1}", propertyName, value);
         }
 
-        /// <summary>
-        /// Checks whether there is a single "SonarQubeSetting" item with the expected name and setting value
-        /// </summary>
-        public static void AssertExpectedAnalysisSetting(BuildResult actualResult, string settingName, string expectedValue)
-        {
-            /* The equivalent XML would look like this:
-            <ItemGroup>
-              <SonarQubeSetting Include="settingName">
-                <Value>expectedValue</Value
-              </SonarQubeSetting>
-            </ItemGroup>
-            */
-
-            Assert.IsNotNull(actualResult.ProjectStateAfterBuild, "Test error: ProjectStateAfterBuild should not be null");
-
-            var matches = actualResult.ProjectStateAfterBuild.GetItemsByItemTypeAndEvaluatedInclude(BuildTaskConstants.SettingItemName, settingName);
-
-            Assert.AreNotEqual(0, matches.Count(), "Expected SonarQubeSetting with include value of '{0}' does not exist", settingName);
-            Assert.AreEqual(1, matches.Count(), "Only expecting one SonarQubeSetting with include value of '{0}' to exist", settingName);
-
-            var item = matches.Single();
-            var value = item.GetMetadataValue(BuildTaskConstants.SettingValueMetadataName);
-
-            Assert.AreEqual(expectedValue, value, "SonarQubeSetting with include value '{0}' does not have the expected value", settingName);
-        }
-
-        /// <summary>
-        /// Checks that a SonarQubeSetting does not exist
-        /// </summary>
-        public static void AssertAnalysisSettingDoesNotExist(BuildResult actualResult, string settingName)
-        {
-            Assert.IsNotNull(actualResult.ProjectStateAfterBuild, "Test error: ProjectStateAfterBuild should not be null");
-
-            var matches = actualResult.ProjectStateAfterBuild.GetItemsByItemTypeAndEvaluatedInclude(BuildTaskConstants.SettingItemName, settingName);
-
-            Assert.AreEqual(0, matches.Count(), "Not expected SonarQubeSetting with include value of '{0}' to exist. Actual occurrences: {1}", settingName, matches.Count());
-        }
-
-        /// <summary>
-        /// Checks that a single ItemGroup item with the specified value exists
-        /// </summary>
-        public static void AssertSingleItemExists(BuildResult actualResult, string itemType, string expectedValue)
-        {
-            /* The equivalent XML would look like this:
-            <ItemGroup>
-              <itemType Include="expectedValue">
-              </itemType>
-            </ItemGroup>
-            */
-
-            Assert.IsNotNull(actualResult.ProjectStateAfterBuild, "Test error: ProjectStateAfterBuild should not be null");
-
-            var matches = actualResult.ProjectStateAfterBuild.GetItemsByItemTypeAndEvaluatedInclude(itemType, expectedValue);
-
-            Assert.AreEqual(1, matches.Count(), "Expecting one item of type '{0}' with value '{1}' to exist", itemType, expectedValue);
-        }
-
-        /// <summary>
-        /// Checks that an ItemGroup item does not exit
-        /// </summary>
-        public static void AssertItemDoesNotExist(BuildResult actualResult, string itemType, string itemValue)
-        {
-            /* The equivalent XML would look like this:
-            <ItemGroup>
-              <itemType Include="expectedValue">
-              </itemType>
-            </ItemGroup>
-            */
-
-            Assert.IsNotNull(actualResult.ProjectStateAfterBuild, "Test error: ProjectStateAfterBuild should not be null");
-
-            var matches = actualResult.ProjectStateAfterBuild.GetItemsByItemTypeAndEvaluatedInclude(itemType, itemValue);
-
-            Assert.AreEqual(0, matches.Where(i => itemValue.Equals(i.EvaluatedInclude)),
-                "Not expecting any '{0}' items with value '{1}' to exist", itemType, itemValue);
-        }
-
-        /// <summary>
-        /// Checks that the expected number of ItemType entries exist
-        /// </summary>
-        public static void AssertExpectedItemGroupCount(BuildResult actualResult, string itemType, int expectedCount)
-        {
-            Assert.IsNotNull(actualResult.ProjectStateAfterBuild, "Test error: ProjectStateAfterBuild should not be null");
-
-            IEnumerable<ProjectItemInstance> matches = actualResult.ProjectStateAfterBuild.GetItems(itemType);
-
-            BuildUtilities.LogMessage("<{0}> item values:", itemType);
-            foreach(var item in matches)
-            {
-                BuildUtilities.LogMessage("\t{0}", item.EvaluatedInclude);
-            }
-
-            Assert.AreEqual(expectedCount, matches.Count(), "Unexpected number of '{0}' items", itemType);
-        }
-
-        /// <summary>
-        /// Checks that no analysis warnings will be treated as errors nor will they be ignored
-        /// </summary>
-        public static void AssertWarningsAreNotTreatedAsErrorsNorIgnored(BuildResult actualResult)
-        {
-            AssertExpectedPropertyValue(actualResult.ProjectStateAfterBuild, TargetProperties.TreatWarningsAsErrors, "false");
-            AssertExpectedPropertyValue(actualResult.ProjectStateAfterBuild, TargetProperties.WarningsAsErrors, "");
-            AssertExpectedPropertyValue(actualResult.ProjectStateAfterBuild, TargetProperties.WarningLevel, "4");
-        }
-
         #endregion Assertions
-
-        #region Private methods
-
-        /// <summary>
-        /// Writes the build and target output to the output stream
-        /// </summary>
-        public static void DumpTargetResult(BuildResult result, string target)
-        {
-            if (result == null)
-            {
-                throw new ArgumentNullException(nameof(result));
-            }
-
-            BuildUtilities.LogMessage("Overall build result: {0}", result.OverallResult.ToString());
-
-            if (!result.ResultsByTarget.TryGetValue(target, out TargetResult targetResult))
-            {
-                BuildUtilities.LogMessage(@"Could not find result for target ""{0}""", target);
-            }
-            else
-            {
-                BuildUtilities.LogMessage(@"Results for target ""{0}""", target);
-                BuildUtilities.LogMessage("\tTarget exception: {0}", targetResult.Exception == null ? "{null}" : targetResult.Exception.Message);
-                BuildUtilities.LogMessage("\tTarget result: {0}", targetResult.ResultCode.ToString());
-            }
-        }
-
-        #endregion Private methods
     }
 }

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildLogAssertions.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildLogAssertions.cs
@@ -19,6 +19,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -133,6 +134,44 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
         public static void AssertExpectedWarningCount(this BuildLog log, int expected)
         {
             log.Warnings.Count.Should().Be(expected);
+        }
+
+        public static string GetCapturedPropertyValue(this BuildLog log, string propertyName)
+        {
+            var capturedData = log.CapturedProperties.SingleOrDefault(
+                p => p.Name.Equals(propertyName, System.StringComparison.OrdinalIgnoreCase));
+
+            capturedData.Should().NotBeNull($"Test logger error: failed to find captured property '{propertyName}'");
+
+            return capturedData.Value;
+        }
+
+        public static void AssertExpectedCapturedPropertyValue(this BuildLog log, string propertyName, string expectedValue)
+        {
+            var capturedValue = GetCapturedPropertyValue(log, propertyName);
+            capturedValue.Should().Be(expectedValue, "Captured property '{0}' does not have the expected value", propertyName);
+        }
+
+        public static IList<BuildItem> GetCapturedItemValues(this BuildLog log, string itemName)
+        {
+            return log.CapturedItemValues.Where(
+                p => p.Name.Equals(itemName, System.StringComparison.OrdinalIgnoreCase)).ToList();
+        }
+
+        public static void AssertSingleItemExists(this BuildLog log, string itemName, string expectedValue)
+        {
+            var capturedData = log.CapturedItemValues.SingleOrDefault(
+                p => p.Name.Equals(itemName, System.StringComparison.OrdinalIgnoreCase) &&
+                        p.Value.Equals(expectedValue, System.StringComparison.Ordinal));
+
+            capturedData.Should().NotBeNull($"Test logger error: failed to expected captured item value. " 
+                + $"Item name: '{itemName}', expected value: {expectedValue}");
+        }
+
+        public static void AssertExpectedItemGroupCount(this BuildLog log, string itemName, int expectedCount)
+        {
+            log.CapturedItemValues.Count(p => p.Name.Equals(itemName, System.StringComparison.OrdinalIgnoreCase))
+                .Should().Be(expectedCount);
         }
     }
 }

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildLogAssertions.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildLogAssertions.cs
@@ -152,7 +152,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
             capturedValue.Should().Be(expectedValue, "Captured property '{0}' does not have the expected value", propertyName);
         }
 
-        public static IList<BuildItem> GetCapturedItemValues(this BuildLog log, string itemName)
+        public static IEnumerable<BuildItem> GetCapturedItemValues(this BuildLog log, string itemName)
         {
             return log.CapturedItemValues.Where(
                 p => p.Name.Equals(itemName, System.StringComparison.OrdinalIgnoreCase)).ToList();
@@ -164,7 +164,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
                 p => p.Name.Equals(itemName, System.StringComparison.OrdinalIgnoreCase) &&
                         p.Value.Equals(expectedValue, System.StringComparison.Ordinal));
 
-            capturedData.Should().NotBeNull($"Test logger error: failed to expected captured item value. " 
+            capturedData.Should().NotBeNull("Test logger error: failed to expected captured item value. " 
                 + $"Item name: '{itemName}', expected value: {expectedValue}");
         }
 

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildRunner.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildRunner.cs
@@ -47,6 +47,9 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
             var exePath = MSBuildLocator.GetMSBuildPath(msBuildVersion, testContext);
             exePath.Should().NotBeNull($"Test setup failure - failed to locate MSBuild.exe for version {msBuildVersion}");
             File.Exists(exePath).Should().BeTrue($"expecting the returned msbuild.exe file to exist. File path: {exePath}");
+            Path.GetFileName(exePath).Should().Be("msbuild.exe");
+            Path.GetDirectoryName(exePath).Split(new char[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar })
+                .Should().Contain(msBuildVersion);
 
             // The build is being run in a separate process so we can't directly
             // capture the property values or which tasks/targets were executed.

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/SimpleXmlLogger.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/SimpleXmlLogger.cs
@@ -149,6 +149,12 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
 
             var propertyData = msg.Split(new string[] { CapturedDataSeparator }, System.StringSplitOptions.None);
 
+            if (propertyData.Length < 3)
+            {
+                log.Errors.Add($"Test logger error: unexpected value for captured property data message: {e.Message}. Expecting at least a three part message: CAPTURE{CapturedDataSeparator}[PROPERTY or ITEM]{CapturedDataSeparator}...");
+                return;
+            }
+
             switch (propertyData[1])
             {
                 case "PROPERTY":

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/SimpleXmlLogger.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/SimpleXmlLogger.cs
@@ -100,7 +100,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
         {
             foreach (KeyValuePair<string, string> kvp in e.BuildEnvironment)
             {
-                log.BuildProperties.Add(new BuildProperty { Name = kvp.Key, Value = kvp.Value });
+                log.BuildProperties.Add(new BuildKeyValue { Name = kvp.Key, Value = kvp.Value });
             }
         }
 

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -571,7 +571,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
         {
             var matches = actualResult.GetCapturedItemValues(BuildTaskConstants.SettingItemName);
 
-            Assert.AreEqual(0, matches.Count(), "Not expected SonarQubeSetting with include value of '{0}' to exist. Actual occurrences: {1}", settingName, matches.Count());
+            matches.Count().Should().Be(0, "Not expected SonarQubeSetting with include value of '{0}' to exist. Actual occurrences: {1}", settingName, matches.Count());
         }
 
         /// <summary>
@@ -587,13 +587,13 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
             </ItemGroup>
             */
 
-            var matches = actualResult.GetCapturedItemValues(BuildTaskConstants.SettingItemName)
-                .Where(v => v.Value.Equals(settingName, System.StringComparison.Ordinal));
+            var settings = actualResult.GetCapturedItemValues(BuildTaskConstants.SettingItemName);
+            settings.Any().Should().BeTrue();
 
-            matches.Count().Should().NotBe(0, "Expected SonarQubeSetting with include value of '{0}' does not exist", settingName);
-            matches.Count().Should().Be(1, "Only expecting one SonarQubeSetting with include value of '{0}' to exist", settingName);
+            var matches = settings.Where(v => v.Value.Equals(settingName, System.StringComparison.Ordinal)).ToList();
+            matches.Count.Should().Be(1, $"Only one and only expecting one SonarQubeSetting with include value of '{0}' to exist. Count: {matches.Count}", settingName);
 
-            var item = matches.Single();
+            var item = matches[0];
             var value = item.Metadata.SingleOrDefault(v => v.Name.Equals(BuildTaskConstants.SettingValueMetadataName));
 
             value.Should().NotBeNull();

--- a/tests/SonarScanner.MSBuild.Tasks.Integrationtests/MSBuildExecution/BuildLog.cs
+++ b/tests/SonarScanner.MSBuild.Tasks.Integrationtests/MSBuildExecution/BuildLog.cs
@@ -33,7 +33,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
     /// </summary>
     public class BuildLog
     {
-        public List<BuildProperty> BuildProperties { get; set; } = new List<BuildProperty>();
+        public List<BuildKeyValue> BuildProperties { get; set; } = new List<BuildKeyValue>();
 
         public List<BuildKeyValue> CapturedProperties { get; set; } = new List<BuildKeyValue>();
 

--- a/tests/SonarScanner.MSBuild.Tasks.Integrationtests/MSBuildExecution/BuildLog.cs
+++ b/tests/SonarScanner.MSBuild.Tasks.Integrationtests/MSBuildExecution/BuildLog.cs
@@ -35,6 +35,10 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
     {
         public List<BuildProperty> BuildProperties { get; set; } = new List<BuildProperty>();
 
+        public List<BuildKeyValue> CapturedProperties { get; set; } = new List<BuildKeyValue>();
+
+        public List<BuildItem> CapturedItemValues { get; set; } = new List<BuildItem>();
+
         public List<string> Targets { get; set; } = new List<string>();
 
         public List<string> Tasks { get; set; } = new List<string>();
@@ -110,7 +114,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
         }
     }
 
-    public class BuildProperty
+    public class BuildKeyValue
     {
         [XmlAttribute]
         public string Name { get; set; }
@@ -119,4 +123,14 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
         public string Value { get; set; }
     }
 
+    public class BuildItem
+    {
+        [XmlAttribute]
+        public string Name { get; set; }
+
+        [XmlAttribute]
+        public string Value { get; set; }
+
+        public List<BuildKeyValue> Metadata { get; set; }
+    }
 }


### PR DESCRIPTION
Removed redundant methods from _BuildUtilities_ and _BuildAssertions_.

All of the integration tests that run builds now use _msbuild.exe_ rather than executing the build engine in-memory.

There are still some tests in _ImportBeforeTargetsTests_ and _SonarIntegrationTargetsTests_ use the MSBuild API to evaluation properties (i.e. checking that MSBuild is processing conditional properties as expected). 