### PR TITLE
Fix minimum SQ version

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
@@ -159,7 +159,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
 
             var config = new AnalysisConfig
             {
-                SonarQubeVersion = "7.5",
+                SonarQubeVersion = "7.4",
                 AnalyzersSettings = new List<AnalyzerSettings>
                 {
                     new AnalyzerSettings
@@ -217,7 +217,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         {
             var config = new AnalysisConfig
             {
-                SonarQubeVersion = "7.4.1.2",
+                SonarQubeVersion = "7.3.1.2",
                 ServerSettings = new AnalysisProperties
                 {
                     // Should be ignored for old server version
@@ -236,7 +236,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
             // Should default to true i.e. don't override, merge
             var config = new AnalysisConfig
             {
-                SonarQubeVersion = "7.5.0.0"
+                SonarQubeVersion = "7.4.0.0"
             };
 
             var result = GetAnalyzerSettings.ShouldMergeAnalysisSettings(config);
@@ -267,7 +267,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         {
             var config = new AnalysisConfig
             {
-                SonarQubeVersion = "7.5",
+                SonarQubeVersion = "7.4",
                 ServerSettings = new AnalysisProperties
                 {
                     new Property { Id = "sonar.roslyn.importAllIssues", Value = "false"}
@@ -285,7 +285,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
             // Arrange
             var config = new AnalysisConfig
             {
-                SonarQubeVersion = "7.5",
+                SonarQubeVersion = "7.4",
                 AnalyzersSettings = new List<AnalyzerSettings>
                 {
                     new AnalyzerSettings
@@ -312,7 +312,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
             // Arrange
             var config = new AnalysisConfig
             {
-                SonarQubeVersion = "7.5",
+                SonarQubeVersion = "7.4",
                 AnalyzersSettings = new List<AnalyzerSettings>
                 {
                     new AnalyzerSettings

--- a/src/SonarScanner.MSBuild.Tasks/GetAnalyzerSettings.cs
+++ b/src/SonarScanner.MSBuild.Tasks/GetAnalyzerSettings.cs
@@ -122,10 +122,10 @@ namespace SonarScanner.MSBuild.Tasks
         {
             // See https://github.com/SonarSource/sonar-scanner-msbuild/issues/561
             // Legacy behaviour is to overwrite. The only time we don't is if the
-            // we are using SQ 7.5 or greater and sonar.roslyn.importAllIssues is not 
+            // we are using SQ 7.4 or greater and sonar.roslyn.importAllIssues is not 
             // set or is true.
             var serverVersion = config?.FindServerVersion();
-            if (serverVersion != null && serverVersion >= new Version("7.5"))
+            if (serverVersion != null && serverVersion >= new Version("7.4"))
             {
                 var settingInFile = config.GetSettingOrDefault("sonar.roslyn.importAllIssues", true, "true");
                 if (Boolean.TryParse(settingInFile, out var includeInFile))


### PR DESCRIPTION
Both the product code and tests where using the wrong value (7.5). Should have been 7.4.
See https://github.com/SonarSource/sonar-scanner-msbuild/issues/561
