### PR TITLE
Reduce errors linked to locked dlls

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tests/BootstrapperClassTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tests/BootstrapperClassTests.cs
@@ -211,9 +211,9 @@ namespace SonarQube.Bootstrapper.Tests
                 logger.DebugMessages[1].Should().Match("Cannot delete file: '*\\.sonarqube\\bin\\SonarScanner.MSBuild.Common.dll' because The process cannot access the file 'SonarScanner.MSBuild.Common.dll' because it is being used by another process..");
                 logger.DebugMessages[2].Should().Match("Cannot delete file: '*\\.sonarqube\\bin\\SonarScanner.MSBuild.Tasks.dll' because The process cannot access the file 'SonarScanner.MSBuild.Tasks.dll' because it is being used by another process..");
 
-                logger.AssertErrorLogged(@"Cannot copy a different version of the SonarScanner for MSBuild assemblies because they are used by a running MSBuild process. To resolve this problem try one of the following:
-- Use the same version of SonarScanner for MSBuild to analyze this project
-- Run msbuild or dotnet with '/nr:false'");
+                logger.AssertErrorLogged(@"Cannot copy a different version of the SonarScanner for MSBuild assemblies because they are used by a running MSBuild/.Net Core process. To resolve this problem try one of the following:
+- Analyze this project using the same version of SonarScanner for MSBuild
+- Build your project with the '/nr:false' switch");
 
                 // Do not close before to ensure the file is locked
                 file1.Close();

--- a/src/SonarScanner.MSBuild/BootstrapperClass.cs
+++ b/src/SonarScanner.MSBuild/BootstrapperClass.cs
@@ -37,7 +37,7 @@ namespace SonarScanner.MSBuild
         private readonly IProcessorFactory processorFactory;
         private readonly IBootstrapperSettings bootstrapSettings;
         private readonly ILogger logger;
-        private readonly Func<string, Version> getAssemblyVersion;
+        private readonly Func<string, Version> getAssemblyVersionFunc;
 
         public BootstrapperClass(IProcessorFactory processorFactory, IBootstrapperSettings bootstrapSettings, ILogger logger)
             : this(processorFactory, bootstrapSettings, logger, assemblyPath => AssemblyName.GetAssemblyName(assemblyPath).Version)
@@ -45,12 +45,12 @@ namespace SonarScanner.MSBuild
         }
 
         public BootstrapperClass(IProcessorFactory processorFactory, IBootstrapperSettings bootstrapSettings, ILogger logger,
-            Func<string, Version> getAssemblyVersion)
+            Func<string, Version> getAssemblyVersionFunc)
         {
             this.processorFactory = processorFactory;
             this.bootstrapSettings = bootstrapSettings;
             this.logger = logger;
-            this.getAssemblyVersion = getAssemblyVersion;
+            this.getAssemblyVersionFunc = getAssemblyVersionFunc;
 
             Debug.Assert(this.bootstrapSettings != null, "Bootstrapper settings should not be null");
             Debug.Assert(this.bootstrapSettings.Phase != AnalysisPhase.Unspecified, "Expecting the processing phase to be specified");
@@ -189,7 +189,7 @@ namespace SonarScanner.MSBuild
                 {
                     File.Copy(from, to);
                 }
-                else if (this.getAssemblyVersion(from).CompareTo(this.getAssemblyVersion(to)) != 0)
+                else if (this.getAssemblyVersionFunc(from).CompareTo(this.getAssemblyVersionFunc(to)) != 0)
                 {
                     this.logger.LogError(Resources.ERROR_DllLockedMultipleScanners);
                     return false;

--- a/src/SonarScanner.MSBuild/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild/Resources.Designer.cs
@@ -106,9 +106,9 @@ namespace SonarScanner.MSBuild {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot copy a different version of the SonarScanner for MSBuild assemblies because they are used by a running MSBuild process. To resolve this problem try one of the following:
-        ///- Use the same version of SonarScanner for MSBuild to analyze this project
-        ///- Run msbuild or dotnet with &apos;/nr:false&apos;.
+        ///   Looks up a localized string similar to Cannot copy a different version of the SonarScanner for MSBuild assemblies because they are used by a running MSBuild/.Net Core process. To resolve this problem try one of the following:
+        ///- Analyze this project using the same version of SonarScanner for MSBuild
+        ///- Build your project with the &apos;/nr:false&apos; switch.
         /// </summary>
         internal static string ERROR_DllLockedMultipleScanners {
             get {

--- a/src/SonarScanner.MSBuild/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild/Resources.Designer.cs
@@ -106,6 +106,17 @@ namespace SonarScanner.MSBuild {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot copy a different version of the SonarScanner for MSBuild assemblies because they are used by a running MSBuild process. To resolve this problem try one of the following:
+        ///- Use the same version of SonarScanner for MSBuild to analyze this project
+        ///- Run msbuild or dotnet with &apos;/nr:false&apos;.
+        /// </summary>
+        internal static string ERROR_DllLockedMultipleScanners {
+            get {
+                return ResourceManager.GetString("ERROR_DllLockedMultipleScanners", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} failed. Exit code: {1}.
         /// </summary>
         internal static string ERROR_ProcessingFailed {

--- a/src/SonarScanner.MSBuild/Resources.resx
+++ b/src/SonarScanner.MSBuild/Resources.resx
@@ -132,6 +132,11 @@
   <data name="ERROR_ConfigFileNotFound" xml:space="preserve">
     <value>SonarQube analysis could not be completed because the analysis configuration file could not be found: {0}.</value>
   </data>
+  <data name="ERROR_DllLockedMultipleScanners" xml:space="preserve">
+    <value>Cannot copy a different version of the SonarScanner for MSBuild assemblies because they are used by a running MSBuild process. To resolve this problem try one of the following:
+- Use the same version of SonarScanner for MSBuild to analyze this project
+- Run msbuild or dotnet with '/nr:false'</value>
+  </data>
   <data name="ERROR_ProcessingFailed" xml:space="preserve">
     <value>{0} failed. Exit code: {1}</value>
   </data>

--- a/src/SonarScanner.MSBuild/Resources.resx
+++ b/src/SonarScanner.MSBuild/Resources.resx
@@ -133,9 +133,9 @@
     <value>SonarQube analysis could not be completed because the analysis configuration file could not be found: {0}.</value>
   </data>
   <data name="ERROR_DllLockedMultipleScanners" xml:space="preserve">
-    <value>Cannot copy a different version of the SonarScanner for MSBuild assemblies because they are used by a running MSBuild process. To resolve this problem try one of the following:
-- Use the same version of SonarScanner for MSBuild to analyze this project
-- Run msbuild or dotnet with '/nr:false'</value>
+    <value>Cannot copy a different version of the SonarScanner for MSBuild assemblies because they are used by a running MSBuild/.Net Core process. To resolve this problem try one of the following:
+- Analyze this project using the same version of SonarScanner for MSBuild
+- Build your project with the '/nr:false' switch</value>
   </data>
   <data name="ERROR_ProcessingFailed" xml:space="preserve">
     <value>{0} failed. Exit code: {1}</value>


### PR DESCRIPTION
Fix #535 

The idea is to try to delete as many folders/files as possible inside the `.sonarqube` folder. When reaching the copy dll step, we will compare versions and skip if they are the same of fail with a better message if they are different.