### PR TITLE
Added merge/overwrite switch logic to GetAnalyzerSettings task

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildLogAssertions.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/BuildLogAssertions.cs
@@ -163,7 +163,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
                 p => p.Name.Equals(itemName, System.StringComparison.OrdinalIgnoreCase) &&
                         p.Value.Equals(expectedValue, System.StringComparison.Ordinal));
 
-            capturedData.Should().NotBeNull("Test logger error: failed to expected captured item value. " 
+            capturedData.Should().NotBeNull("Test logger error: failed to find expected captured item value. " 
                 + $"Item name: '{itemName}', expected value: {expectedValue}");
         }
 

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
@@ -146,6 +146,73 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
             testSubject.AdditionalFiles.Should().BeEquivalentTo(expectedAdditionalFiles);
         }
 
+        [TestMethod]
+        public void ShouldMerge_OldServerVersion_ReturnsFalse()
+        {
+            var config = new AnalysisConfig
+            {
+                SonarQubeVersion = "7.4.1.2",
+                ServerSettings = new AnalysisProperties
+                {
+                    // Should be ignored for old server version
+                    new Property { Id = "sonar.roslyn.importAllIssues", Value = "true"}
+                }
+            };
+
+            var result = GetAnalyzerSettings.ShouldMergeAnalysisSettings(config);
+
+            result.Should().Be(false);
+        }
+
+        [TestMethod]
+        public void ShouldMerge_NewServerVersion_NoSetting_ReturnsTrue()
+        {
+            // Should default to true i.e. don't override, merge
+            var config = new AnalysisConfig
+            {
+                SonarQubeVersion = "7.5.0.0"
+            };
+
+            var result = GetAnalyzerSettings.ShouldMergeAnalysisSettings(config);
+
+            result.Should().Be(true);
+        }
+
+        [TestMethod]
+        public void ShouldMerge_NewServerVersion_SettingIsTrue_ReturnsTrue()
+        {
+            var config = new AnalysisConfig
+            {
+                SonarQubeVersion = "8.9",
+                ServerSettings = new AnalysisProperties
+                {
+                    // Import all issues = true => override = false
+                    new Property { Id = "sonar.roslyn.importAllIssues", Value = "true"}
+                }
+            };
+
+            var result = GetAnalyzerSettings.ShouldMergeAnalysisSettings(config);
+
+            result.Should().Be(true);
+        }
+
+        [TestMethod]
+        public void ShouldMerge_NewServerVersion_SettingIsFalse_ReturnsFalse()
+        {
+            var config = new AnalysisConfig
+            {
+                SonarQubeVersion = "7.5",
+                ServerSettings = new AnalysisProperties
+                {
+                    new Property { Id = "sonar.roslyn.importAllIssues", Value = "false"}
+                }
+            };
+
+            var result = GetAnalyzerSettings.ShouldMergeAnalysisSettings(config);
+
+            result.Should().Be(false);
+        }
+
         #endregion Tests
 
         #region Checks methods

--- a/src/SonarScanner.MSBuild.Common/AnalysisConfig/AnalysisConfigExtensions.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisConfig/AnalysisConfigExtensions.cs
@@ -156,6 +156,35 @@ namespace SonarScanner.MSBuild.Common
             return null;
         }
 
+        public static Version FindServerVersion(this AnalysisConfig config)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            Version.TryParse(config.SonarQubeVersion, out var version);
+            return version;
+        }
+
+        public static string GetSettingOrDefault(this AnalysisConfig config, string settingName, bool includeServerSettings, string defaultValue)
+        {
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+            if (settingName == null)
+            {
+                throw new ArgumentNullException(nameof(settingName));
+            }
+
+            if (config.GetAnalysisSettings(includeServerSettings).TryGetValue(settingName, out var value))
+            {
+                return value;
+            }
+            return defaultValue;
+        }
+
         #endregion Public methods
 
         #region Private methods

--- a/src/SonarScanner.MSBuild.Common/AnalysisConfig/Include.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisConfig/Include.cs
@@ -18,47 +18,16 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace SonarScanner.MSBuild.Common
 {
-    public class RuleSet
+    public class Include
     {
         [XmlAttribute]
-        public string Name { get; set; }
+        public string Path { get; set; }
 
         [XmlAttribute]
-        public string Description { get; set; }
-
-        [XmlAttribute]
-        public string ToolsVersion { get; set; }
-
-        [XmlElement(ElementName = "Include")]
-        public List<Include> Includes { get; set; }
-
-        [XmlElement]
-        public List<Rules> Rules { get; set; } = new List<Rules>();
-
-        public void Save(string fileName)
-        {
-            if (string.IsNullOrWhiteSpace(fileName))
-            {
-                throw new ArgumentNullException(nameof(fileName));
-            }
-
-            Serializer.SaveModel(this, fileName);
-        }
-
-        public static RuleSet Load(string fileName)
-        {
-            if (string.IsNullOrWhiteSpace(fileName))
-            {
-                throw new ArgumentNullException(nameof(fileName));
-            }
-
-            return Serializer.LoadModel<RuleSet>(fileName);
-        }
+        public string Action { get; set; }
     }
 }

--- a/src/SonarScanner.MSBuild.Tasks/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.Tasks/Resources.Designer.cs
@@ -61,11 +61,47 @@ namespace SonarScanner.MSBuild.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Creating merged ruleset at &apos;{0}&apos;.
+        /// </summary>
+        internal static string AnalyzerSettings_CreatingMergedRuleset {
+            get {
+                return ResourceManager.GetString("AnalyzerSettings_CreatingMergedRuleset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Merging analysis settings....
+        /// </summary>
+        internal static string AnalyzerSettings_MergingSettings {
+            get {
+                return ResourceManager.GetString("AnalyzerSettings_MergingSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Analyzer settings for language {0} have not been specified in the analysis config file.
         /// </summary>
         internal static string AnalyzerSettings_NotSpecifiedInConfig {
             get {
                 return ResourceManager.GetString("AnalyzerSettings_NotSpecifiedInConfig", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Original ruleset not specified. Using generated ruleset at &apos;{0}&apos;.
+        /// </summary>
+        internal static string AnalyzerSettings_OriginalRulesetNotSpecified {
+            get {
+                return ResourceManager.GetString("AnalyzerSettings_OriginalRulesetNotSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Overwriting analysis settings....
+        /// </summary>
+        internal static string AnalyzerSettings_OverwritingSettings {
+            get {
+                return ResourceManager.GetString("AnalyzerSettings_OverwritingSettings", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.Tasks/Resources.resx
+++ b/src/SonarScanner.MSBuild.Tasks/Resources.resx
@@ -196,4 +196,16 @@ Error: {1}</value>
   <data name="IsTest_UsingDefaultRegEx" xml:space="preserve">
     <value>Using default regular expression for detecting test projects: {0}</value>
   </data>
+  <data name="AnalyzerSettings_CreatingMergedRuleset" xml:space="preserve">
+    <value>Creating merged ruleset at '{0}'</value>
+  </data>
+  <data name="AnalyzerSettings_MergingSettings" xml:space="preserve">
+    <value>Merging analysis settings...</value>
+  </data>
+  <data name="AnalyzerSettings_OriginalRulesetNotSpecified" xml:space="preserve">
+    <value>Original ruleset not specified. Using generated ruleset at '{0}'</value>
+  </data>
+  <data name="AnalyzerSettings_OverwritingSettings" xml:space="preserve">
+    <value>Overwriting analysis settings...</value>
+  </data>
 </root>

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -378,7 +378,11 @@
   <Target Name="SetRoslynCodeAnalysisProperties">
 
     <!-- Fetch the relevant settings from the config file -->
-    <GetAnalyzerSettings AnalysisConfigDir="$(SonarQubeConfigPath)" Language="$(SQLanguage)" OriginalAdditionalFiles="@(AdditionalFiles)">
+    <GetAnalyzerSettings AnalysisConfigDir="$(SonarQubeConfigPath)"
+                         Language="$(SQLanguage)"
+                         OriginalAdditionalFiles="@(AdditionalFiles)"
+                         OriginalRulesetFilePath="$(ResolvedCodeAnalysisRuleset)"
+                         ProjectSpecificOutputDirectory="$(ProjectSpecificOutDir)">
       <Output TaskParameter="RuleSetFilePath" PropertyName="SQRuleSetFilePath" />
       <Output TaskParameter="AnalyzerFilePaths" ItemName="SQAnalyzerFilePaths" />
       <Output TaskParameter="AdditionalFiles" ItemName="SQAdditionalFiles" />


### PR DESCRIPTION
This commit adds and tests the switching logic in the existing _GetAnalyzerSettings_ custom MSBuild task to decide whether to overwrite all of the Roslyn analyzer configuration in the project (the legacy behaviour) or to merge it.

TODO: new merge behaviour is not implemented

Part 1 of #561 