### PR TITLE
Don't set the JVM memory size by default

### DIFF
--- a/Tests/SonarScanner.MSBuild.Shim.Tests/MockProcessRunner.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Tests/MockProcessRunner.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+using FluentAssertions;
+using SonarScanner.MSBuild.Common;
+
+namespace SonarScanner.MSBuild.Shim.Tests
+{
+    internal class MockProcessRunner : IProcessRunner
+    {
+        private bool executeResult;
+
+        public MockProcessRunner(bool executeResult)
+        {
+            this.executeResult = executeResult;
+        }
+
+        public ProcessRunnerArguments SuppliedArguments { get; private set; }
+
+        #region IProcessRunner interface
+
+        public bool Execute(ProcessRunnerArguments runnerArgs)
+        {
+            runnerArgs.Should().NotBeNull();
+            SuppliedArguments = runnerArgs;
+
+            return executeResult;
+        }
+
+        #endregion IProcessRunner interface
+    }
+}

--- a/Tests/SonarScanner.MSBuild.Shim.Tests/SonarScanner.MSBuild.Shim.Tests.csproj
+++ b/Tests/SonarScanner.MSBuild.Shim.Tests/SonarScanner.MSBuild.Shim.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="..\..\AssemblyInfo.Shared.cs">
       <Link>Properties\AssemblyInfo.Shared.cs</Link>
     </Compile>
+    <Compile Include="MockProcessRunner.cs" />
     <Compile Include="MockRoslynV1SarifFixer.cs" />
     <Compile Include="PathHelperTests.cs" />
     <Compile Include="ProjectInfoReportBuilderTests.cs" />

--- a/Tests/SonarScanner.MSBuild.Shim.Tests/SonarScannerWrapperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Tests/SonarScannerWrapperTests.cs
@@ -19,9 +19,9 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarScanner.MSBuild.Common;
@@ -35,9 +35,6 @@ namespace SonarScanner.MSBuild.Shim.Tests
         private const string ExpectedConsoleMessagePrefix = "Args passed to dummy scanner: ";
 
         public TestContext TestContext { get; set; }
-
-        private const int SuccessExitCode = 0;
-        private const int FailureExitCode = 4;
 
         #region Tests
 
@@ -78,25 +75,24 @@ namespace SonarScanner.MSBuild.Shim.Tests
         {
             // Arrange
             var testLogger = new TestLogger();
-            var exePath = CreateDummarySonarScannerBatchFile();
-            var propertiesFilePath = CreateDummySonarScannerPropertiesFile();
 
             using (var scope = new EnvironmentVariableScope())
             {
                 scope.SetVariable(SonarScannerWrapper.SonarScannerHomeVariableName, null);
-                var config = new AnalysisConfig() { SonarScannerWorkingDirectory = TestUtils.CreateTestSpecificFolder(TestContext) };
+                var config = new AnalysisConfig() { SonarScannerWorkingDirectory = "C:\\working\\dir" };
+                var mockRunner = new MockProcessRunner(executeResult: true);
 
                 // Act
-                var success = SonarScannerWrapper.ExecuteJavaRunner(config, Enumerable.Empty<string>(), testLogger, exePath, propertiesFilePath);
+                var success = ExecuteJavaRunnerIgnoringAsserts(config, Enumerable.Empty<string>(), testLogger, "c:\\file.exe", "d:\\properties.prop", mockRunner);
 
                 // Assert
-                VerifyProcessRunOutcome(testLogger, TestUtils.CreateTestSpecificFolder(TestContext), success, true);
+                VerifyProcessRunOutcome(mockRunner, testLogger, "C:\\working\\dir", success, true);
                 testLogger.AssertMessageNotLogged(SonarScanner.MSBuild.Shim.Resources.MSG_SonarScannerHomeIsSet);
             }
         }
 
         [TestMethod]
-        public void SonarScannerrHome_MessageLoggedIfAlreadySet()
+        public void SonarScannerHome_MessageLoggedIfAlreadySet()
         {
             using (var scope = new EnvironmentVariableScope())
             {
@@ -104,15 +100,15 @@ namespace SonarScanner.MSBuild.Shim.Tests
 
                 // Arrange
                 var testLogger = new TestLogger();
-                var exePath = CreateDummarySonarScannerBatchFile();
-                var propertiesFilePath = CreateDummySonarScannerPropertiesFile();
-                var config = new AnalysisConfig() { SonarScannerWorkingDirectory = TestUtils.CreateTestSpecificFolder(TestContext) };
+                var mockRunner = new MockProcessRunner(executeResult: true);
+                var config = new AnalysisConfig() { SonarScannerWorkingDirectory = "c:\\workingDir" };
 
                 // Act
-                var success = SonarScannerWrapper.ExecuteJavaRunner(config, Enumerable.Empty<string>(), testLogger, exePath, propertiesFilePath);
+                var success = ExecuteJavaRunnerIgnoringAsserts(config, Enumerable.Empty<string>(), testLogger, "c:\\exePath", "f:\\props.txt", mockRunner);
 
                 // Assert
-                VerifyProcessRunOutcome(testLogger, TestUtils.CreateTestSpecificFolder(TestContext), success, true);
+                VerifyProcessRunOutcome(mockRunner, testLogger, "c:\\workingDir", success, true);
+                testLogger.AssertInfoMessageExists(SonarScanner.MSBuild.Shim.Resources.MSG_SonarScannerHomeIsSet);
             }
         }
 
@@ -121,15 +117,16 @@ namespace SonarScanner.MSBuild.Shim.Tests
         {
             // Arrange
             var logger = new TestLogger();
-            var exePath = CreateDummarySonarScannerBatchFile();
-            var propertiesFilePath = CreateDummySonarScannerPropertiesFile();
-            var config = new AnalysisConfig() { SonarScannerWorkingDirectory = TestUtils.CreateTestSpecificFolder(TestContext) };
+            var mockRunner = new MockProcessRunner(executeResult: true);
+            var config = new AnalysisConfig() { SonarScannerWorkingDirectory = "c:\\work" };
 
             // Act
-            var success = SonarScannerWrapper.ExecuteJavaRunner(config, Enumerable.Empty<string>(), logger, exePath, propertiesFilePath);
+            var success = ExecuteJavaRunnerIgnoringAsserts(config, Enumerable.Empty<string>(), logger, "c:\\exe.Path", "d:\\propertiesFile.Path", mockRunner);
 
             // Assert
-            VerifyProcessRunOutcome(logger, TestUtils.CreateTestSpecificFolder(TestContext), success, true);
+            VerifyProcessRunOutcome(mockRunner, logger, "c:\\work", success, true);
+            // Check that the JVM size is set
+            logger.InfoMessages.Should().Contain(msg => msg.Contains("-Xmx1024m"));
         }
 
         [TestMethod]
@@ -139,29 +136,28 @@ namespace SonarScanner.MSBuild.Shim.Tests
 
             // Arrange
             var logger = new TestLogger();
-
-            var exePath = CreateDummarySonarScannerBatchFile();
-            var propertiesFilePath = CreateDummySonarScannerPropertiesFile();
-
             var userArgs = new string[] { "-Dsonar.login=me", "-Dsonar.password=my.pwd" };
 
+            var mockRunner = new MockProcessRunner(executeResult: true);
+
             // Act
-            var success = SonarScannerWrapper.ExecuteJavaRunner(
-                new AnalysisConfig() { SonarScannerWorkingDirectory = TestUtils.CreateTestSpecificFolder(TestContext) },
+            var success = ExecuteJavaRunnerIgnoringAsserts(
+                new AnalysisConfig() { SonarScannerWorkingDirectory = "D:\\dummyWorkingDirectory" },
                 userArgs,
                 logger,
-                exePath,
-                propertiesFilePath);
+                "c:\\dummy.exe",
+                "c:\\foo.properties",
+                mockRunner);
 
             // Assert
-            VerifyProcessRunOutcome(logger, TestUtils.CreateTestSpecificFolder(TestContext), success, true);
+            VerifyProcessRunOutcome(mockRunner, logger, "D:\\dummyWorkingDirectory", success, true);
 
-            var actualCmdLineArgs = CheckStandardArgsPassed(logger, propertiesFilePath);
+            CheckStandardArgsPassed(mockRunner, "c:\\foo.properties");
 
-            var loginIndex = CheckArgExists("-Dsonar.login=me", actualCmdLineArgs);
-            var pwdIndex = CheckArgExists("-Dsonar.password=my.pwd", actualCmdLineArgs);
+            var loginIndex = CheckArgExists("-Dsonar.login=me", mockRunner);
+            var pwdIndex = CheckArgExists("-Dsonar.password=my.pwd", mockRunner);
 
-            var propertiesFileIndex = CheckArgExists(SonarScannerWrapper.ProjectSettingsFileArgName, actualCmdLineArgs);
+            var propertiesFileIndex = CheckArgExists(SonarScannerWrapper.ProjectSettingsFileArgName, mockRunner);
 
             propertiesFileIndex.Should().BeGreaterThan(loginIndex, "User arguments should appear first");
             propertiesFileIndex.Should().BeGreaterThan(pwdIndex, "User arguments should appear first");
@@ -174,12 +170,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
 
             // Arrange
             var logger = new TestLogger();
-
-            var testDir = TestUtils.CreateTestSpecificFolder(TestContext);
-
-            var exePath = CreateDummarySonarScannerBatchFile();
-            var propertiesFilePath = CreateDummySonarScannerPropertiesFile();
-
+            var mockRunner = new MockProcessRunner(executeResult: true);
             var userArgs = new string[] { "-Dxxx=yyy", "-Dsonar.password=cmdline.password" };
 
             // Create a config file containing sensitive arguments
@@ -189,26 +180,29 @@ namespace SonarScanner.MSBuild.Shim.Tests
                 new Property() { Id = SonarProperties.SonarPassword, Value = "file.password - should not be returned" },
                 new Property() { Id = "file.not.sensitive.key", Value = "not sensitive value" }
             };
+
+            var testDir = TestUtils.CreateTestSpecificFolder(TestContext);
             var settingsFilePath = Path.Combine(testDir, "fileSettings.txt");
             fileSettings.Save(settingsFilePath);
 
-            var config = new AnalysisConfig() { SonarScannerWorkingDirectory = TestUtils.CreateTestSpecificFolder(TestContext) };
+            var config = new AnalysisConfig() { SonarScannerWorkingDirectory = testDir };
             config.SetSettingsFilePath(settingsFilePath);
 
             // Act
-            var success = SonarScannerWrapper.ExecuteJavaRunner(config, userArgs, logger, exePath, propertiesFilePath);
+            var success = ExecuteJavaRunnerIgnoringAsserts(config, userArgs, logger, "c:\\foo.exe", "c:\\foo.props", mockRunner);
 
             // Assert
-            VerifyProcessRunOutcome(logger, TestUtils.CreateTestSpecificFolder(TestContext), success, true);
-            var actualCmdLineArgs = CheckStandardArgsPassed(logger, propertiesFilePath);
+            VerifyProcessRunOutcome(mockRunner, logger, testDir, success, true);
+
+            CheckStandardArgsPassed(mockRunner, "c:\\foo.props");
 
             // Non-sensitive values from the file should not be passed on the command line
-            CheckArgDoesNotExist("file.not.sensitive.key", actualCmdLineArgs);
+            CheckArgDoesNotExist("file.not.sensitive.key", mockRunner);
 
-            var dbPwdIndex = CheckArgExists("-Dsonar.jdbc.password=file db pwd", actualCmdLineArgs); // sensitive value from file
-            var userPwdIndex = CheckArgExists("-Dsonar.password=cmdline.password", actualCmdLineArgs); // sensitive value from cmd line: overrides file value
+            var dbPwdIndex = CheckArgExists("-Dsonar.jdbc.password=file db pwd", mockRunner); // sensitive value from file
+            var userPwdIndex = CheckArgExists("-Dsonar.password=cmdline.password", mockRunner); // sensitive value from cmd line: overrides file value
 
-            var propertiesFileIndex = CheckArgExists(SonarScannerWrapper.ProjectSettingsFileArgName, actualCmdLineArgs);
+            var propertiesFileIndex = CheckArgExists(SonarScannerWrapper.ProjectSettingsFileArgName, mockRunner);
 
             propertiesFileIndex.Should().BeGreaterThan(dbPwdIndex, "User arguments should appear first");
             propertiesFileIndex.Should().BeGreaterThan(userPwdIndex, "User arguments should appear first");
@@ -217,102 +211,69 @@ namespace SonarScanner.MSBuild.Shim.Tests
         [TestMethod]
         public void WrapperError_Success_NoStdErr()
         {
-            TestWrapperErrorHandling(exitCode: SuccessExitCode, addMessageToStdErr: false, expectedOutcome: true);
+            TestWrapperErrorHandling(executeResult: true, addMessageToStdErr: false, expectedOutcome: true);
         }
 
         [TestMethod]
         [WorkItem(202)] //SONARMSBRU-202
         public void WrapperError_Success_StdErr()
         {
-            TestWrapperErrorHandling(exitCode: SuccessExitCode, addMessageToStdErr: true, expectedOutcome: true);
-        }
-
-        [TestMethod]
-        public void WrapperError_None_NoStdErr()
-        {
-            TestWrapperErrorHandling(exitCode: null, addMessageToStdErr: false, expectedOutcome: true);
-        }
-
-        [TestMethod]
-        public void WrapperError_None_StdErr()
-        {
-            TestWrapperErrorHandling(exitCode: null, addMessageToStdErr: true, expectedOutcome: true);
+            TestWrapperErrorHandling(executeResult: true, addMessageToStdErr: true, expectedOutcome: true);
         }
 
         [TestMethod]
         public void WrapperError_Fail_NoStdErr()
         {
-            TestWrapperErrorHandling(exitCode: FailureExitCode, addMessageToStdErr: false, expectedOutcome: false);
+            TestWrapperErrorHandling(executeResult: false, addMessageToStdErr: false, expectedOutcome: false);
         }
 
         [TestMethod]
         public void WrapperError_Fail_StdErr()
         {
-            TestWrapperErrorHandling(exitCode: FailureExitCode, addMessageToStdErr: true, expectedOutcome: false);
+            TestWrapperErrorHandling(executeResult: false, addMessageToStdErr: true, expectedOutcome: false);
         }
 
-        private void TestWrapperErrorHandling(int? exitCode, bool addMessageToStdErr, bool expectedOutcome)
+        private void TestWrapperErrorHandling(bool executeResult, bool addMessageToStdErr, bool expectedOutcome)
         {
             // Arrange
             var logger = new TestLogger();
-            var exePath = CreateDummarySonarScannerBatchFile(addMessageToStdErr, exitCode);
-            var propertiesFilePath = CreateDummySonarScannerPropertiesFile();
-            var config = new AnalysisConfig() { SonarScannerWorkingDirectory = TestUtils.CreateTestSpecificFolder(TestContext) };
+            var mockRunner = new MockProcessRunner(executeResult);
+
+            var config = new AnalysisConfig() { SonarScannerWorkingDirectory = "C:\\working" };
+
+            if (addMessageToStdErr)
+            {
+                logger.LogError("Dummy error");
+            }
 
             // Act
-            var success = SonarScannerWrapper.ExecuteJavaRunner(config, Enumerable.Empty<string>(), logger, exePath, propertiesFilePath);
+            var success = ExecuteJavaRunnerIgnoringAsserts(config, Enumerable.Empty<string>(), logger, "c:\\bar.exe", "c:\\props.xml", mockRunner);
 
             // Assert
-            VerifyProcessRunOutcome(logger, TestUtils.CreateTestSpecificFolder(TestContext), success, expectedOutcome);
+            VerifyProcessRunOutcome(mockRunner, logger, "C:\\working", success, expectedOutcome);
         }
 
         #endregion Tests
 
         #region Private methods
 
-        private string CreateDummarySonarScannerBatchFile(bool addMessageToStdErr = false, int? exitCode = null)
+        private static bool ExecuteJavaRunnerIgnoringAsserts(AnalysisConfig config, IEnumerable<string> userCmdLineArguments, ILogger logger, string exeFileName, string propertiesFileName, IProcessRunner runner)
         {
-            // Create a batch file that echoes the command line args to the console
-            // so they can be captured and checked
-            var testDir = TestUtils.CreateTestSpecificFolder(TestContext);
-            var exePath = Path.Combine(testDir, "dummy.scanner.bat");
-
-            File.Exists(exePath).Should().BeFalse("Not expecting a batch file to already exist: {0}", exePath);
-
-            var sb = new StringBuilder();
-            sb.AppendLine("@echo " + ExpectedConsoleMessagePrefix + " %* \n @echo WorkingDir: %cd%");
-
-            if (addMessageToStdErr)
+            using (new AssertIgnoreScope())
             {
-                sb.AppendLine("echo some_error_message 1>&2");
+                return SonarScannerWrapper.ExecuteJavaRunner(config, userCmdLineArguments, logger, exeFileName, propertiesFileName, runner);
             }
-
-            if (exitCode.HasValue)
-            {
-                sb.AppendLine("exit " + exitCode.Value);
-            }
-
-            File.WriteAllText(exePath, sb.ToString());
-            return exePath;
-        }
-
-        private string CreateDummySonarScannerPropertiesFile()
-        {
-            var testDir = TestUtils.CreateTestSpecificFolder(TestContext);
-            var propertiesFilePath = Path.Combine(testDir, "analysis.properties");
-            File.CreateText(propertiesFilePath);
-            return propertiesFilePath;
         }
 
         #endregion Private methods
 
         #region Checks
 
-        private static void VerifyProcessRunOutcome(TestLogger testLogger, string expectedWorkingDir, bool actualOutcome, bool expectedOutcome)
+        private static void VerifyProcessRunOutcome(MockProcessRunner mockRunner, TestLogger testLogger, string expectedWorkingDir, bool actualOutcome, bool expectedOutcome)
         {
-            actualOutcome.Should().Be(expectedOutcome, "Expecting execution to succeed");
-            testLogger.AssertInfoMessageExists(ExpectedConsoleMessagePrefix);
-            testLogger.AssertInfoMessageExists(expectedWorkingDir);
+            actualOutcome.Should().Be(expectedOutcome);
+
+            mockRunner.SuppliedArguments.WorkingDirectory.Should().Be(expectedWorkingDir);
 
             if (!actualOutcome)
             {
@@ -320,24 +281,27 @@ namespace SonarScanner.MSBuild.Shim.Tests
             }
         }
 
-        private static string CheckStandardArgsPassed(TestLogger logger, string expectedPropertiesFilePath)
+        private void CheckStandardArgsPassed(MockProcessRunner mockRunner, string expectedPropertiesFilePath)
         {
-            var message = logger.AssertSingleInfoMessageExists(ExpectedConsoleMessagePrefix);
-
-            CheckArgExists("-Dproject.settings=" + expectedPropertiesFilePath, message); // should always be passing the properties file
-
-            return message;
+            CheckArgExists("-Dproject.settings=" + expectedPropertiesFilePath, mockRunner); // should always be passing the properties file
         }
 
-        private static int CheckArgExists(string expectedArg, string allArgs)
+        /// <summary>
+        /// Checks that the argument exists, and returns the start position of the argument in the list of
+        /// concatenated arguments so we can check that the arguments are passed in the correct order
+        /// </summary>
+        private int CheckArgExists(string expectedArg, MockProcessRunner mockRunner)
         {
+            var allArgs = string.Join(" ", mockRunner.SuppliedArguments.CmdLineArgs);
             var index = allArgs.IndexOf(expectedArg);
             index.Should().BeGreaterThan(-1, "Expected argument was not found. Arg: '{0}', all args: '{1}'", expectedArg, allArgs);
             return index;
+
         }
 
-        private static void CheckArgDoesNotExist(string argToCheck, string allArgs)
+        private static void CheckArgDoesNotExist(string argToCheck, MockProcessRunner mockRunner)
         {
+            string allArgs = mockRunner.SuppliedArguments.GetEscapedArguments();
             var index = allArgs.IndexOf(argToCheck);
             index.Should().Be(-1, "Not expecting to find the argument. Arg: '{0}', all args: '{1}'", argToCheck, allArgs);
         }

--- a/src/SonarScanner.MSBuild.Common/Interfaces/IProcessRunner.cs
+++ b/src/SonarScanner.MSBuild.Common/Interfaces/IProcessRunner.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarScanner.MSBuild.Common
+{
+    public interface IProcessRunner
+    {
+        bool Execute(ProcessRunnerArguments runnerArgs);
+    }
+}

--- a/src/SonarScanner.MSBuild.Common/ProcessRunner.cs
+++ b/src/SonarScanner.MSBuild.Common/ProcessRunner.cs
@@ -28,7 +28,7 @@ namespace SonarScanner.MSBuild.Common
     /// <summary>
     /// Helper class to run an executable and capture the output
     /// </summary>
-    public sealed class ProcessRunner
+    public sealed class ProcessRunner : IProcessRunner
     {
         public const int ErrorCode = 1;
 

--- a/src/SonarScanner.MSBuild.Shim/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.Shim/Resources.Designer.cs
@@ -96,7 +96,7 @@ namespace SonarScanner.MSBuild.Shim {
         ///  1. The project has not been built - the project must be built in between the begin and end steps
         ///  2. An unsupported version of MSBuild has been used to build the project. Currently MSBuild 14.0 and 15.0 are supported
         ///  3. The begin, build and end steps have not all been launched from the same folder
-        ///  4. None of the analyzed projects have a valid ProjectGuid and you [rest of string was truncated]&quot;;.
+        ///  4. None of the analyzed projects have a valid ProjectGuid and yo [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ERR_NoProjectInfoFilesFound {
             get {
@@ -249,20 +249,11 @@ namespace SonarScanner.MSBuild.Shim {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is already set. Value: {1}.
+        ///   Looks up a localized string similar to Using the supplied value for {0}. Value: {1}.
         /// </summary>
-        internal static string MSG_SonarScannerOptsAlreadySet {
+        internal static string MSG_UsingSuppliedSonarScannerOptsValue {
             get {
-                return ResourceManager.GetString("MSG_SonarScannerOptsAlreadySet", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} is not configured. Setting it to the default value of {1}.
-        /// </summary>
-        internal static string MSG_SonarScannerOptsDefaultUsed {
-            get {
-                return ResourceManager.GetString("MSG_SonarScannerOptsDefaultUsed", resourceCulture);
+                return ResourceManager.GetString("MSG_UsingSuppliedSonarScannerOptsValue", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.Shim/Resources.resx
+++ b/src/SonarScanner.MSBuild.Shim/Resources.resx
@@ -155,11 +155,8 @@ Possible causes:
   <data name="ERR_SonarScannerExecutionFailed" xml:space="preserve">
     <value>The SonarQube Scanner did not complete successfully</value>
   </data>
-  <data name="MSG_SonarScannerOptsDefaultUsed" xml:space="preserve">
-    <value>{0} is not configured. Setting it to the default value of {1}</value>
-  </data>
-  <data name="MSG_SonarScannerOptsAlreadySet" xml:space="preserve">
-    <value>{0} is already set. Value: {1}</value>
+  <data name="MSG_UsingSuppliedSonarScannerOptsValue" xml:space="preserve">
+    <value>Using the supplied value for {0}. Value: {1}</value>
   </data>
   <data name="REPORT_ExcludedProjectsTitle" xml:space="preserve">
     <value>Excluded projects</value>

--- a/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
@@ -114,7 +114,7 @@ namespace SonarScanner.MSBuild.Shim
             }
 
             var exeFileName = FindScannerExe();
-            return ExecuteJavaRunner(config, userCmdLineArguments, logger, exeFileName, fullPropertiesFilePath);
+            return ExecuteJavaRunner(config, userCmdLineArguments, logger, exeFileName, fullPropertiesFilePath, new ProcessRunner(logger));
         }
 
         private static string FindScannerExe()
@@ -124,7 +124,7 @@ namespace SonarScanner.MSBuild.Shim
             return Path.Combine(binFolder, $"sonar-scanner-{SonarScannerVersion}", "bin", $"sonar-scanner{fileExtension}");
         }
 
-        public /* for test purposes */ static bool ExecuteJavaRunner(AnalysisConfig config, IEnumerable<string> userCmdLineArguments, ILogger logger, string exeFileName, string propertiesFileName)
+        public /* for test purposes */ static bool ExecuteJavaRunner(AnalysisConfig config, IEnumerable<string> userCmdLineArguments, ILogger logger, string exeFileName, string propertiesFileName, IProcessRunner runner)
         {
             Debug.Assert(File.Exists(exeFileName), "The specified exe file does not exist: " + exeFileName);
             Debug.Assert(File.Exists(propertiesFileName), "The specified properties file does not exist: " + propertiesFileName);
@@ -147,8 +147,6 @@ namespace SonarScanner.MSBuild.Shim
                 WorkingDirectory = config.SonarScannerWorkingDirectory,
                 EnvironmentVariables = envVarsDictionary
             };
-
-            var runner = new ProcessRunner(logger);
 
             // SONARMSBRU-202 Note that the Sonar Scanner may write warnings to stderr so
             // we should only rely on the exit code when deciding if it ran successfully

--- a/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
@@ -46,12 +46,6 @@ namespace SonarScanner.MSBuild.Shim
         /// </summary>
         public const string ProjectSettingsFileArgName = "project.settings";
 
-        /// <summary>
-        /// Default value for the SONAR_SCANNER_OPTS
-        /// </summary>
-        /// <remarks>Reserving more than is available on the agent will cause the sonar-scanner to fail</remarks>
-        private const string SonarScannerOptsDefaultValue = "-Xmx1024m";
-
         private const string CmdLineArgPrefix = "-D";
 
         // This version needs to be in sync with version in src/Packaging/Directory.Build.props.
@@ -181,32 +175,16 @@ namespace SonarScanner.MSBuild.Shim
         {
             IDictionary<string, string> envVarsDictionary = new Dictionary<string, string>();
 
-            // Always set a value for SONAR_SCANNER_OPTS just in case it is set at process-level
-            // which wouldn't be inherited by the child sonar-scanner process.
-            var sonarScannerOptsValue = GetSonarScannerOptsValue(logger);
-            envVarsDictionary.Add(SonarScannerOptsVariableName, sonarScannerOptsValue);
+            // If there is a value for SONAR_SCANNER_OPTS then pass it through explicitly just in case it is
+            // set at process-level (which wouldn't otherwise be inherited by the child sonar-scanner process)
+            var sonarScannerOptsValue = Environment.GetEnvironmentVariable(SonarScannerOptsVariableName);
+            if (sonarScannerOptsValue != null)
+            {
+                envVarsDictionary.Add(SonarScannerOptsVariableName, sonarScannerOptsValue);
+                logger.LogInfo(Resources.MSG_UsingSuppliedSonarScannerOptsValue, SonarScannerOptsVariableName, sonarScannerOptsValue);
+            }
 
             return envVarsDictionary;
-        }
-
-        /// <summary>
-        /// Get the value of the SONAR_SCANNER_OPTS variable that controls the amount of memory available to the JDK so that the sonar-scanner doesn't
-        /// hit OutOfMemory exceptions. If no env variable with this name is defined then a default value is used.
-        /// </summary>
-        private static string GetSonarScannerOptsValue(ILogger logger)
-        {
-            var existingValue = Environment.GetEnvironmentVariable(SonarScannerOptsVariableName);
-
-            if (!string.IsNullOrWhiteSpace(existingValue))
-            {
-                logger.LogInfo(Resources.MSG_SonarScannerOptsAlreadySet, SonarScannerOptsVariableName, existingValue);
-                return existingValue;
-            }
-            else
-            {
-                logger.LogInfo(Resources.MSG_SonarScannerOptsDefaultUsed, SonarScannerOptsVariableName, SonarScannerOptsDefaultValue);
-                return SonarScannerOptsDefaultValue;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fix #656 

I suggest reviewing the commits separately. The first is a refactoring of the existing tests so they don't execute a batch file as part of the test.
The second commit is the actual fix, and is much simpler.