### PR TITLE
Fixed tests affected by VSTS task environment variable

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/AnalysisConfigGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/AnalysisConfigGeneratorTests.cs
@@ -365,12 +365,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             TestContext.AddResultFile(config.FileName);
         }
 
-        private static void AssertSettingDoesNotExist(string key, AnalysisConfig actualConfig)
-        {
-            var found = actualConfig.GetAnalysisSettings(true).TryGetProperty(key, out Property setting);
-            found.Should().BeFalse("The setting should not exist. Key: {0}", key);
-        }
-
         private static void AssertExpectedServerSetting(string key, string expectedValue, AnalysisConfig actualConfig)
         {
             var found = Property.TryGetProperty(key, actualConfig.ServerSettings, out Property property);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/PreprocessTestUtils.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/PreprocessTestUtils.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.TFS;
 using TestUtilities;
 
@@ -39,6 +40,9 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
             scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildUri_Legacy, null);
             scope.SetVariable(TeamBuildSettings.EnvironmentVariables.BuildUri_TFS2015, null);
+
+            // The Sonar VSTS tasks set and use this environment variable
+            scope.SetVariable(EnvScannerPropertiesProvider.ENV_VAR_KEY, null);
 
             return scope;
         }

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/EnvScannerPropertiesProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/EnvScannerPropertiesProvider.cs
@@ -30,7 +30,7 @@ namespace SonarScanner.MSBuild.Common
     /// </summary>
     public class EnvScannerPropertiesProvider : IAnalysisPropertyProvider
     {
-        private const string ENV_VAR_KEY = "SONARQUBE_SCANNER_PARAMS";
+        public const string ENV_VAR_KEY = "SONARQUBE_SCANNER_PARAMS";
         private readonly IEnumerable<Property> properties;
 
         public static bool TryCreateProvider(ILogger logger, out IAnalysisPropertyProvider provider)

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/EnvScannerPropertiesProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/EnvScannerPropertiesProvider.cs
@@ -30,7 +30,7 @@ namespace SonarScanner.MSBuild.Common
     /// </summary>
     public class EnvScannerPropertiesProvider : IAnalysisPropertyProvider
     {
-        public const string ENV_VAR_KEY = "SONARQUBE_SCANNER_PARAMS";
+        public static readonly string ENV_VAR_KEY = "SONARQUBE_SCANNER_PARAMS";
         private readonly IEnumerable<Property> properties;
 
         public static bool TryCreateProvider(ILogger logger, out IAnalysisPropertyProvider provider)


### PR DESCRIPTION
The Sonar VSTS tasks set the SONARQUBE_SCANNER_PARAMS environment variable, which caused some of the tests to behave differently or fail.
The affected tests have been modified so that they are not affected by, and do not in turn affect, the VSTS build environment.