### PR TITLE
Build fail with scanner for msbuild when OutputPath property of WPF project contains $(MSBuildProjectName)

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
@@ -324,6 +324,52 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
 
         #endregion Fakes projects tests
 
+        #region Temp projects tests
+
+        [TestMethod]
+        public void WriteProjectInfo_WpfTmpCase1_ProjectIsExcluded()
+        {
+            // Checks that .tmp_proj projects are excluded from analysis
+            WriteProjectInfo_WpfTmpCase_ProjectIsExcluded("f.tmp_proj");
+        }
+
+        [TestMethod]
+        public void WriteProjectInfo_WpfTmpCase2_ProjectIsExcluded()
+        {
+            // Checks that _wpftmp.csproj projects are excluded from analysis
+            WriteProjectInfo_WpfTmpCase_ProjectIsExcluded("f_wpftmp.csproj");
+        }
+
+        [TestMethod]
+        public void WriteProjectInfo_WpfTmpCase3_ProjectIsExcluded()
+        {
+            // Checks that _wpftmp.vbproj projects are excluded from analysis
+            WriteProjectInfo_WpfTmpCase_ProjectIsExcluded("f_wpftmp.vbproj");
+        }
+
+        private void WriteProjectInfo_WpfTmpCase_ProjectIsExcluded(string projectName)
+        {
+            // Arrange
+            var rootInputFolder = TestUtils.CreateTestSpecificFolder(TestContext, "Inputs");
+            var rootOutputFolder = TestUtils.CreateTestSpecificFolder(TestContext, "Outputs");
+
+            EnsureAnalysisConfig(rootInputFolder, "pattern that won't match anything");
+
+            var preImportProperties = CreateDefaultAnalysisProperties(rootInputFolder, rootOutputFolder);
+            preImportProperties.AssemblyName = "f";
+
+            var descriptor = BuildUtilities.CreateValidProjectDescriptor(rootInputFolder, projectName);
+
+            // Act
+            var projectInfo = ExecuteWriteProjectInfo(descriptor, preImportProperties, rootOutputFolder);
+
+            // Assert
+            AssertProjectIsExcluded(projectInfo);
+            AssertIsNotTestProject(projectInfo);
+        }
+
+        #endregion Temp projects tests
+
         #region File list tests
 
         [TestMethod]
@@ -889,6 +935,11 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
         private static void AssertIsTestProject(ProjectInfo projectInfo)
         {
             projectInfo.ProjectType.Should().Be(ProjectType.Test, "Should be a test project");
+        }
+
+        private static void AssertIsNotTestProject(ProjectInfo projectInfo)
+        {
+            projectInfo.ProjectType.Should().NotBe(ProjectType.Test, "Should not be a test project");
         }
 
         private static void AssertProjectIsExcluded(ProjectInfo projectInfo)

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -172,6 +172,24 @@
       <SonarQubeExclude>true</SonarQubeExclude>
     </PropertyGroup>
 
+    <!-- Temporary project detection -->
+    <!-- Some kinds of project have logic to trigger additional special builds based on
+         the same project file e.g. WPF projects build a temporary assembly before
+         the main compilation takes place.
+         We only want to analyze the "normal" build of the project, so we should turn off analysis
+         for the known cases. -->
+
+    <PropertyGroup>
+      <!-- Special case 1: WPF projects call the task Windows.GenerateTemporaryTargetAssembly in PresentationBuildTasks. -->
+      <IsTempProject Condition="$(MSBuildProjectFile.EndsWith('.tmp_proj', System.StringComparison.OrdinalIgnoreCase))">true</IsTempProject>
+      <IsTempProject Condition="$(MSBuildProjectFile.EndsWith('_wpftmp.csproj', System.StringComparison.OrdinalIgnoreCase))">true</IsTempProject>
+      <IsTempProject Condition="$(MSBuildProjectFile.EndsWith('_wpftmp.vbproj', System.StringComparison.OrdinalIgnoreCase))">true</IsTempProject>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="$(IsTempProject) == 'true' AND $(SonarQubeExclude)==''" >
+      <SonarQubeExclude>true</SonarQubeExclude>
+    </PropertyGroup>
+
     <PropertyGroup Condition=" $(SonarQubeTestProject) == '' ">
       <!-- The MS Test project type guid-->
       <SonarQubeMsTestProjectTypeGuid>3AC096D0-A1C2-E12C-1390-A8335801FDAB</SonarQubeMsTestProjectTypeGuid>


### PR DESCRIPTION
Fix #513 