### PR TITLE
Simplify the GetAnalyzerSettings task

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/SimpleXmlLogger.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/MSBuildExecution/SimpleXmlLogger.cs
@@ -22,7 +22,7 @@ using System.Collections.Generic;
 using Microsoft.Build.Framework;
 
 // See MSDN for an example: https://msdn.microsoft.com/en-us/library/ms171471#Anchor_5
-// Example usage: msbuild x.csproj /logger:SonarScanner.MSBuild.Tasks.IntegrationTests.SimpleXmkLogger,..\SonarScanner.MSBuild.Tasks.IntegrationTests\bin\Debug\Logger.dll;log1.txt /noconsolelogger
+// Example usage: msbuild x.csproj /logger:SonarScanner.MSBuild.Tasks.IntegrationTests.SimpleXmlLogger,..\SonarScanner.MSBuild.Tasks.IntegrationTests\bin\Debug\Logger.dll;log1.txt /noconsolelogger
 
 namespace SonarScanner.MSBuild.Tasks.IntegrationTests
 {
@@ -144,6 +144,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
 
             if (!msg.StartsWith($"CAPTURE{CapturedDataSeparator}"))
             {
+                log.LogMessage(e.Message);
                 return;
             }
 

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -155,7 +155,8 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
     <AdditionalFiles Include='should.not.be.removed.additional2.txt' />
 
     <!-- This additional file matches one in the config and should be replaced -->
-    <AdditionalFiles Include='should.be.removed\CONFIG.1.TXT' />
+    <AdditionalFiles Include='should.be.removed/CONFIG.1.TXT' />
+    <AdditionalFiles Include='should.be.removed\CONFIG.2.TXT' />
 
   </ItemGroup>
 ";
@@ -227,7 +228,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
     <AdditionalFiles Include='should.not.be.removed.additional2.txt' />
 
     <!-- This additional file matches one in the config and should be replaced -->
-    <AdditionalFiles Include='should.be.removed\CONFIG.1.TXT' />
+    <AdditionalFiles Include='d:/should.be.removed/CONFIG.1.TXT' />
 
   </ItemGroup>
 ";

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
@@ -106,7 +106,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
                         Language = "my lang",
                         RuleSetFilePath = "f:\\yyy.ruleset",
                         AnalyzerAssemblyPaths = filesInConfig,
-                        AdditionalFilePaths = new List<string> { "c:\\add1.txt", "d:\\add2.txt" }
+                        AdditionalFilePaths = new List<string> { "c:\\add1.txt", "d:\\add2.txt", "e:\\subdir\\add3.txt" }
                     },
 
                     new AnalyzerSettings
@@ -121,9 +121,12 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
             };
 
             var testSubject = CreateConfiguredTestSubject(config, "my lang", TestContext);
-            testSubject.OriginalAdditionalFiles = new string[] {
+            testSubject.OriginalAdditionalFiles = new string[]
+            {
                 "original.should.be.preserved.txt",
-                "original.should.be.replaced\\add2.txt" };
+                "original.should.be.replaced\\add2.txt",
+                "e://foo//should.be.replaced//add3.txt"
+            };
 
             // Act
             ExecuteAndCheckSuccess(testSubject);
@@ -131,7 +134,8 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
             // Assert
             testSubject.RuleSetFilePath.Should().Be("f:\\yyy.ruleset");
             testSubject.AnalyzerFilePaths.Should().BeEquivalentTo(expectedAnalyzers);
-            testSubject.AdditionalFilePaths.Should().BeEquivalentTo("c:\\add1.txt", "d:\\add2.txt", "original.should.be.preserved.txt");
+            testSubject.AdditionalFilePaths.Should().BeEquivalentTo("c:\\add1.txt", "d:\\add2.txt",
+                "e:\\subdir\\add3.txt", "original.should.be.preserved.txt");
         }
 
         [TestMethod]

--- a/src/SonarScanner.MSBuild.Tasks/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.Tasks/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace SonarScanner.MSBuild.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Removing duplicate analyzers: {0}.
+        /// </summary>
+        internal static string Analyzer_Settings_RemovingDuplicateAnalyzers {
+            get {
+                return ResourceManager.GetString("Analyzer_Settings_RemovingDuplicateAnalyzers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Creating merged ruleset at &apos;{0}&apos;.
         /// </summary>
         internal static string AnalyzerSettings_CreatingMergedRuleset {
@@ -75,6 +84,15 @@ namespace SonarScanner.MSBuild.Tasks {
         internal static string AnalyzerSettings_MergingSettings {
             get {
                 return ResourceManager.GetString("AnalyzerSettings_MergingSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No analysis settings were found in the Sonar config file for the current language: {0}.
+        /// </summary>
+        internal static string AnalyzerSettings_NoSettingsFoundForCurrentLanguage {
+            get {
+                return ResourceManager.GetString("AnalyzerSettings_NoSettingsFoundForCurrentLanguage", resourceCulture);
             }
         }
         
@@ -102,6 +120,15 @@ namespace SonarScanner.MSBuild.Tasks {
         internal static string AnalyzerSettings_OverwritingSettings {
             get {
                 return ResourceManager.GetString("AnalyzerSettings_OverwritingSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Removing duplicate additional files: {0}.
+        /// </summary>
+        internal static string AnalyzerSettings_RemovingDuplicateAdditionalFiles {
+            get {
+                return ResourceManager.GetString("AnalyzerSettings_RemovingDuplicateAdditionalFiles", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.Tasks/Resources.resx
+++ b/src/SonarScanner.MSBuild.Tasks/Resources.resx
@@ -208,4 +208,13 @@ Error: {1}</value>
   <data name="AnalyzerSettings_OverwritingSettings" xml:space="preserve">
     <value>Overwriting analysis settings...</value>
   </data>
+  <data name="AnalyzerSettings_NoSettingsFoundForCurrentLanguage" xml:space="preserve">
+    <value>No analysis settings were found in the Sonar config file for the current language: {0}</value>
+  </data>
+  <data name="AnalyzerSettings_RemovingDuplicateAdditionalFiles" xml:space="preserve">
+    <value>Removing duplicate additional files: {0}</value>
+  </data>
+  <data name="Analyzer_Settings_RemovingDuplicateAnalyzers" xml:space="preserve">
+    <value>Removing duplicate analyzers: {0}</value>
+  </data>
 </root>

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -385,8 +385,7 @@
                          ProjectSpecificOutputDirectory="$(ProjectSpecificOutDir)">
       <Output TaskParameter="RuleSetFilePath" PropertyName="SQRuleSetFilePath" />
       <Output TaskParameter="AnalyzerFilePaths" ItemName="SQAnalyzerFilePaths" />
-      <Output TaskParameter="AdditionalFiles" ItemName="SQAdditionalFiles" />
-      <Output TaskParameter="AdditionalFilesToRemove" ItemName="SQAdditionalFilesToRemove" />
+      <Output TaskParameter="AdditionalFilePaths" ItemName="SQAdditionalFiles" />
     </GetAnalyzerSettings>
 
     <PropertyGroup>
@@ -404,16 +403,16 @@
     </WriteLinesToFile>
 
     <ItemGroup>
-      <!-- Remove any existing analyzers and additional files -->
+      <!-- Clear the original set of analyzers and additional files -->
       <Analyzer Remove="@(Analyzer)" />
-      <AdditionalFiles Remove="@(SQAdditionalFilesToRemove)" />
+      <AdditionalFiles Remove="@(AdditionalFiles)" />
 
-      <!-- Add specified analyzers and additional files (if any) -->
+      <!-- Use the set of analyzers and additional files calculated by the GetAnalyzerSettings task -->
       <Analyzer Include="@(SQAnalyzerFilePaths)" />
       <AdditionalFiles Include="@(SQAdditionalFiles)" />
       <AdditionalFiles Include="$(ProjectConfFilePath)" />
     </ItemGroup>
-
+  
   </Target>
 
   <Target Name="SetRoslynAnalysisResults"

--- a/tests/SonarScanner.MSBuild.Tasks.Integrationtests/MSBuildExecution/BuildLog.cs
+++ b/tests/SonarScanner.MSBuild.Tasks.Integrationtests/MSBuildExecution/BuildLog.cs
@@ -49,6 +49,21 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
 
         public bool BuildSucceeded { get; set; }
 
+        #region Message logging
+
+        private readonly StringBuilder messageLogBuilder = new StringBuilder();
+
+        // We want the normal messages to appear in the log file as a string rather than as a series
+        // of discrete messages to make them more readable.
+        public string MessageLog { get; set; } // for serialization
+
+        public void LogMessage(string message)
+        {
+            messageLogBuilder.AppendLine(message);
+        }
+
+        #endregion
+
         public string GetPropertyValue(string propertyName)
         {
             TryGetPropertyValue(propertyName, out var propertyValue);
@@ -75,6 +90,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
 
         public void Save(string filePath)
         {
+            MessageLog = messageLogBuilder.ToString();
             SerializeObjectToFile(filePath, this);
             FilePath = filePath;
         }


### PR DESCRIPTION
The interaction between the targets file and _GetAnalyzerSettings_ custom task was more complicated than necessary so I decided to simplify it before making the next set of changes related to the supporting external analyzers.

I also improved the logging in the test framework to make diagnosing test failures easier.