### PR TITLE
Refactor E2EAnalysisTests MSBuild tests to use XML for project creation

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildUtilities.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/Infrastructure/BuildUtilities.cs
@@ -18,15 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using FluentAssertions;
 using Microsoft.Build.Construction;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarScanner.MSBuild.Common;
-using TestUtilities;
 
 namespace SonarScanner.MSBuild.Tasks.IntegrationTests
 {
@@ -36,105 +31,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
         //public const string MSBuildToolsVersionForTestProjects = "14.0"; // use this line for VS2015
         public const string MSBuildToolsVersionForTestProjects = "15.0"; // use this line for VS2017
 
-        private const string StandardImportBeforePropertyName = "ImportByWildcardBeforeMicrosoftCommonTargets";
-        private const string StandardImportAfterPropertyName = "ImportByWildcardAfterMicrosoftCommonTargets";
-        private const string UserImportBeforePropertyName = "ImportUserLocationsByWildcardBeforeMicrosoftCommonTargets";
-        private const string UserImportAfterPropertyName = "ImportUserLocationsByWildcardAfterMicrosoftCommonTargets";
-
         #region Project creation helpers
-
-        /// <summary>
-        /// Creates and returns a valid project descriptor for a project in the supplied folders
-        /// </summary>
-        public static ProjectDescriptor CreateValidProjectDescriptor(string parentDirectory, string projectFileName = "MyProject.xproj.txt", bool isVBProject = false)
-        {
-            var descriptor = new ProjectDescriptor()
-            {
-                ProjectLanguage = isVBProject ? SonarScanner.MSBuild.Common.ProjectLanguages.VisualBasic : SonarScanner.MSBuild.Common.ProjectLanguages.CSharp,
-                ProjectGuid = Guid.NewGuid(),
-                IsTestProject = false,
-                ParentDirectoryPath = parentDirectory,
-                ProjectFolderName = "MyProjectDir",
-                ProjectFileName = projectFileName
-            };
-            return descriptor;
-        }
-        
-        /// <summary>
-        /// Creates a project file on disk from the specified descriptor.
-        /// Sets the SonarQube output folder property, if specified.
-        /// </summary>
-        public static ProjectRootElement CreateInitializedProjectRoot(TestContext testContext, ProjectDescriptor descriptor, IDictionary<string, string> preImportProperties)
-        {
-            if (testContext == null)
-            {
-                throw new ArgumentNullException(nameof(testContext));
-            }
-            if (descriptor == null)
-            {
-                throw new ArgumentNullException(nameof(descriptor));
-            }
-
-            var projectRoot = BuildUtilities.CreateAnalysisProject(testContext, descriptor, preImportProperties);
-
-            projectRoot.ToolsVersion = MSBuildToolsVersionForTestProjects;
-
-            projectRoot.Save(descriptor.FullFilePath);
-
-            testContext.AddResultFile(descriptor.FullFilePath);
-            return projectRoot;
-        }
-
-        /// <summary>
-        /// Creates and returns a minimal C# or VB project file that can be built.
-        /// The project imports the C#/VB targets and any other optional targets that are specified.
-        /// The project is NOT saved.
-        /// </summary>
-        /// <param name="preImportProperties">Any properties that need to be set before the C# targets are imported. Can be null.</param>
-        /// <param name="importsBeforeTargets">Any targets that should be imported before the C# targets are imported. Optional.</param>
-        private static ProjectRootElement CreateMinimalBuildableProject(IDictionary<string, string> preImportProperties, bool isVBProject, params string[] importsBeforeTargets)
-        {
-            var root = ProjectRootElement.Create();
-
-            foreach(var importTarget in importsBeforeTargets)
-            {
-                File.Exists(importTarget).Should().BeTrue("Test error: the specified target file does not exist. Path: {0}", importTarget);
-                root.AddImport(importTarget);
-            }
-
-            if (preImportProperties != null)
-            {
-                foreach(var kvp in preImportProperties)
-                {
-                    root.AddProperty(kvp.Key, kvp.Value);
-                }
-            }
-
-            // Ensure the output path is set
-            if (preImportProperties == null || !preImportProperties.ContainsKey("OutputPath"))
-            {
-                root.AddProperty("OutputPath", @"bin\");
-            }
-
-            // Ensure the language is set
-            if (preImportProperties == null || !preImportProperties.ContainsKey("Language"))
-            {
-                root.AddProperty("Language", isVBProject ? "VB" : "C#");
-            }
-
-            // Import the standard Microsoft targets
-            if (isVBProject)
-            {
-                root.AddImport("$(MSBuildToolsPath)\\Microsoft.VisualBasic.targets");
-            }
-            else
-            {
-                root.AddImport("$(MSBuildToolsPath)\\Microsoft.CSharp.targets");
-            }
-            root.AddProperty("OutputType", "library"); // build a library so we don't need a Main method
-
-            return root;
-        }
 
         /// <summary>
         /// Creates and returns a new MSBuild project using the supplied template
@@ -162,95 +59,5 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
         }
 
         #endregion Project creation helpers
-
-        #region Miscellaneous public methods
-
-        /// <summary>
-        /// Sets properties to disable the normal ImportAfter/ImportBefore behavior to
-        /// prevent any additional targets from being picked up.
-        /// This is necessary so the tests run correctly on machines that have
-        /// the installation targets installed.
-        /// See the Microsoft Common targets for more info e.g. C:\Program Files (x86)\MSBuild\12.0\Bin\Microsoft.Common.CurrentVersion.targets
-        /// Any existing settings for those properties will be over-ridden.
-        /// </summary>
-        public static void DisableStandardTargetsWildcardImporting(IDictionary<string, string> properties)
-        {
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
-            }
-
-            properties[StandardImportBeforePropertyName] = "false";
-            properties[StandardImportAfterPropertyName] = "false";
-            properties[UserImportBeforePropertyName] = "false";
-            properties[UserImportAfterPropertyName] = "false";
-        }
-
-        #endregion Miscellaneous public methods
-
-        #region Private methods
-
-        /// <summary>
-        /// Creates and returns an empty MSBuild project using the data in the supplied descriptor.
-        /// The project will import the SonarQube analysis targets file and the standard C# targets file.
-        /// The project name and GUID will be set if the values are supplied in the descriptor.
-        /// </summary>
-        private static ProjectRootElement CreateAnalysisProject(TestContext testContext, ProjectDescriptor descriptor,
-            IDictionary<string, string> preImportProperties)
-        {
-            if (testContext == null)
-            {
-                throw new ArgumentNullException(nameof(testContext));
-            }
-            if (descriptor == null)
-            {
-                throw new ArgumentNullException(nameof(descriptor));
-            }
-
-            var sqTargetFile = TestUtils.EnsureAnalysisTargetsExists(testContext);
-            File.Exists(sqTargetFile).Should().BeTrue("Test error: the SonarQube analysis targets file could not be found. Full path: {0}", sqTargetFile);
-            testContext.AddResultFile(sqTargetFile);
-
-            var properties = preImportProperties ?? new Dictionary<string, string>();
-
-            // Disable the standard "ImportBefore/ImportAfter" behavior if the caller
-            // hasn't defined what they want to happen explicitly
-            if (!properties.ContainsKey(StandardImportBeforePropertyName))
-            {
-                DisableStandardTargetsWildcardImporting(properties);
-            }
-
-            var root = CreateMinimalBuildableProject(properties, descriptor.IsVbProject, sqTargetFile);
-
-            // Set the location of the task assembly
-            if (!properties.ContainsKey(TargetProperties.SonarBuildTasksAssemblyFile))
-            {
-                root.AddProperty(TargetProperties.SonarBuildTasksAssemblyFile, typeof(WriteProjectInfoFile).Assembly.Location);
-            }
-
-            if (descriptor.ProjectGuid != Guid.Empty)
-            {
-                root.AddProperty(TargetProperties.ProjectGuid, descriptor.ProjectGuid.ToString("D"));
-            }
-
-            foreach (var file in descriptor.Files)
-            {
-                root.AddItem(file.ItemGroup, file.FilePath);
-            }
-
-            if (descriptor.IsTestProject && !root.Properties.Any(p => string.Equals(p.Name, TargetProperties.SonarQubeTestProject)))
-            {
-                root.AddProperty(TargetProperties.SonarQubeTestProject, "true");
-            }
-
-            if (descriptor.Encoding != null)
-            {
-                root.AddProperty(TargetProperties.CodePage, descriptor.Encoding.CodePage.ToString());
-            }
-
-            return root;
-        }
-
-        #endregion Private methods
     }
 }

--- a/Tests/TestUtilities/ProjectInfoAssertions.cs
+++ b/Tests/TestUtilities/ProjectInfoAssertions.cs
@@ -99,19 +99,19 @@ namespace TestUtilities
             return match;
         }
 
-        public static void AssertNoAnalysisResultsExist(ProjectInfo projectInfo)
+        public static void AssertNoAnalysisResultsExist(this ProjectInfo projectInfo)
         {
             projectInfo.AnalysisResults.Should().BeNullOrEmpty("Not expecting analysis results to exist. Count: {0}", projectInfo.AnalysisResults.Count);
         }
 
-        public static void AssertAnalysisResultDoesNotExists(ProjectInfo projectInfo, string resultId)
+        public static void AssertAnalysisResultDoesNotExists(this ProjectInfo projectInfo, string resultId)
         {
             projectInfo.AnalysisResults.Should().NotBeNull("AnalysisResults should not be null");
             var found = ProjectInfoExtensions.TryGetAnalyzerResult(projectInfo, resultId, out AnalysisResult result);
             found.Should().BeFalse("Not expecting to find an analysis result for id. Id: {0}", resultId);
         }
 
-        public static AnalysisResult AssertAnalysisResultExists(ProjectInfo projectInfo, string resultId)
+        public static AnalysisResult AssertAnalysisResultExists(this ProjectInfo projectInfo, string resultId)
         {
             projectInfo.AnalysisResults.Should().NotBeNull("AnalysisResults should not be null");
             var found = ProjectInfoExtensions.TryGetAnalyzerResult(projectInfo, resultId, out AnalysisResult result);
@@ -120,7 +120,7 @@ namespace TestUtilities
             return result;
         }
 
-        public static AnalysisResult AssertAnalysisResultExists(ProjectInfo projectInfo, string resultId, string expectedLocation)
+        public static AnalysisResult AssertAnalysisResultExists(this ProjectInfo projectInfo, string resultId, string expectedLocation)
         {
             var result = AssertAnalysisResultExists(projectInfo, resultId);
             result.Location.Should().Be(expectedLocation,


### PR DESCRIPTION
With this change, none of the tests use the MSBuild APIs to create project files