### PR TITLE
Fix up ITs to run under VSTS

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.20.0.1708</version>
+      <version>3.21.0.1721</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/CppTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/CppTest.java
@@ -72,7 +72,7 @@ public class CppTest {
     .build();
 
   @ClassRule
-  public static TemporaryFolder temp = new TemporaryFolder();
+  public static TemporaryFolder temp = TestUtils.createTempFolder();
 
   @Before
   public void cleanup() {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/SQLServerTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/SQLServerTest.java
@@ -61,7 +61,7 @@ public class SQLServerTest {
     .build();
 
   @ClassRule
-  public static TemporaryFolder temp = new TemporaryFolder();
+  public static TemporaryFolder temp = TestUtils.createTempFolder();
 
   @Before
   public void setUp() {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -551,7 +551,7 @@ public class ScannerMSBuildTest {
     }
 
     ORCHESTRATOR.executeBuild(scanner);
-    TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild", folderName + ".sln");
+    TestUtils.runMSBuildWithoutVstsEnvVars(ORCHESTRATOR, projectDir, "/t:Rebuild", folderName + ".sln");
 
     scanner = TestUtils.newScanner(ORCHESTRATOR, projectDir)
       .addArgument("end");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -445,7 +445,7 @@ public class ScannerMSBuildTest {
 
   @Test
   public void testCSharpSharedFiles() throws IOException {
-    runBeginBuildAndEndForStandardProject("CSharpSharedFiles", false);
+    runBeginBuildAndEndForStandardProject("CSharpSharedFiles", true);
 
     assertThat(getComponent("CSharpSharedFiles:Common.cs"))
       .isNotNull();

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -560,10 +560,8 @@ public class ScannerMSBuildTest {
     ORCHESTRATOR.executeBuild(scanner);
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild", folderName + ".sln");
 
-    scanner = TestUtils.newScanner(ORCHESTRATOR, projectDir)
-      .addArgument("end");
-
-    ORCHESTRATOR.executeBuild(scanner);
+    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir)
+      .addArgument("end"));
 
     TestUtils.dumpComponentList(ORCHESTRATOR);
   }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -543,7 +543,8 @@ public class ScannerMSBuildTest {
       .addArgument("begin")
       .setProjectKey(folderName)
       .setProjectName(folderName)
-      .setProjectVersion("1.0");
+      .setProjectVersion("1.0")
+      .addArgument("/d:sonar.verbose=true");
 
     if (VstsUtils.isRunningUnderVsts()){
       VstsUtils.clearVstsEnvironmentVarsUsedByScanner(scanner);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -543,8 +543,7 @@ public class ScannerMSBuildTest {
       .addArgument("begin")
       .setProjectKey(folderName)
       .setProjectName(folderName)
-      .setProjectVersion("1.0")
-      .addArgument("/d:sonar.verbose=true");
+      .setProjectVersion("1.0");
 
     if (setProjectBaseDirExplicitly) {
       // When running under VSTS the scanner calculates the projectBaseDir differently.

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -108,7 +108,7 @@ public class ScannerMSBuildTest {
     .build();
 
   @ClassRule
-  public static TemporaryFolder temp = new TemporaryFolder();
+  public static TemporaryFolder temp = TestUtils.createTempFolder();
 
   @Before
   public void setUp() {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -548,6 +548,8 @@ public class ScannerMSBuildTest {
 
     ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir)
       .addArgument("end"));
+
+    TestUtils.dumpComponentList(ORCHESTRATOR);
   }
 
   private static WsComponents.Component getComponent(String componentKey) {
@@ -570,9 +572,7 @@ public class ScannerMSBuildTest {
   }
 
   private static WsClient newWsClient() {
-    return WsClientFactories.getDefault().newClient(HttpConnector.newBuilder()
-      .url(ORCHESTRATOR.getServer().getUrl())
-      .build());
+    return TestUtils.newWsClient(ORCHESTRATOR);
   }
 
   private static void startProxy(boolean needProxyAuth) throws Exception {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -105,7 +105,7 @@ public class TestUtils {
   public static TemporaryFolder createTempFolder() {
     // If the test is being run under VSTS then the Scanner will
     // expect the project to be under the VSTS sources directory
-    String vstsSourcePath = System.getenv("Build.SourcesDirectory");
+    String vstsSourcePath = System.getenv("BUILD_SOURCESDIRECTORY");
     File baseDirectory = null;
     if (vstsSourcePath == null){
       LOG.info("Tests are not running under VSTS");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -136,8 +136,8 @@ public class TestUtils {
     File baseDirectory = null;
     if (VstsUtils.isRunningUnderVsts()){
       String vstsSourcePath = VstsUtils.getSourcesDirectory();
-      LOG.info("Tests are running under VSTS. Build dir:  " + vstsSourcePath);
-      baseDirectory = new File(vstsSourcePath);
+//      LOG.info("Tests are running under VSTS. Build dir:  " + vstsSourcePath);
+//      baseDirectory = new File(vstsSourcePath);
     }
     else {
       LOG.info("Tests are not running under VSTS");
@@ -176,9 +176,14 @@ public class TestUtils {
 
     BuildResult result = new BuildResult();
     StreamConsumer.Pipe writer = new StreamConsumer.Pipe(result.getLogsWriter());
-    int status = CommandExecutor.create().execute(Command.create(msBuildPath.toString())
+    Command msBuildCommand = Command.create(msBuildPath.toString())
       .addArguments(arguments)
-      .setDirectory(projectDir.toFile()), writer, 60 * 1000);
+      .setDirectory(projectDir.toFile());
+    if (VstsUtils.isRunningUnderVsts()) {
+      VstsUtils.clearVstsEnvironmentVarsUsedByScanner(msBuildCommand);
+    }
+
+    int status = CommandExecutor.create().execute(msBuildCommand, writer, 60 * 1000);
     result.addStatus(status);
     return result;
   }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -102,6 +102,21 @@ public class TestUtils {
     return jars.get(0);
   }
 
+  public static TemporaryFolder createTempFolder() {
+    // If the test is being run under VSTS then the Scanner will
+    // expect the project to be under the VSTS sources directory
+    String vstsSourcePath = System.getenv("AGENT_BUILDDIRECTORY");
+    File baseDirectory = null;
+    if (vstsSourcePath == null){
+      LOG.info("Tests are not running under VSTS");
+    }
+    else {
+      LOG.info("Tests are running under VSTS. Build dir:  " + vstsSourcePath);
+      baseDirectory = new File(vstsSourcePath);
+    }
+    return new TemporaryFolder(baseDirectory);
+  }
+
   public static Path projectDir(TemporaryFolder temp, String projectName) throws IOException {
     Path projectDir = Paths.get("projects").resolve(projectName);
     FileUtils.deleteDirectory(new File(temp.getRoot(), projectName));

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -167,11 +167,16 @@ public class TestUtils {
   }
 
   public static void runMSBuild(Orchestrator orch, Path projectDir, String... arguments) {
-    BuildResult r = runMSBuildQuietly(orch, projectDir, arguments);
+    BuildResult r = runMSBuildQuietly(orch, projectDir, false, arguments);
     assertThat(r.isSuccess()).isTrue();
   }
 
-  private static BuildResult runMSBuildQuietly(Orchestrator orch, Path projectDir, String... arguments) {
+  public static void runMSBuildWithoutVstsEnvVars(Orchestrator orch, Path projectDir, String... arguments) {
+    BuildResult r = runMSBuildQuietly(orch, projectDir, true , arguments);
+    assertThat(r.isSuccess()).isTrue();
+  }
+
+  private static BuildResult runMSBuildQuietly(Orchestrator orch, Path projectDir, Boolean clearVstsEnvVars, String... arguments) {
     Path msBuildPath = getMsBuildPath(orch);
 
     BuildResult result = new BuildResult();
@@ -179,7 +184,7 @@ public class TestUtils {
     Command msBuildCommand = Command.create(msBuildPath.toString())
       .addArguments(arguments)
       .setDirectory(projectDir.toFile());
-    if (VstsUtils.isRunningUnderVsts()) {
+    if (clearVstsEnvVars && VstsUtils.isRunningUnderVsts()) {
       VstsUtils.clearVstsEnvironmentVarsUsedByScanner(msBuildCommand);
     }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -105,7 +105,7 @@ public class TestUtils {
   public static TemporaryFolder createTempFolder() {
     // If the test is being run under VSTS then the Scanner will
     // expect the project to be under the VSTS sources directory
-    String vstsSourcePath = System.getenv("AGENT_BUILDDIRECTORY");
+    String vstsSourcePath = System.getenv("Build.SourcesDirectory");
     File baseDirectory = null;
     if (vstsSourcePath == null){
       LOG.info("Tests are not running under VSTS");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -85,17 +85,18 @@ public class TestUtils {
       LOG.info("Using Scanner for MSBuild " + scannerVersion);
       scannerLocation = mavenLocation(scannerVersion);
     }
-    else if (VstsUtils.isRunningUnderVsts()) {
-      // if running under VSTS, look for the artifacts in the staging directory
-      String artifactsPath = VstsUtils.getArtifactsDowloadDirectory();
-      LOG.info("Running under VSTS. Using Scanner for MSBuild from the artifacts directory: "
-        + artifactsPath);
-      scannerLocation = FindScannerZip(artifactsPath);
-    }
     else {
-      // run locally
-      LOG.info("Using Scanner for MSBuild from the local build");
-      scannerLocation = FindScannerZip("../DeploymentArtifacts/BuildAgentPayload/Release");
+      String scannerLocationEnv = System.getenv("SCANNER_LOCATION");
+      if(scannerLocationEnv != null) {
+        LOG.info("Using Scanner for MSBuild specified by %SCANNER_LOCATION%: " + scannerLocationEnv);
+        Path scannerPath = Paths.get(scannerLocationEnv, "sonarscanner-msbuild-net46.zip");
+        scannerLocation = FileLocation.of(scannerPath.toFile());
+      }
+      else {
+        // run locally
+        LOG.info("Using Scanner for MSBuild from the local build");
+        scannerLocation = FindScannerZip("../DeploymentArtifacts/BuildAgentPayload/Release");
+      }
     }
 
     LOG.info("Scanner location: " + scannerLocation);
@@ -104,6 +105,7 @@ public class TestUtils {
   }
 
   private static Location FindScannerZip(String folderPath){
+    Path root = Paths.get(folderPath);
     Path scannerZip = Paths.get(folderPath + "/sonarscanner-msbuild-net46.zip");
     Location scannerLocation = FileLocation.of(scannerZip.toFile());
     return scannerLocation;

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -58,7 +58,7 @@ import sun.rmi.runtime.Log;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUtils {
-  private final static Logger LOG = LoggerFactory.getLogger(ScannerMSBuildTest.class);
+  final static Logger LOG = LoggerFactory.getLogger(ScannerMSBuildTest.class);
 
   @CheckForNull
   public static String getScannerVersion(Orchestrator orchestrator) {
@@ -136,8 +136,8 @@ public class TestUtils {
     File baseDirectory = null;
     if (VstsUtils.isRunningUnderVsts()){
       String vstsSourcePath = VstsUtils.getSourcesDirectory();
-//      LOG.info("Tests are running under VSTS. Build dir:  " + vstsSourcePath);
-//      baseDirectory = new File(vstsSourcePath);
+      LOG.info("Tests are running under VSTS. Build dir:  " + vstsSourcePath);
+      baseDirectory = new File(vstsSourcePath);
     }
     else {
       LOG.info("Tests are not running under VSTS");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -22,7 +22,6 @@ package com.sonar.it.scanner.msbuild;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.ScannerForMSBuild;
-import com.sonar.orchestrator.config.Configuration;
 import com.sonar.orchestrator.locator.FileLocation;
 import com.sonar.orchestrator.locator.Location;
 import com.sonar.orchestrator.locator.MavenLocation;
@@ -31,7 +30,6 @@ import com.sonar.orchestrator.util.CommandExecutor;
 import com.sonar.orchestrator.util.StreamConsumer;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,8 +38,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import org.apache.commons.io.FileUtils;
@@ -53,7 +49,6 @@ import org.sonarqube.ws.client.HttpConnector;
 import org.sonarqube.ws.client.WsClient;
 import org.sonarqube.ws.client.WsClientFactories;
 import org.sonarqube.ws.client.component.SearchWsRequest;
-import sun.rmi.runtime.Log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -167,28 +162,19 @@ public class TestUtils {
   }
 
   public static void runMSBuild(Orchestrator orch, Path projectDir, String... arguments) {
-    BuildResult r = runMSBuildQuietly(orch, projectDir, false, arguments);
+    BuildResult r = runMSBuildQuietly(orch, projectDir, arguments);
     assertThat(r.isSuccess()).isTrue();
   }
 
-  public static void runMSBuildWithoutVstsEnvVars(Orchestrator orch, Path projectDir, String... arguments) {
-    BuildResult r = runMSBuildQuietly(orch, projectDir, true , arguments);
-    assertThat(r.isSuccess()).isTrue();
-  }
-
-  private static BuildResult runMSBuildQuietly(Orchestrator orch, Path projectDir, Boolean clearVstsEnvVars, String... arguments) {
+  private static BuildResult runMSBuildQuietly(Orchestrator orch, Path projectDir, String... arguments) {
     Path msBuildPath = getMsBuildPath(orch);
 
     BuildResult result = new BuildResult();
     StreamConsumer.Pipe writer = new StreamConsumer.Pipe(result.getLogsWriter());
-    Command msBuildCommand = Command.create(msBuildPath.toString())
+    int status = CommandExecutor.create().execute(Command.create(msBuildPath.toString())
       .addArguments(arguments)
-      .setDirectory(projectDir.toFile());
-    if (clearVstsEnvVars && VstsUtils.isRunningUnderVsts()) {
-      VstsUtils.clearVstsEnvironmentVarsUsedByScanner(msBuildCommand);
-    }
+      .setDirectory(projectDir.toFile()), writer, 60 * 1000);
 
-    int status = CommandExecutor.create().execute(msBuildCommand, writer, 60 * 1000);
     result.addStatus(status);
     return result;
   }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/VBNetTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/VBNetTest.java
@@ -70,7 +70,7 @@ public class VBNetTest {
     .build();
 
   @ClassRule
-  public static TemporaryFolder temp = new TemporaryFolder();
+  public static TemporaryFolder temp = TestUtils.createTempFolder();
 
   @Before
   public void cleanup() {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/VstsUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/VstsUtils.java
@@ -19,6 +19,9 @@
  */
 package com.sonar.it.scanner.msbuild;
 
+import com.sonar.orchestrator.build.ScannerForMSBuild;
+import com.sonar.orchestrator.util.Command;
+
 public class VstsUtils {
 
   static Boolean isRunningUnderVsts(){
@@ -31,6 +34,16 @@ public class VstsUtils {
 
   static String getArtifactsDowloadDirectory(){
     return GetVstsEnvironmentVariable("SYSTEM_ARTIFACTSDIRECTORY");
+  }
+
+  static void clearVstsEnvironmentVarsUsedByScanner(ScannerForMSBuild scanner){
+    scanner.setEnvironmentVariable("BUILD_SOURCESDIRECTORY", "")
+      .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "");
+  }
+
+  static void clearVstsEnvironmentVarsUsedByScanner(Command command){
+    command.setEnvironmentVariable("BUILD_SOURCESDIRECTORY", "")
+      .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "");
   }
 
   private static String GetVstsEnvironmentVariable(String name){

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/VstsUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/VstsUtils.java
@@ -1,0 +1,24 @@
+package com.sonar.it.scanner.msbuild;
+
+public class VstsUtils {
+
+  static Boolean isRunningUnderVsts(){
+    return System.getenv("BUILD_SOURCESDIRECTORY") != null;
+  }
+
+  static String getSourcesDirectory(){
+    return GetVstsEnvironmentVariable("BUILD_SOURCESDIRECTORY");
+  }
+
+  static String getArtifactsDowloadDirectory(){
+    return GetVstsEnvironmentVariable("SYSTEM_ARTIFACTSDIRECTORY");
+  }
+
+  private static String GetVstsEnvironmentVariable(String name){
+    String value = System.getenv(name);
+    if (name == null){
+      throw new IllegalStateException("Unable to find VSTS environment variable: " + name);
+    }
+    return value;
+  }
+}

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/VstsUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/VstsUtils.java
@@ -19,9 +19,6 @@
  */
 package com.sonar.it.scanner.msbuild;
 
-import com.sonar.orchestrator.build.ScannerForMSBuild;
-import com.sonar.orchestrator.util.Command;
-
 public class VstsUtils {
 
   final static String ENV_BUILD_DIRECTORY = "AGENT_BUILDDIRECTORY";
@@ -33,18 +30,6 @@ public class VstsUtils {
 
   static String getSourcesDirectory(){
     return GetVstsEnvironmentVariable(ENV_SOURCES_DIRECTORY);
-  }
-
-  static void clearVstsEnvironmentVarsUsedByScanner(ScannerForMSBuild scanner){
-    TestUtils.LOG.info("Clearing VSTS environment variables for scanner invocation...");
-    scanner.setEnvironmentVariable(ENV_SOURCES_DIRECTORY, "")
-      .setEnvironmentVariable(ENV_BUILD_DIRECTORY, "");
-  }
-
-  static void clearVstsEnvironmentVarsUsedByScanner(Command command){
-    TestUtils.LOG.info("Clearing VSTS environment variables for MSBuild invocation...");
-    command.setEnvironmentVariable(ENV_SOURCES_DIRECTORY, "")
-      .setEnvironmentVariable(ENV_BUILD_DIRECTORY, "");
   }
 
   private static String GetVstsEnvironmentVariable(String name){

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/VstsUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/VstsUtils.java
@@ -24,26 +24,27 @@ import com.sonar.orchestrator.util.Command;
 
 public class VstsUtils {
 
+  final static String ENV_BUILD_DIRECTORY = "AGENT_BUILDDIRECTORY";
+  final static String ENV_SOURCES_DIRECTORY = "BUILD_SOURCESDIRECTORY";
+
   static Boolean isRunningUnderVsts(){
-    return System.getenv("AGENT_BUILDDIRECTORY") != null;
+    return System.getenv(ENV_BUILD_DIRECTORY) != null;
   }
 
   static String getSourcesDirectory(){
-    return GetVstsEnvironmentVariable("BUILD_SOURCESDIRECTORY");
-  }
-
-  static String getArtifactsDowloadDirectory(){
-    return GetVstsEnvironmentVariable("SYSTEM_ARTIFACTSDIRECTORY");
+    return GetVstsEnvironmentVariable(ENV_SOURCES_DIRECTORY);
   }
 
   static void clearVstsEnvironmentVarsUsedByScanner(ScannerForMSBuild scanner){
-    scanner.setEnvironmentVariable("BUILD_SOURCESDIRECTORY", "")
-      .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "");
+    TestUtils.LOG.info("Clearing VSTS environment variables for scanner invocation...");
+    scanner.setEnvironmentVariable(ENV_SOURCES_DIRECTORY, "")
+      .setEnvironmentVariable(ENV_BUILD_DIRECTORY, "");
   }
 
   static void clearVstsEnvironmentVarsUsedByScanner(Command command){
-    command.setEnvironmentVariable("BUILD_SOURCESDIRECTORY", "")
-      .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "");
+    TestUtils.LOG.info("Clearing VSTS environment variables for MSBuild invocation...");
+    command.setEnvironmentVariable(ENV_SOURCES_DIRECTORY, "")
+      .setEnvironmentVariable(ENV_BUILD_DIRECTORY, "");
   }
 
   private static String GetVstsEnvironmentVariable(String name){

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/VstsUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/VstsUtils.java
@@ -1,9 +1,28 @@
+/*
+ * Scanner for MSBuild :: Integration Tests
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package com.sonar.it.scanner.msbuild;
 
 public class VstsUtils {
 
   static Boolean isRunningUnderVsts(){
-    return System.getenv("BUILD_SOURCESDIRECTORY") != null;
+    return System.getenv("AGENT_BUILDDIRECTORY") != null;
   }
 
   static String getSourcesDirectory(){


### PR DESCRIPTION
The Scanner for MSBuild detects when it is being run in a VSTS build and behaves differently (e.g. uses VSTS environment variables to configure settings). This broke some of the ITs.