### PR TITLE
Fix test file locking issue

### DIFF
--- a/Tests/TestUtilities/SQPropertiesFileReader.cs
+++ b/Tests/TestUtilities/SQPropertiesFileReader.cs
@@ -86,7 +86,10 @@ namespace TestUtilities
             Debug.Assert(!string.IsNullOrWhiteSpace(fullPath), "fullPath should be specified");
 
             properties = new JavaProperties();
-            properties.Load(File.Open(fullPath, FileMode.Open));
+            using (var stream = File.Open(fullPath, FileMode.Open))
+            {
+                properties.Load(stream);
+            }
         }
 
         #endregion FilePropertiesProvider


### PR DESCRIPTION
Fixes the remaining VSTS test failures.
Seven of the tests were using this class to check the contents of the setting file, then calling _testContext.AddResultFile(...)_. The call to _AddResultFile_ was failing because this class was still holding a lock on the file.