### PR TITLE
Update ITs to match latest release of SonarC# results

### DIFF
--- a/its/projects/ConsoleMultiLanguage/ConsoleCSharp/ConsoleCSharp.csproj
+++ b/its/projects/ConsoleMultiLanguage/ConsoleCSharp/ConsoleCSharp.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{836183AA-5841-4A0E-ADC0-E337EEC543AB}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ConsoleCSharp</RootNamespace>
     <AssemblyName>ConsoleCSharp</AssemblyName>

--- a/its/projects/ExcludedTest/Excluded/Excluded.csproj
+++ b/its/projects/ExcludedTest/Excluded/Excluded.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{CE9F44AE-DFA1-49A5-9BD8-A7CA848E2939}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
 	<SonarQubeExclude>true</SonarQubeExclude>
     <RootNamespace>Excluded</RootNamespace>

--- a/its/projects/ExcludedTest/Normal/Normal.csproj
+++ b/its/projects/ExcludedTest/Normal/Normal.csproj
@@ -5,7 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{B93B287C-47DB-4406-9EAB-653BCF7D20DC}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Normal</RootNamespace>
     <AssemblyName>Normal</AssemblyName>

--- a/its/projects/ProjectUnderTest/ProjectUnderTest/CSProj1.csproj
+++ b/its/projects/ProjectUnderTest/ProjectUnderTest/CSProj1.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{1049030E-AC7A-49D0-BEDC-F414C5C7DDD8}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ProjectUnderTest</RootNamespace>
-    <AssemblyName>ProjectUnderTest</AssemblyName>
+    <RootNamespace>CSProj1</RootNamespace>
+    <AssemblyName>CSProj1</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SonarQubeExclude Condition=" '$(ExcludeProjectsFromAnalysis)' == 'true' ">true</SonarQubeExclude>

--- a/its/projects/ProjectUnderTest/ProjectUnderTest/Foo.cs
+++ b/its/projects/ProjectUnderTest/ProjectUnderTest/Foo.cs
@@ -20,7 +20,7 @@
 
 using System;
 
-namespace ProjectUnderTest
+namespace CSProj1
 {
     /* FxCop violations: 
     *

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -147,9 +147,7 @@ public class ScannerMSBuildTest {
 
     List<Issue> issues = ORCHESTRATOR.getServer().wsClient().issueClient().find(IssueQuery.create()).list();
     assertThat(issues).hasSize(2);
-    assertThat(getMeasureAsInteger(FILE_KEY, "ncloc")).isEqualTo(23);
-    assertThat(getMeasureAsInteger(PROJECT_KEY, "ncloc")).isEqualTo(37);
-    assertThat(getMeasureAsInteger(FILE_KEY, "lines")).isEqualTo(58);
+    assertLineCountForProjectUnderTest();
   }
 
   @Test
@@ -183,9 +181,7 @@ public class ScannerMSBuildTest {
 
     List<Issue> issues = ORCHESTRATOR.getServer().wsClient().issueClient().find(IssueQuery.create()).list();
     assertThat(issues).hasSize(2);
-    assertThat(getMeasureAsInteger(FILE_KEY, "ncloc")).isEqualTo(23);
-    assertThat(getMeasureAsInteger(PROJECT_KEY, "ncloc")).isEqualTo(37);
-    assertThat(getMeasureAsInteger(FILE_KEY, "lines")).isEqualTo(58);
+    assertLineCountForProjectUnderTest();
 
     assertThat(seenByProxy).isNotEmpty();
   }
@@ -222,9 +218,14 @@ public class ScannerMSBuildTest {
 
     List<Issue> issues = ORCHESTRATOR.getServer().wsClient().issueClient().find(IssueQuery.create()).list();
     assertThat(issues).hasSize(2);
+    assertLineCountForProjectUnderTest();
+  }
+
+  private void assertLineCountForProjectUnderTest()
+  {
     assertThat(getMeasureAsInteger(FILE_KEY, "ncloc")).isEqualTo(23);
     assertThat(getMeasureAsInteger(PROJECT_KEY, "ncloc")).isEqualTo(37);
-    assertThat(getMeasureAsInteger(FILE_KEY, "lines")).isEqualTo(58);
+    assertThat(getMeasureAsInteger(FILE_KEY, "lines")).isEqualTo(71);
   }
 
   @Test


### PR DESCRIPTION
So the QA is now failing because of some change of behaviors on the latest SonarC# (used by the scanner for msbuild ITs).