### PR TITLE
[DO NOT MERGE] Adding SonarQube.Client as submodule in sonarqube-webclient

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sonarqube-webclient"]
+	path = sonarqube-webclient
+	url = https://github.com/sonarsource/sonarqube-webclient-dotnet

--- a/SonarScanner.MSBuild.sln
+++ b/SonarScanner.MSBuild.sln
@@ -52,6 +52,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SonarScanner.MSBuild", "src
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Legacy", "Legacy", "{631622D0-344F-4390-B80A-2227E015A261}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SonarQube.Client", "sonarqube-webclient\SonarQube.Client\SonarQube.Client.csproj", "{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SonarQube.Client.Tests", "sonarqube-webclient\SonarQube.Client.Tests\SonarQube.Client.Tests.csproj", "{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -272,6 +276,30 @@ Global
 		{B9F6FCA4-CD6C-4426-9835-D86160B30072}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{B9F6FCA4-CD6C-4426-9835-D86160B30072}.Release|x86.ActiveCfg = Release|Any CPU
 		{B9F6FCA4-CD6C-4426-9835-D86160B30072}.Release|x86.Build.0 = Release|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Debug|x86.Build.0 = Debug|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Release|x86.ActiveCfg = Release|Any CPU
+		{5E513FC3-BDA7-40F2-8B6A-1BB9372ACB99}.Release|x86.Build.0 = Release|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Debug|x86.Build.0 = Debug|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Release|x86.ActiveCfg = Release|Any CPU
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -289,6 +317,7 @@ Global
 		{BF55995C-B05B-44D0-B80E-2366CC5ACCDE} = {E04A4D31-AC10-4F56-9678-5D538932578C}
 		{6E599202-77D0-41CD-9AFF-7450DC83A85C} = {37FB4C72-0F3D-4BF2-9F78-2780A76746A2}
 		{35848C6E-2018-4831-94FA-40D7E45B5A09} = {631622D0-344F-4390-B80A-2227E015A261}
+		{8FEFDB82-CBDB-4B52-B221-BB604DFD60E6} = {E04A4D31-AC10-4F56-9678-5D538932578C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F1322FF5-8DA8-4714-ABD1-B289A655E630}

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/DataModel/QualityProfile.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/DataModel/QualityProfile.cs
@@ -19,7 +19,7 @@
  */
 
 using System.Collections.Generic;
-using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
+using SonarQube.Client.Models;
 
 namespace SonarScanner.MSBuild.PreProcessor.Tests
 {
@@ -33,8 +33,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             Language = language;
             Organization = organization;
             this.projectIds = new HashSet<string>();
-            InactiveRules = new List<SonarRule>();
-            ActiveRules = new List<SonarRule>();
+            InactiveRules = new List<SonarQubeRule>();
+            ActiveRules = new List<SonarQubeRule>();
         }
 
         public QualityProfile AddProject(string projectKey, string projectBranch = null)
@@ -49,13 +49,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             return this;
         }
 
-        public QualityProfile AddRule(SonarRule rule)
+        public QualityProfile AddRule(SonarQubeRule rule)
         {
             ActiveRules.Add(rule);
             return this;
         }
 
-        public QualityProfile AddInactiveRule(SonarRule rule)
+        public QualityProfile AddInactiveRule(SonarQubeRule rule)
         {
             InactiveRules.Add(rule);
             return this;
@@ -65,7 +65,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         public string Language { get; }
         public string Organization { get; }
         public IEnumerable<string> Projects { get { return this.projectIds; } }
-        public IList<SonarRule> ActiveRules { get; }
-        public IList<SonarRule> InactiveRules { get; }
+        public IList<SonarQubeRule> ActiveRules { get; }
+        public IList<SonarQubeRule> InactiveRules { get; }
     }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/DataModel/ServerDataModel.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/DataModel/ServerDataModel.cs
@@ -24,7 +24,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using FluentAssertions;
-using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
+using SonarQube.Client.Models;
 using TestUtilities;
 
 namespace SonarScanner.MSBuild.PreProcessor.Tests
@@ -63,13 +63,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             return profile;
         }
 
-        public void AddActiveRuleToProfile(string qProfile, SonarRule rule)
+        public void AddActiveRuleToProfile(string qProfile, SonarQubeRule rule)
         {
             var profile = FindProfile(qProfile);
             profile.ActiveRules.Add(rule);
         }
 
-        public void AddInactiveRuleToProfile(string qProfile, SonarRule rule)
+        public void AddInactiveRuleToProfile(string qProfile, SonarQubeRule rule)
         {
             var profile = FindProfile(qProfile);
             profile.InactiveRules.Add(rule);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/MockRoslynAnalyzerProvider.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/MockRoslynAnalyzerProvider.cs
@@ -20,8 +20,8 @@
 
 using System.Collections.Generic;
 using FluentAssertions;
+using SonarQube.Client.Models;
 using SonarScanner.MSBuild.Common;
-using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
 using SonarScanner.MSBuild.TFS;
 
 namespace SonarScanner.MSBuild.PreProcessor.Tests
@@ -37,7 +37,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         #region IAnalyzerProvider methods
 
         AnalyzerSettings IAnalyzerProvider.SetupAnalyzer(TeamBuildSettings settings, IDictionary<string, string> serverSettings,
-            IEnumerable<SonarRule> activeRules, IEnumerable<SonarRule> inactiveRules, string language)
+            IEnumerable<SonarQubeRule> activeRules, IEnumerable<SonarQubeRule> inactiveRules, string language)
         {
             settings.Should().NotBeNull();
             serverSettings.Should().NotBeNull();

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/MockSonarQubeServer.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/MockSonarQubeServer.cs
@@ -24,7 +24,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using FluentAssertions;
-using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
+using SonarQube.Client.Models;
 
 namespace SonarScanner.MSBuild.PreProcessor.Tests
 {
@@ -52,7 +52,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
         #region ISonarQubeServer methods
 
-        IList<SonarRule> ISonarQubeServer.GetActiveRules(string qprofile)
+        IList<SonarQubeRule> ISonarQubeServer.GetActiveRules(string qprofile)
         {
             LogMethodCalled();
 
@@ -66,7 +66,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             return profile.ActiveRules;
         }
 
-        IList<SonarRule> ISonarQubeServer.GetInactiveRules(string qprofile, string language)
+        IList<SonarQubeRule> ISonarQubeServer.GetInactiveRules(string qprofile, string language)
         {
             LogMethodCalled();
             qprofile.Should().NotBeNullOrEmpty("Quality profile is required");

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/PreProcessorTests.cs
@@ -24,8 +24,8 @@ using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using SonarQube.Client.Models;
 using SonarScanner.MSBuild.Common;
-using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
 using SonarScanner.MSBuild.TFS;
 using TestUtilities;
 
@@ -80,11 +80,11 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
             data.AddQualityProfile("qp1", "cs", null)
                 .AddProject("key")
-                .AddRule(new SonarRule("csharpsquid", "cs.rule3"));
+                .AddRule(new SonarQubeRule("cs.rule3", "csharpsquid", true));
 
             data.AddQualityProfile("qp2", "vbnet", null)
                 .AddProject("key")
-                .AddRule(new SonarRule("vbnet", "vb.rule3"));
+                .AddRule(new SonarQubeRule("vb.rule3", "vbnet", true));
 
             var mockAnalyzerProvider = new MockRoslynAnalyzerProvider
             {
@@ -154,7 +154,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
             data.AddQualityProfile("qp2", "vbnet", null)
                 .AddProject("key")
-                .AddRule(new SonarRule("vbnet", "vb.rule3"));
+                .AddRule(new SonarQubeRule("vb.rule3", "vbnet", true));
 
             var mockAnalyzerProvider = new MockRoslynAnalyzerProvider
             {
@@ -221,11 +221,11 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
             data.AddQualityProfile("qp1", "cs", "organization")
                 .AddProject("key")
-                .AddRule(new SonarRule("csharpsquid", "cs.rule3"));
+                .AddRule(new SonarQubeRule("cs.rule3", "csharpsquid", true));
 
             data.AddQualityProfile("qp2", "vbnet", "organization")
                 .AddProject("key")
-                .AddRule(new SonarRule("vbnet", "vb.rule3"));
+                .AddRule(new SonarQubeRule("vb.rule3", "vbnet", true));
 
             var mockAnalyzerProvider = new MockRoslynAnalyzerProvider
             {
@@ -342,13 +342,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
             data.AddQualityProfile("qp1", "cs", null)
                 .AddProject("invalid")
-                .AddRule(new SonarRule("fxcop", "cs.rule1"))
-                .AddRule(new SonarRule("fxcop", "cs.rule2"));
+                .AddRule(new SonarQubeRule("cs.rule1", "fxcop", true))
+                .AddRule(new SonarQubeRule("cs.rule2", "fxcop", true));
 
             data.AddQualityProfile("qp2", "vbnet", null)
                 .AddProject("invalid")
-                .AddRule(new SonarRule("fxcop-vbnet", "vb.rule1"))
-                .AddRule(new SonarRule("fxcop-vbnet", "vb.rule2"));
+                .AddRule(new SonarQubeRule("vb.rule1", "fxcop-vbnet", true))
+                .AddRule(new SonarQubeRule("vb.rule2", "fxcop-vbnet", true));
 
             var mockAnalyzerProvider = new MockRoslynAnalyzerProvider
             {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/RoslynAnalyzerProviderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/RoslynAnalyzerProviderTests.cs
@@ -25,9 +25,9 @@ using System.Linq;
 using System.Xml;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarQube.Client.Models;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.PreProcessor.Roslyn;
-using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
 using SonarScanner.MSBuild.TFS;
 using TestUtilities;
 
@@ -54,8 +54,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         {
             // Arrange
             var logger = new TestLogger();
-            IList<SonarRule> activeRules = new List<SonarRule>();
-            IList<SonarRule> inactiveRules = new List<SonarRule>();
+            var activeRules = new List<SonarQubeRule>();
+            var inactiveRules = new List<SonarQubeRule>();
             var pluginKey = RoslynAnalyzerProvider.CSharpPluginKey;
             IDictionary<string, string> serverSettings = new Dictionary<string, string>();
             var settings = CreateSettings(TestUtils.CreateTestSpecificFolder(TestContext));
@@ -80,8 +80,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         {
             // Arrange
             var logger = new TestLogger();
-            IList<SonarRule> activeRules = new List<SonarRule>();
-            IList<SonarRule> inactiveRules = new List<SonarRule>();
+            var activeRules = new List<SonarQubeRule>();
+            var inactiveRules = new List<SonarQubeRule>();
             var pluginKey = "csharp";
             IDictionary<string, string> serverSettings = new Dictionary<string, string>();
             var settings = CreateSettings(TestUtils.CreateTestSpecificFolder(TestContext));
@@ -98,8 +98,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             // Arrange
             var rootFolder = CreateTestFolders();
             var logger = new TestLogger();
-            IList<SonarRule> activeRules = createActiveRules();
-            IList<SonarRule> inactiveRules = createInactiveRules();
+            var activeRules = createActiveRules();
+            var inactiveRules = createInactiveRules();
             var language = RoslynAnalyzerProvider.CSharpLanguage;
 
             // missing properties to get plugin related properties
@@ -145,8 +145,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             // Arrange
             var rootFolder = CreateTestFolders();
             var logger = new TestLogger();
-            IList<SonarRule> activeRules = createActiveRules();
-            IList<SonarRule> inactiveRules = createInactiveRules();
+            var activeRules = createActiveRules();
+            var inactiveRules = createInactiveRules();
             var language = RoslynAnalyzerProvider.CSharpLanguage;
             var mockInstaller = new MockAnalyzerInstaller
             {
@@ -179,16 +179,16 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
         #region Private methods
 
-        private List<SonarRule> createInactiveRules()
+        private List<SonarQubeRule> createInactiveRules()
         {
-            var list = new List<SonarRule>
+            var list = new List<SonarQubeRule>
             {
-                new SonarRule("csharpsquid", "S1000", false)
+                new SonarQubeRule("S1000", "csharpsquid", false)
             };
             return list;
         }
 
-        private List<SonarRule> createActiveRules()
+        private List<SonarQubeRule> createActiveRules()
         {
             /*
             <Rules AnalyzerId=""SonarLint.CSharp"" RuleNamespace=""SonarLint.CSharp"">
@@ -199,16 +199,14 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
               <Rule Id=""Wintellect003"" Action=""Warning""/>
             </Rules>
             */
-            var rules = new List<SonarRule>();
-            var ruleWithParameter = new SonarRule("csharpsquid", "S1116", true);
-            var p = new Dictionary<string, string>
+            var rules = new List<SonarQubeRule>();
+            var ruleWithParameter = new SonarQubeRule("S1116", "csharpsquid", true, new Dictionary<string, string>
             {
                 { "key", "value" }
-            };
-            ruleWithParameter.Parameters = p;
+            });
             rules.Add(ruleWithParameter);
-            rules.Add(new SonarRule("csharpsquid", "S1125", true));
-            rules.Add(new SonarRule("roslyn.wintellect", "Wintellect003", true));
+            rules.Add(new SonarQubeRule("S1125", "csharpsquid", true));
+            rules.Add(new SonarQubeRule("Wintellect003", "roslyn.wintellect", true));
 
             return rules;
         }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/RoslynRuleSetGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/RoslynRuleSetGeneratorTests.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarQube.Client.Models;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
 
@@ -47,8 +48,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         {
             IDictionary<string, string> dict = new Dictionary<string, string>();
             var generator = new RoslynRuleSetGenerator(dict);
-            IEnumerable<SonarRule> activeRules = new List<SonarRule>();
-            IEnumerable<SonarRule> inactiveRules = new List<SonarRule>();
+            var activeRules = new List<SonarQubeRule>();
+            var inactiveRules = new List<SonarQubeRule>();
             var language = "cs";
 
             Action act1 = () => generator.Generate(activeRules, inactiveRules, null);
@@ -66,10 +67,10 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         {
             IDictionary<string, string> dict = new Dictionary<string, string>();
             var generator = new RoslynRuleSetGenerator(dict);
-            var activeRules = new List<SonarRule>();
-            IEnumerable<SonarRule> inactiveRules = new List<SonarRule>();
+            var activeRules = new List<SonarQubeRule>();
+            var inactiveRules = new List<SonarQubeRule>();
             var language = "cs";
-            activeRules.Add(new SonarRule("repo", "key"));
+            activeRules.Add(new SonarQubeRule("key", "repo", true));
 
             var ruleSet = generator.Generate(activeRules, inactiveRules, language);
             // No analyzer
@@ -98,17 +99,17 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             };
 
             var generator = new RoslynRuleSetGenerator(dict);
-            var activeRules = new List<SonarRule>();
-            var inactiveRules = new List<SonarRule>();
+            var activeRules = new List<SonarQubeRule>();
+            var inactiveRules = new List<SonarQubeRule>();
             var language = "cs";
 
-            activeRules.Add(new SonarRule("csharpsquid", "S1000", true));
-            activeRules.Add(new SonarRule("csharpsquid", "S1001", true));
-            activeRules.Add(new SonarRule("roslyn.custom", "custom", "custom.internal", true));
-            activeRules.Add(new SonarRule("other.repo", "other.rule", true));
+            activeRules.Add(new SonarQubeRule("S1000", "csharpsquid", true));
+            activeRules.Add(new SonarQubeRule("S1001", "csharpsquid", true));
+            activeRules.Add(new SonarQubeRule("custom", "roslyn.custom", true));
+            activeRules.Add(new SonarQubeRule("other.rule", "other.repo", true));
 
-            inactiveRules.Add(new SonarRule("csharpsquid", "S1002", false));
-            inactiveRules.Add(new SonarRule("roslyn.custom", "S1005", false));
+            inactiveRules.Add(new SonarQubeRule("S1002", "csharpsquid", false));
+            inactiveRules.Add(new SonarQubeRule("S1005", "roslyn.custom", false));
 
             var ruleSet = generator.Generate(activeRules, inactiveRules, language);
             string[] activatedCSharp = { "S1000", "S1001" };

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/SonarQubeServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/SonarQubeServerTest.cs
@@ -1,0 +1,331 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using SonarQube.Client;
+using SonarQube.Client.Models;
+using SonarScanner.MSBuild.Common;
+using TestUtilities;
+
+namespace SonarScanner.MSBuild.PreProcessor.Tests
+{
+    [TestClass]
+    public class SonarQubeServerTest
+    {
+        private Mock<ISonarQubeService> serviceMock;
+        private TestLogger logger;
+        private Mock<IFileWrapper> fileWrapperMock;
+        private SonarQubeServer server;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            logger = new TestLogger();
+
+            var connectionInfo = new ConnectionInformation(new Uri("http://localhost"));
+
+            serviceMock = new Mock<ISonarQubeService>(MockBehavior.Strict);
+
+            serviceMock.Setup(x => x.ConnectAsync(connectionInfo, It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            fileWrapperMock = new Mock<IFileWrapper>();
+
+            server = new SonarQubeServer(serviceMock.Object, connectionInfo, logger);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            serviceMock.VerifyAll();
+        }
+
+        [TestMethod]
+        public void GetServerVersion_Returns_Version()
+        {
+            serviceMock
+                .SetupGet(x => x.SonarQubeVersion)
+                .Returns(new Version("1.2.3"));
+
+            var result = server.GetServerVersion();
+
+            result.Major.Should().Be(1);
+            result.Minor.Should().Be(2);
+            result.Revision.Should().Be(3);
+        }
+
+        [TestMethod]
+        public void GetActiveRules_Throws_HttpRequestException()
+        {
+            serviceMock
+                .Setup(x => x.GetRulesAsync(true, "quality-profile", CancellationToken.None))
+                .Throws(GetHttpRequestException(HttpStatusCode.NotFound));
+
+            var action = new Action(() => server.GetActiveRules("quality-profile"));
+
+            action.Should().ThrowExactly<HttpRequestException>();
+
+            logger.Warnings.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetActiveRules_Returns_Rules()
+        {
+            IList<SonarQubeRule> rules = new []
+            {
+                new SonarQubeRule("rule1", "repo1", true),
+                new SonarQubeRule("rule2", "repo2", true),
+            };
+
+            serviceMock
+                .Setup(x => x.GetRulesAsync(true, "quality-profile", CancellationToken.None))
+                .Returns(Task.FromResult(rules));
+
+            server.GetActiveRules("quality-profile").Should().BeEquivalentTo(rules);
+        }
+
+        [TestMethod]
+        public void GetInactiveRules_Throws_HttpRequestException()
+        {
+            serviceMock
+                .Setup(x => x.GetRulesAsync(false, "quality-profile", CancellationToken.None))
+                .Throws(GetHttpRequestException(HttpStatusCode.NotFound));
+
+            var action = new Action(() => server.GetInactiveRules("quality-profile", "ignored"));
+
+            action.Should().ThrowExactly<HttpRequestException>();
+
+            logger.Warnings.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetInactiveRules_Returns_Rules()
+        {
+            IList<SonarQubeRule> rules = new[]
+            {
+                new SonarQubeRule("rule1", "repo1", false),
+                new SonarQubeRule("rule2", "repo2", false),
+            };
+
+            serviceMock
+                .Setup(x => x.GetRulesAsync(false, "quality-profile", CancellationToken.None))
+                .Returns(Task.FromResult(rules));
+
+            server.GetInactiveRules("quality-profile", "ignored").Should().BeEquivalentTo(rules);
+        }
+
+        [TestMethod]
+        public void GetAllLanguages_Throws_HttpRequestException()
+        {
+            serviceMock
+                .Setup(x => x.GetAllLanguagesAsync(CancellationToken.None))
+                .Throws(GetHttpRequestException(HttpStatusCode.NotFound));
+
+            var action = new Action(() => server.GetAllLanguages());
+
+            action.Should().ThrowExactly<HttpRequestException>();
+
+            logger.Warnings.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetAllLanguages_Returns_Languages()
+        {
+            IList<SonarQubeLanguage> languages = new[]
+            {
+                new SonarQubeLanguage("csharp", "C#"),
+                new SonarQubeLanguage("vbnet", "VB.NET"),
+            };
+
+            serviceMock
+                .Setup(x => x.GetAllLanguagesAsync(CancellationToken.None))
+                .Returns(Task.FromResult(languages));
+
+            var result = server.GetAllLanguages();
+
+            result.Should().BeEquivalentTo("csharp", "vbnet");
+
+            logger.Warnings.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetAllLanguages_Returns_Null()
+        {
+            // This should never happen, ISonarQubeService is not supposed to return null.
+            // We code it defensively, though.
+            serviceMock
+                .Setup(x => x.GetAllLanguagesAsync(CancellationToken.None))
+                .Returns(Task.FromResult((IList<SonarQubeLanguage>)null));
+
+            var result = server.GetAllLanguages();
+
+            result.Should().BeNull();
+
+            logger.Warnings.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetProperties_Throws_HttpRequestException_Forbidden()
+        {
+            serviceMock
+                .Setup(x => x.GetAllPropertiesAsync("project-key:branch", CancellationToken.None))
+                .Throws(GetHttpRequestException(HttpStatusCode.Forbidden));
+
+            var action = new Action(() => server.GetProperties("project-key", "branch"));
+
+            action.Should().ThrowExactly<HttpRequestException>();
+
+            logger.Warnings.Should()
+                .Contain("To analyze private projects make sure the scanner user has 'Browse' permission.");
+        }
+
+        [TestMethod]
+        public void GetProperties_Throws_HttpRequestException_Other()
+        {
+            serviceMock
+                .Setup(x => x.GetRulesAsync(false, "quality-profile", CancellationToken.None))
+                .Throws(GetHttpRequestException(HttpStatusCode.NotFound));
+
+            var action = new Action(() => server.GetInactiveRules("quality-profile", "ignored"));
+
+            action.Should().ThrowExactly<HttpRequestException>();
+
+            logger.Warnings.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void GetProperties_Returns_Properties()
+        {
+            IList<SonarQubeProperty> properties = new[]
+            {
+                new SonarQubeProperty("key1", "value1"),
+                new SonarQubeProperty("key2", "value2"),
+            };
+
+            serviceMock
+                .Setup(x => x.GetAllPropertiesAsync("project-key:branch-name", CancellationToken.None))
+                .Returns(Task.FromResult(properties));
+
+            var result = server.GetProperties("project-key", "branch-name");
+
+            result.Keys.Should().BeEquivalentTo("key1", "key2");
+            result.Values.Should().BeEquivalentTo("value1", "value2");
+        }
+
+        [TestMethod]
+        public void GetProperties_Service_Returns_Null()
+        {
+            // This should never happen, ISonarQubeService is not supposed to return null.
+            // We code it defensively, though.
+            serviceMock
+                .Setup(x => x.GetAllPropertiesAsync("project-key:branch-name", CancellationToken.None))
+                .Returns(Task.FromResult<IList<SonarQubeProperty>>(null));
+
+            var result = server.GetProperties("project-key", "branch-name");
+
+            result.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void GetProperties_TestProjectPattern_Old_Property_Replaced()
+        {
+            IList<SonarQubeProperty> properties = new[]
+            {
+                // This is the old, deprecated property key, it should be replaced with a new one
+                new SonarQubeProperty("sonar.cs.msbuild.testProjectPattern", "some pattern"),
+            };
+
+            serviceMock
+                .Setup(x => x.GetAllPropertiesAsync("project-key:branch-name", CancellationToken.None))
+                .Returns(Task.FromResult(properties));
+
+            var result = server.GetProperties("project-key", "branch-name");
+
+            result.Keys.Should().BeEquivalentTo("sonar.msbuild.testProjectPattern"); // used to be "sonar.cs.msbuild.testProjectPattern"
+            result.Values.Should().BeEquivalentTo("some pattern");
+
+            logger.Warnings.Should()
+                .Contain("The property 'sonar.cs.msbuild.testProjectPattern' defined in SonarQube is deprecated. Set the property 'sonar.msbuild.testProjectPattern' in the scanner instead.");
+        }
+
+        [TestMethod]
+        public void TryDownloadEmbeddedFile_Throws_HttpRequestException_NotFound()
+        {
+            serviceMock
+                .Setup(x => x.DownloadStaticFileAsync("plugin-key", "file-name.ext", CancellationToken.None))
+                .Throws(GetHttpRequestException(HttpStatusCode.NotFound));
+
+            var result = server.TryDownloadEmbeddedFile("plugin-key", "file-name.ext", "ignored");
+
+            result.Should().BeFalse();
+
+            logger.Warnings.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void TryDownloadEmbeddedFile_Throws_HttpRequestException_Other()
+        {
+            serviceMock
+                .Setup(x => x.DownloadStaticFileAsync("plugin-key", "file-name.ext", CancellationToken.None))
+                .Throws(GetHttpRequestException(HttpStatusCode.Forbidden));
+
+            var action = new Action(() => server.TryDownloadEmbeddedFile("plugin-key", "file-name.ext", "ignored"));
+
+            action.Should().ThrowExactly<HttpRequestException>();
+
+            logger.Warnings.Should().BeEmpty();
+        }
+
+        [TestMethod]
+        public void TryDownloadEmbeddedFile_Throws_HttpRequestException_Other()
+        {
+            serviceMock
+                .Setup(x => x.DownloadStaticFileAsync("plugin-key", "file-name.ext", CancellationToken.None))
+                .Throws(GetHttpRequestException(HttpStatusCode.Forbidden));
+
+            var action = new Action(() => server.TryDownloadEmbeddedFile("plugin-key", "file-name.ext", "ignored"));
+
+            action.Should().ThrowExactly<HttpRequestException>();
+
+            logger.Warnings.Should().BeEmpty();
+        }
+
+        private static Exception GetHttpRequestException(HttpStatusCode statusCode)
+        {
+            var responseMock = new Mock<HttpWebResponse>();
+
+            responseMock
+                .SetupGet(x => x.StatusCode)
+                .Returns(statusCode);
+
+            return new HttpRequestException("message",
+                new WebException("message", null, WebExceptionStatus.ProtocolError, responseMock.Object));
+        }
+    }
+}

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/SonarScanner.MSBuild.PreProcessor.Tests.csproj
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/SonarScanner.MSBuild.PreProcessor.Tests.csproj
@@ -103,6 +103,10 @@
     <Compile Include="WebClientDownloaderTest.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\sonarqube-webclient\SonarQube.Client\SonarQube.Client.csproj">
+      <Project>{5e513fc3-bda7-40f2-8b6a-1bb9372acb99}</Project>
+      <Name>SonarQube.Client</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\SonarScanner.MSBuild.Common\SonarScanner.MSBuild.Common.csproj">
       <Project>{e312fdbb-bc13-4559-8f21-76ca5b88ebc5}</Project>
       <Name>SonarScanner.MSBuild.Common</Name>

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/SonarScanner.MSBuild.PreProcessor.Tests.csproj
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/SonarScanner.MSBuild.PreProcessor.Tests.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.IO.Compression.FileSystem" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
@@ -98,6 +99,7 @@
     <Compile Include="Roslyn\PluginTests.cs" />
     <Compile Include="RulesetWriterTest.cs" />
     <Compile Include="DataModel\QualityProfile.cs" />
+    <Compile Include="SonarQubeServerTest.cs" />
     <Compile Include="SonarWebServiceTest.cs" />
     <Compile Include="TargetsInstallerTests.cs" />
     <Compile Include="WebClientDownloaderTest.cs" />

--- a/src/Packaging/Packaging.csproj
+++ b/src/Packaging/Packaging.csproj
@@ -34,6 +34,7 @@
   <!-- Common -->
   <ItemGroup>
     <!-- Project dependencies - ensure build order -->
+    <ProjectReference Include="$(SourcesRoot)\..\sonarqube-webclient\SonarQube.Client\SonarQube.Client.csproj" />
     <ProjectReference Include="$(SourcesRoot)\SonarScanner.MSBuild.Common\SonarScanner.MSBuild.Common.csproj" />
     <ProjectReference Include="$(SourcesRoot)\SonarScanner.MSBuild\SonarScanner.MSBuild.csproj" />
     <ProjectReference Include="$(SourcesRoot)\SonarScanner.MSBuild.Tasks\SonarScanner.MSBuild.Tasks.csproj" />
@@ -47,6 +48,7 @@
     <TargetFiles Include="$(SourcesRoot)\SonarScanner.MSBuild.Tasks\Targets\SonarQube.Integration.ImportBefore.targets" />
 
     <!-- Dlls -->
+    <ScannerFiles Include="$(SourcesRoot)\..\sonarqube-webclient\SonarQube.Client\bin\$(Configuration)\$(CommonFrameworkVersion)\SonarQube.Client.dll" />
     <ScannerFiles Include="$(SourcesRoot)\SonarScanner.MSBuild\bin\$(Configuration)\$(TargetFramework)\SonarQube.Analysis.xml" />
     <ScannerFiles Include="$(SourcesRoot)\SonarScanner.MSBuild.Common\bin\$(Configuration)\$(CommonFrameworkVersion)\SonarScanner.MSBuild.Common.dll" />
     <ScannerFiles Include="$(SourcesRoot)\SonarScanner.MSBuild.PreProcessor\bin\$(Configuration)\$(CommonFrameworkVersion)\SonarScanner.MSBuild.PreProcessor.dll" />
@@ -57,6 +59,7 @@
 
     <!-- Third-parties dlls -->
     <ScannerFiles Include="$(SourcesRoot)\SonarScanner.MSBuild.PreProcessor\bin\$(Configuration)\$(CommonFrameworkVersion)\Newtonsoft.Json.dll" />
+    <ScannerFiles Include="$(SourcesRoot)\SonarScanner.MSBuild.PreProcessor\bin\$(Configuration)\$(CommonFrameworkVersion)\Google.Protobuf.dll" />
   </ItemGroup>
 
   <!-- Common debug files -->

--- a/src/SonarScanner.MSBuild.Common/IO/IFileWrapper.cs
+++ b/src/SonarScanner.MSBuild.Common/IO/IFileWrapper.cs
@@ -28,5 +28,6 @@ namespace SonarScanner.MSBuild.Common
         string ReadAllText(string path);
         void Copy(string sourceFileName, string destFileName, bool overwrite);
         Stream Open(string path);
+        Stream Create(string path);
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IAnalyzerProvider.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IAnalyzerProvider.cs
@@ -21,7 +21,7 @@
 using System.Collections.Generic;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.TFS;
-using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
+using SonarQube.Client.Models;
 
 namespace SonarScanner.MSBuild.PreProcessor
 {
@@ -35,6 +35,6 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// <param name="projectKey">Identifier for the project being analyzed</param>
         /// <returns>The settings required to configure the build for Roslyn a analyzer</returns>
         AnalyzerSettings SetupAnalyzer(TeamBuildSettings settings, IDictionary<string, string> serverSettings,
-            IEnumerable<SonarRule> activeRules, IEnumerable<SonarRule> inactiveRules, string language);
+            IEnumerable<SonarQubeRule> activeRules, IEnumerable<SonarQubeRule> inactiveRules, string language);
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarQubeServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarQubeServer.cs
@@ -20,7 +20,7 @@
 
 using System;
 using System.Collections.Generic;
-using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
+using SonarQube.Client.Models;
 
 namespace SonarScanner.MSBuild.PreProcessor
 {
@@ -29,9 +29,9 @@ namespace SonarScanner.MSBuild.PreProcessor
     /// </summary>
     public interface ISonarQubeServer
     {
-        IList<SonarRule> GetInactiveRules(string qprofile, string language);
+        IList<SonarQubeRule> GetInactiveRules(string qprofile, string language);
 
-        IList<SonarRule> GetActiveRules(string qprofile);
+        IList<SonarQubeRule> GetActiveRules(string qprofile);
 
         /// <summary>
         /// Get all keys of all available languages

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/ActiveRule.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/ActiveRule.cs
@@ -18,10 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
 using System.Collections.Generic;
 
 namespace SonarScanner.MSBuild.PreProcessor.Roslyn.Model
 {
+    [Obsolete]
     public class SonarRule
     {
         public string RepoKey { set; get; }
@@ -40,20 +42,20 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn.Model
         {
         }
 
-        public SonarRule(string repoKey, string ruleKey)
+        public SonarRule(string ruleKey, string repoKey)
         {
             RepoKey = repoKey;
             RuleKey = ruleKey;
         }
 
-        public SonarRule(string repoKey, string ruleKey, bool isActive)
+        public SonarRule(string ruleKey, string repoKey, bool isActive)
         {
             RepoKey = repoKey;
             RuleKey = ruleKey;
             IsActive = isActive;
         }
 
-        public SonarRule(string repoKey, string ruleKey, string internalKey, bool isActive)
+        public SonarRule(string ruleKey, string repoKey, string internalKey, bool isActive)
         {
             RepoKey = repoKey;
             RuleKey = ruleKey;

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
@@ -23,6 +23,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using SonarQube.Client.Models;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
 using SonarScanner.MSBuild.TFS;
@@ -60,7 +61,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
         }
 
         public AnalyzerSettings SetupAnalyzer(TeamBuildSettings settings, IDictionary<string, string> serverSettings,
-            IEnumerable<SonarRule> activeRules, IEnumerable<SonarRule> inactiveRules, string language)
+            IEnumerable<SonarQubeRule> activeRules, IEnumerable<SonarQubeRule> inactiveRules, string language)
         {
             this.sqSettings = settings ?? throw new ArgumentNullException(nameof(settings));
             this.sqServerSettings = serverSettings ?? throw new ArgumentNullException(nameof(serverSettings));
@@ -106,7 +107,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
         /// Active rules should never be empty, but depending on the server settings of repo keys, we might have no rules in the ruleset.
         /// In that case, this method returns null.
         /// </summary>
-        private AnalyzerSettings ConfigureAnalyzer(string language, IEnumerable<SonarRule> activeRules, IEnumerable<SonarRule> inactiveRules)
+        private AnalyzerSettings ConfigureAnalyzer(string language, IEnumerable<SonarQubeRule> activeRules, IEnumerable<SonarQubeRule> inactiveRules)
         {
             var ruleSetGenerator = new RoslynRuleSetGenerator(this.sqServerSettings);
             var ruleSet = ruleSetGenerator.Generate(activeRules, inactiveRules, language);
@@ -151,7 +152,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
             return Path.Combine(settings.SonarConfigDirectory, GetRoslynRulesetFileName(language));
         }
 
-        private IEnumerable<string> WriteAdditionalFiles(string language, IEnumerable<SonarRule> activeRules)
+        private IEnumerable<string> WriteAdditionalFiles(string language, IEnumerable<SonarQubeRule> activeRules)
         {
             Debug.Assert(activeRules != null, "Supplied active rules should not be null");
 
@@ -166,7 +167,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
             return additionalFiles;
         }
 
-        private string WriteSonarLintXmlFile(string language, IEnumerable<SonarRule> activeRules)
+        private string WriteSonarLintXmlFile(string language, IEnumerable<SonarQubeRule> activeRules)
         {
             if (string.IsNullOrWhiteSpace(language))
             {
@@ -199,7 +200,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
             return fullPath;
         }
 
-        public IEnumerable<string> FetchAnalyzerAssemblies(IEnumerable<SonarRule> activeRules, string language)
+        public IEnumerable<string> FetchAnalyzerAssemblies(IEnumerable<SonarQubeRule> activeRules, string language)
         {
             var repoKeys = ActiveRulesPartialRepoKey(activeRules, language);
             IList<Plugin> plugins = new List<Plugin>();
@@ -248,7 +249,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
             return partialRepoKey + ".staticResourceName";
         }
 
-        private static ICollection<string> ActiveRulesPartialRepoKey(IEnumerable<SonarRule> activeRules, string language)
+        private static ICollection<string> ActiveRulesPartialRepoKey(IEnumerable<SonarQubeRule> activeRules, string language)
         {
             var list = new HashSet<string>
             {
@@ -259,9 +260,9 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
 
             foreach (var activeRule in activeRules)
             {
-                if (activeRule.RepoKey.StartsWith(ROSLYN_REPOSITORY_PREFIX))
+                if (activeRule.RepositoryKey.StartsWith(ROSLYN_REPOSITORY_PREFIX))
                 {
-                    list.Add(activeRule.RepoKey.Substring(ROSLYN_REPOSITORY_PREFIX.Length));
+                    list.Add(activeRule.RepositoryKey.Substring(ROSLYN_REPOSITORY_PREFIX.Length));
                 }
             }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynRuleSetGenerator.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynRuleSetGenerator.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using SonarQube.Client.Models;
 using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild.PreProcessor.Roslyn.Model
@@ -41,7 +42,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn.Model
         /// The ruleset can be empty if there are no active rules belonging to the repo keys "vbnet", "csharpsquid" or "roslyn.*".
         /// </summary>
         /// <exception cref="AnalysisException">if mandatory properties that should be associated with the repo key are missing.</exception>
-        public RuleSet Generate(IEnumerable<SonarRule> activeRules, IEnumerable<SonarRule> inactiveRules, string language)
+        public RuleSet Generate(IEnumerable<SonarQubeRule> activeRules, IEnumerable<SonarQubeRule> inactiveRules, string language)
         {
             if (activeRules == null)
             {
@@ -74,7 +75,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn.Model
                 {
                     AnalyzerId = MandatoryPropertyValue(AnalyzerIdPropertyKey(entry.Key)),
                     RuleNamespace = MandatoryPropertyValue(RuleNamespacePropertyKey(entry.Key)),
-                    RuleList = entry.Value.Select(r => new Rule(r.RuleKey, r.IsActive ? "Warning" : "None")).ToList()
+                    RuleList = entry.Value.Select(r => new Rule(r.Key, r.IsActive ? "Warning" : "None")).ToList()
                 };
 
                 ruleSet.Rules.Add(rules);
@@ -83,19 +84,19 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn.Model
             return ruleSet;
         }
 
-        private static Dictionary<string, List<SonarRule>> RoslynRulesByPartialRepoKey(IEnumerable<SonarRule> rules,
+        private static Dictionary<string, List<SonarQubeRule>> RoslynRulesByPartialRepoKey(IEnumerable<SonarQubeRule> rules,
             string language)
         {
-            var rulesByPartialRepoKey = new Dictionary<string, List<SonarRule>>();
+            var rulesByPartialRepoKey = new Dictionary<string, List<SonarQubeRule>>();
 
             foreach (var rule in rules)
             {
-                if (rule.RepoKey.StartsWith(ROSLYN_REPOSITORY_PREFIX))
+                if (rule.RepositoryKey.StartsWith(ROSLYN_REPOSITORY_PREFIX))
                 {
-                    var pluginKey = rule.RepoKey.Substring(ROSLYN_REPOSITORY_PREFIX.Length);
+                    var pluginKey = rule.RepositoryKey.Substring(ROSLYN_REPOSITORY_PREFIX.Length);
                     AddDict(rulesByPartialRepoKey, pluginKey, rule);
                 }
-                else if ("csharpsquid".Equals(rule.RepoKey) || "vbnet".Equals(rule.RepoKey))
+                else if ("csharpsquid".Equals(rule.RepositoryKey) || "vbnet".Equals(rule.RepositoryKey))
                 {
                     AddDict(rulesByPartialRepoKey, string.Format(SONARANALYZER_PARTIAL_REPO_KEY, language), rule);
                 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynSonarLint.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynSonarLint.cs
@@ -21,17 +21,17 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using SonarQube.Client.Models;
 using SonarScanner.MSBuild.Common;
-using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
 
 namespace SonarScanner.MSBuild.PreProcessor.Roslyn
 {
     internal static class RoslynSonarLint
     {
-        public static string GenerateXml(IEnumerable<SonarRule> activeRules, IDictionary<string, string> serverSettings,
+        public static string GenerateXml(IEnumerable<SonarQubeRule> activeRules, IDictionary<string, string> serverSettings,
             string language, string repoKey)
         {
-            var repoActiveRules = activeRules.Where(ar => repoKey.Equals(ar.RepoKey));
+            var repoActiveRules = activeRules.Where(ar => repoKey.Equals(ar.RepositoryKey));
             var settings = serverSettings.Where(a => a.Key.StartsWith("sonar." + language + "."));
 
             var builder = new StringBuilder();
@@ -53,9 +53,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
             foreach (var activeRule in repoActiveRules)
             {
                 builder.AppendLine("    <Rule>");
-                var templateKey = activeRule.TemplateKey;
-                var ruleKey = templateKey ?? activeRule.RuleKey;
-                builder.AppendLine("      <Key>" + EscapeXml(ruleKey) + "</Key>");
+                builder.AppendLine("      <Key>" + EscapeXml(activeRule.Key) + "</Key>");
 
                 if (activeRule.Parameters != null && activeRule.Parameters.Any())
                 {

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarQubeServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarQubeServer.cs
@@ -1,0 +1,136 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using SonarQube.Client;
+using SonarQube.Client.Models;
+using SonarScanner.MSBuild.Common;
+
+namespace SonarScanner.MSBuild.PreProcessor
+{
+    public class SonarQubeServer : ISonarQubeServer
+    {
+        private const string oldDefaultProjectTestPattern = @"[^\\]*test[^\\]*$";
+
+        private readonly ISonarQubeService sonarQubeService;
+        private readonly ConnectionInformation connectionInformation;
+        private readonly ILogger logger;
+
+        private bool isConnected;
+
+        public SonarQubeServer(ISonarQubeService sonarQubeService, ConnectionInformation connectionInformation, ILogger logger)
+        {
+            this.sonarQubeService = sonarQubeService;
+            this.connectionInformation = connectionInformation;
+            this.logger = logger;
+        }
+
+        public IList<SonarQubeRule> GetActiveRules(string qprofile) =>
+            EnsureConnected(
+                () => sonarQubeService.GetRulesAsync(true, qprofile, CancellationToken.None));
+
+        public IEnumerable<string> GetAllLanguages() =>
+            EnsureConnected(
+                () => sonarQubeService.GetAllLanguagesAsync(CancellationToken.None)).Select(l => l.Key);
+
+        public IList<SonarQubeRule> GetInactiveRules(string qprofile, string language) =>
+            EnsureConnected(
+                () => sonarQubeService.GetRulesAsync(false, qprofile, CancellationToken.None));
+
+        public IDictionary<string, string> GetProperties(string projectKey, string projectBranch)
+        {
+            var properties = EnsureConnected(
+                () => sonarQubeService.GetAllPropertiesAsync(GetCompositeProjectKey(projectKey, projectBranch), CancellationToken.None))
+                .ToDictionary(p => p.Key, p => p.Value);
+
+            ValidateTestProjectPattern(properties);
+
+            return properties;
+        }
+
+        private static string GetCompositeProjectKey(string projectKey, string projectBranch) =>
+            string.IsNullOrEmpty(projectBranch)
+                ? projectKey
+                : $"{projectKey}:{projectBranch}";
+
+        public Version GetServerVersion() =>
+            sonarQubeService.SonarQubeVersion;
+
+        public bool TryDownloadEmbeddedFile(string pluginKey, string embeddedFileName, string targetDirectory)
+        {
+            var stream = EnsureConnected(
+                () => sonarQubeService.DownloadStaticFileAsync(pluginKey, embeddedFileName, CancellationToken.None));
+
+            using (var file = File.Create(Path.Combine(targetDirectory, embeddedFileName)))
+            {
+                stream.CopyTo(file);
+                return true;
+            }
+        }
+
+        public bool TryGetQualityProfile(string projectKey, string projectBranch, string organization,
+            string language, out string qualityProfileKey)
+        {
+            var qualityProfile = EnsureConnected(
+                () => sonarQubeService.GetQualityProfileAsync(
+                    GetCompositeProjectKey(projectKey, projectBranch),
+                    organization,
+                    new SonarQubeLanguage(language, language),
+                    CancellationToken.None));
+
+            qualityProfileKey = qualityProfile.Key;
+            return true;
+        }
+
+        private T EnsureConnected<T>(Func<Task<T>> func)
+        {
+            if (!isConnected)
+            {
+                sonarQubeService
+                    .ConnectAsync(connectionInformation, CancellationToken.None)
+                    .GetAwaiter()
+                    .GetResult();
+                isConnected = true;
+            }
+            return func().GetAwaiter().GetResult();
+        }
+
+        private Dictionary<string, string> ValidateTestProjectPattern(Dictionary<string, string> settings)
+        {
+            // http://jira.sonarsource.com/browse/SONAR-5891 and https://jira.sonarsource.com/browse/SONARMSBRU-285
+            if (settings.ContainsKey("sonar.cs.msbuild.testProjectPattern"))
+            {
+                var value = settings["sonar.cs.msbuild.testProjectPattern"];
+                if (value != oldDefaultProjectTestPattern)
+                {
+                    this.logger.LogWarning("The property 'sonar.cs.msbuild.testProjectPattern' defined in SonarQube is deprecated. Set the property 'sonar.msbuild.testProjectPattern' in the scanner instead.");
+                }
+                settings["sonar.msbuild.testProjectPattern"] = value;
+                settings.Remove("sonar.cs.msbuild.testProjectPattern");
+            }
+            return settings;
+        }
+    }
+}

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarQubeServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarQubeServer.cs
@@ -22,6 +22,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using SonarQube.Client;
@@ -36,85 +38,150 @@ namespace SonarScanner.MSBuild.PreProcessor
 
         private readonly ISonarQubeService sonarQubeService;
         private readonly ConnectionInformation connectionInformation;
+        private readonly IFileWrapper fileWrapper;
         private readonly ILogger logger;
+        private readonly Task connect;
 
-        private bool isConnected;
-
-        public SonarQubeServer(ISonarQubeService sonarQubeService, ConnectionInformation connectionInformation, ILogger logger)
+        public SonarQubeServer(ISonarQubeService sonarQubeService, ConnectionInformation connectionInformation, IFileWrapper fileWrapper, ILogger logger)
         {
-            this.sonarQubeService = sonarQubeService;
-            this.connectionInformation = connectionInformation;
-            this.logger = logger;
+            this.sonarQubeService = sonarQubeService ?? throw new ArgumentNullException(nameof(sonarQubeService));
+            this.connectionInformation = connectionInformation ?? throw new ArgumentNullException(nameof(connectionInformation));
+            this.fileWrapper = fileWrapper ?? throw new ArgumentNullException(nameof(fileWrapper));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            // This task will be awaited before each service call to ensure the service is connected.
+            this.connect = sonarQubeService.ConnectAsync(connectionInformation, CancellationToken.None);
         }
 
-        public IList<SonarQubeRule> GetActiveRules(string qprofile) =>
-            EnsureConnected(
-                () => sonarQubeService.GetRulesAsync(true, qprofile, CancellationToken.None));
+        public Version GetServerVersion() =>
+            SynchronousServiceCall(
+                () => Task.FromResult(this.sonarQubeService.SonarQubeVersion));
 
-        public IEnumerable<string> GetAllLanguages() =>
-            EnsureConnected(
-                () => sonarQubeService.GetAllLanguagesAsync(CancellationToken.None)).Select(l => l.Key);
+        public IList<SonarQubeRule> GetActiveRules(string qprofile) =>
+            SynchronousServiceCall(
+                () => this.sonarQubeService.GetRulesAsync(true, qprofile, CancellationToken.None));
 
         public IList<SonarQubeRule> GetInactiveRules(string qprofile, string language) =>
-            EnsureConnected(
-                () => sonarQubeService.GetRulesAsync(false, qprofile, CancellationToken.None));
+            SynchronousServiceCall(
+                () => this.sonarQubeService.GetRulesAsync(false, qprofile, CancellationToken.None));
+
+        public IEnumerable<string> GetAllLanguages()
+        {
+            var languages = SynchronousServiceCall(
+                () => this.sonarQubeService.GetAllLanguagesAsync(CancellationToken.None));
+
+            // This should never happen, the SonarQubeService should never return null
+            if (languages == null)
+            {
+                return null;
+            }
+
+            return languages.Select(l => l.Key);
+        }
 
         public IDictionary<string, string> GetProperties(string projectKey, string projectBranch)
         {
-            var properties = EnsureConnected(
-                () => sonarQubeService.GetAllPropertiesAsync(GetCompositeProjectKey(projectKey, projectBranch), CancellationToken.None))
-                .ToDictionary(p => p.Key, p => p.Value);
+            var compositeProjectKey = GetCompositeProjectKey(projectKey, projectBranch);
 
-            ValidateTestProjectPattern(properties);
+            var properties = SynchronousServiceCall(
+                () => this.sonarQubeService.GetAllPropertiesAsync(compositeProjectKey, CancellationToken.None),
+                LogForbidden);
 
-            return properties;
+            // This should never happen, the SonarQubeService should never return null
+            if (properties == null)
+            {
+                return null;
+            }
+
+            var propertiesDictionary = properties.ToDictionary(p => p.Key, p => p.Value);
+
+            ValidateTestProjectPattern(propertiesDictionary);
+
+            return propertiesDictionary;
         }
+
+        public bool TryDownloadEmbeddedFile(string pluginKey, string embeddedFileName, string targetDirectory)
+        {
+            var stream = SynchronousServiceCall(
+                () => this.sonarQubeService.DownloadStaticFileAsync(pluginKey, embeddedFileName, CancellationToken.None),
+                IgnoreNotFound);
+
+            // When an exception is ignored, 404-NotFound in this case, SynchronousServiceCall returns default(T)
+            if (stream == null)
+            {
+                return false;
+            }
+
+            using (var fileStream = fileWrapper.Create(Path.Combine(targetDirectory, embeddedFileName)))
+            {
+                stream.CopyTo(fileStream);
+            }
+
+            return true;
+        }
+
+        public bool TryGetQualityProfile(string projectKey, string projectBranch, string organization,
+            string language, out string qualityProfileKey)
+        {
+            var compositeProjectKey = GetCompositeProjectKey(projectKey, projectBranch);
+            var sonarLanguage = new SonarQubeLanguage(language, language);
+
+            var qualityProfile = SynchronousServiceCall(
+                () => this.sonarQubeService.GetQualityProfileAsync(compositeProjectKey, organization,
+                        sonarLanguage, CancellationToken.None),
+                IgnoreNotFound);
+
+            // When an exception is ignored, 404-NotFound in this case, SynchronousServiceCall returns default(T)
+            qualityProfileKey = qualityProfile?.Key;
+
+            return qualityProfileKey != null;
+        }
+
+        private bool LogForbidden(HttpRequestException exception)
+        {
+            if (StatusCodeIs(exception, HttpStatusCode.Forbidden))
+            {
+                this.logger.LogWarning("To analyze private projects make sure the scanner user has 'Browse' permission.");
+            }
+            return false; // Do not ignore exception
+        }
+
+        private static bool StatusCodeIs(HttpRequestException exception, HttpStatusCode statusCode) =>
+            exception.InnerException is WebException we &&
+            we.Response is HttpWebResponse response &&
+            response.StatusCode == statusCode;
 
         private static string GetCompositeProjectKey(string projectKey, string projectBranch) =>
             string.IsNullOrEmpty(projectBranch)
                 ? projectKey
                 : $"{projectKey}:{projectBranch}";
 
-        public Version GetServerVersion() =>
-            sonarQubeService.SonarQubeVersion;
+        private bool IgnoreNotFound(HttpRequestException exception) =>
+            StatusCodeIs(exception, HttpStatusCode.NotFound);
 
-        public bool TryDownloadEmbeddedFile(string pluginKey, string embeddedFileName, string targetDirectory)
+        /// <summary>
+        /// Executes an async ISonarQubeService method synchronously and handles exceptions. In case
+        /// the service is not connected the method first connects.
+        /// </summary>
+        /// <remarks>
+        ///
+        /// </remarks>
+        private T SynchronousServiceCall<T>(Func<Task<T>> func, Func<HttpRequestException, bool> ignoreError = null)
         {
-            var stream = EnsureConnected(
-                () => sonarQubeService.DownloadStaticFileAsync(pluginKey, embeddedFileName, CancellationToken.None));
-
-            using (var file = File.Create(Path.Combine(targetDirectory, embeddedFileName)))
+            try
             {
-                stream.CopyTo(file);
-                return true;
+                return AsyncHelper.RunSync(async () =>
+                {
+                    // In case we are not connected yet, wait for the connection task to finish.
+                    await this.connect;
+
+                    return await func();
+                });
             }
-        }
-
-        public bool TryGetQualityProfile(string projectKey, string projectBranch, string organization,
-            string language, out string qualityProfileKey)
-        {
-            var qualityProfile = EnsureConnected(
-                () => sonarQubeService.GetQualityProfileAsync(
-                    GetCompositeProjectKey(projectKey, projectBranch),
-                    organization,
-                    new SonarQubeLanguage(language, language),
-                    CancellationToken.None));
-
-            qualityProfileKey = qualityProfile.Key;
-            return true;
-        }
-
-        private T EnsureConnected<T>(Func<Task<T>> func)
-        {
-            if (!isConnected)
+            catch (HttpRequestException e) when (ignoreError != null && ignoreError(e))
             {
-                sonarQubeService
-                    .ConnectAsync(connectionInformation, CancellationToken.None)
-                    .GetAwaiter()
-                    .GetResult();
-                isConnected = true;
+                return default(T);
             }
-            return func().GetAwaiter().GetResult();
         }
 
         private Dictionary<string, string> ValidateTestProjectPattern(Dictionary<string, string> settings)

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarScanner.MSBuild.PreProcessor.csproj
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarScanner.MSBuild.PreProcessor.csproj
@@ -10,6 +10,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\sonarqube-webclient\SonarQube.Client\SonarQube.Client.csproj" />
     <ProjectReference Include="..\SonarScanner.MSBuild.Common\SonarScanner.MSBuild.Common.csproj" />
     <ProjectReference Include="..\SonarScanner.MSBuild.TFS\SonarScanner.MSBuild.TFS.csproj" />
   </ItemGroup>

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
@@ -30,7 +30,8 @@ using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
 
 namespace SonarScanner.MSBuild.PreProcessor
 {
-    public sealed class SonarWebService : ISonarQubeServer, IDisposable
+    [Obsolete]
+    public sealed class SonarWebService : IDisposable
     {
         private const string oldDefaultProjectTestPattern = @"[^\\]*test[^\\]*$";
         private readonly string serverUrl;
@@ -111,7 +112,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                     page++;
                     var rules = json["rules"].Children<JObject>();
 
-                    return rules.Select(r => new SonarRule(r["repo"].ToString(), ParseRuleKey(r["key"].ToString()), false));
+                    return rules.Select(r => new SonarRule(ParseRuleKey(r["key"].ToString()), r["repo"].ToString(), false));
                 }, ws));
             } while (fetched < total);
 
@@ -159,7 +160,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                             throw new JsonException($"Malformed json response, \"actives\" field should contain rule '{r["key"].ToString()}'");
                         }
 
-                        var activeRule = new SonarRule(r["repo"].ToString(), ParseRuleKey(r["key"].ToString()), true);
+                        var activeRule = new SonarRule(ParseRuleKey(r["key"].ToString()), r["repo"].ToString(), true);
                         if (r["internalKey"] != null)
                         {
                             activeRule.InternalKey = r["internalKey"].ToString();

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
@@ -26,6 +26,7 @@ using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild.PreProcessor
 {
+    [Obsolete]
     public class WebClientDownloader : IDownloader
     {
         private readonly ILogger logger;


### PR DESCRIPTION
The straight cases seem to work - all integration tests pass, except one that checks the log entries. Since the downloader is not used any more the test cannot see its log entries.

TODO:
- remove [Obsolete] and unused files
- add error handling - the old service/downloader classes handled some errors and returned true/false. No errors are handled now
- modify the [class that evaluates](https://github.com/SonarSource/sonar-scanner-msbuild/blob/master/src/SonarScanner.MSBuild.Common/Utilities.cs#L174) the exceptions to catch `HttpResponseException`
- write more tests for error cases
- test with .net core on windows, linux and osx
- the sync execution of the async service methods should be ok, but still it should be tested
- try to use the `ISonarQubeService` interface directly