### PR TITLE
Fail argument processing for dynamic property 'sonar.organization'

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/ArgumentProcessorTests.cs
@@ -365,6 +365,11 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 "/d:sonar.projectVersion=value1");
             logger.AssertSingleErrorExists(SonarProperties.ProjectVersion, "/v");
 
+            logger = CheckProcessingFails(
+                "/key:my.key", "/name:my name", "/version:1.2", "/organization:my_org",
+                "/d:sonar.organization=value1");
+            logger.AssertSingleErrorExists(SonarProperties.Organization, "/o");
+
             // 2. Other values that can't be set
 
             logger = CheckProcessingFails(

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/CmdLineArgPropertyProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/CmdLineArgPropertyProvider.cs
@@ -147,6 +147,8 @@ namespace SonarScanner.MSBuild.Common
                 Resources.ERROR_CmdLine_MustUseProjectName);
             var containsProjectVersion = ContainsNamedParameter(SonarProperties.ProjectVersion, validProperties, logger,
                 Resources.ERROR_CmdLine_MustUseProjectVersion);
+            var containsOrganization = ContainsNamedParameter(SonarProperties.Organization, validProperties, logger,
+                Resources.ERROR_CmdLine_MustUseOrganization);
 
             // Check for others properties that can't be set
             var containsUnsettableWorkingDirectory = ContainsUnsettableParameter(SonarProperties.WorkingDirectory, validProperties,
@@ -159,6 +161,7 @@ namespace SonarScanner.MSBuild.Common
                 !containsProjectKey &&
                 !containsProjectName &&
                 !containsProjectVersion &&
+                !containsOrganization &&
                 !containsUnsettableWorkingDirectory;
         }
 

--- a/src/SonarScanner.MSBuild.Common/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.Common/Resources.Designer.cs
@@ -134,6 +134,15 @@ namespace SonarScanner.MSBuild.Common {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Please use the parameter prefix &apos;/o:&apos; to define the organization of the SonarQube project instead of injecting this organization with the help of the &apos;sonar.organization&apos; property..
+        /// </summary>
+        internal static string ERROR_CmdLine_MustUseOrganization {
+            get {
+                return ResourceManager.GetString("ERROR_CmdLine_MustUseOrganization", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Please use the parameter prefix &apos;/k:&apos; to define the key of the SonarQube project instead of injecting this key with the help of the &apos;sonar.projectKey&apos; property..
         /// </summary>
         internal static string ERROR_CmdLine_MustUseProjectKey {

--- a/src/SonarScanner.MSBuild.Common/Resources.resx
+++ b/src/SonarScanner.MSBuild.Common/Resources.resx
@@ -257,4 +257,7 @@
   <data name="ERROR_InvalidPropertyName" xml:space="preserve">
     <value>At least one property name is missing. Please check that the settings file is valid.</value>
   </data>
+  <data name="ERROR_CmdLine_MustUseOrganization" xml:space="preserve">
+    <value>Please use the parameter prefix '/o:' to define the organization of the SonarQube project instead of injecting this organization with the help of the 'sonar.organization' property.</value>
+  </data>
 </root>


### PR DESCRIPTION
Since the value for the organization can only be set by using the named argument `/o:` or `/organization:`, using `/d:sonar.organization=...` should fail when processing the command line arguments.

This brings the behavior for `/organization:` in line with other named arguments such as `/key:`, `/name:` and `/version:`.