### PR TITLE
Workaround for VSTS-179: added fallback search for coverage files

### DIFF
--- a/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageReportProcessorTests.cs
@@ -1,0 +1,98 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarScanner.MSBuild.TFS.Interfaces;
+using SonarScanner.MSBuild.TFS.Tests.Infrastructure;
+using TestUtilities;
+
+namespace SonarScanner.MSBuild.TFS.Tests
+{
+    [TestClass]
+    public class BuildVNextCoverageReportProcessorTests
+    {
+        public TestContext TestContext { get; set; }
+
+        [TestMethod]
+        public void SearchFallbackShouldBeCalled_IfNoTrxFilesFound()
+        {
+            var mockSearchFallback = new MockSearchFallback();
+            mockSearchFallback.SetReturnedFiles("file1.txt", "file2.txt");
+            var testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
+            var testSubject = new BuildVNextCoverageReportProcessor(new MockReportConverter(), new TestLogger(), mockSearchFallback);
+
+            var settings = new MockBuildSettings
+            {
+                BuildDirectory = testDir
+            };
+
+            IEnumerable<string> trxFilePaths = null;
+            bool result = testSubject.TryGetTrxFilesAccessor(new Common.AnalysisConfig(), settings, out trxFilePaths);
+
+            // Assert
+            result.Should().BeTrue(); // expecting true i.e. carry on even if nothing found
+            testSubject.TrxFilesLocated.Should().BeFalse();
+
+            IEnumerable<string> binaryFilePaths = null;
+            result = testSubject.TryGetVsCoverageFilesAccessor(new Common.AnalysisConfig(), settings, out binaryFilePaths);
+            result.Should().BeTrue();
+            binaryFilePaths.Should().BeEquivalentTo("file1.txt", "file2.txt");
+
+            mockSearchFallback.FallbackCalled.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void SearchFallbackNotShouldBeCalled_IfTrxFilesFound()
+        {
+            var mockSearchFallback = new MockSearchFallback();
+            var testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
+            var testResultsDir = Path.Combine(testDir, "TestResults");
+            Directory.CreateDirectory(testResultsDir);
+            TestUtils.CreateTextFile(testResultsDir, "dummy.trx", "");
+
+            var testSubject = new BuildVNextCoverageReportProcessor(new MockReportConverter(), new TestLogger(), mockSearchFallback);
+
+            var settings = new MockBuildSettings
+            {
+                BuildDirectory = testDir
+            };
+
+            IEnumerable<string> trxFilePaths = null;
+            bool result = testSubject.TryGetTrxFilesAccessor(new Common.AnalysisConfig(), settings, out trxFilePaths);
+
+            // 1) Search for TRX files -> results found
+            result.Should().BeTrue();
+            testSubject.TrxFilesLocated.Should().BeTrue();
+
+            // 2) Now search for .coverage files
+            IEnumerable<string> binaryFilePaths = null;
+            result = testSubject.TryGetVsCoverageFilesAccessor(new Common.AnalysisConfig(), settings, out binaryFilePaths);
+            result.Should().BeTrue();
+            binaryFilePaths.Should().BeEmpty();
+
+            mockSearchFallback.FallbackCalled.Should().BeFalse();
+        }
+    }
+}

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
@@ -1,0 +1,141 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace SonarScanner.MSBuild.TFS.Tests
+{
+    [TestClass]
+    public class BuildVNextCoverageSeachFallbackTests
+    {
+        public TestContext TestContext { get; set; }
+
+        [TestMethod]
+        public void Fallback_AgentDirectory_CalculatedCorrectly()
+        {
+            // Arrange
+            var testSubject = new BuildVNextCoverageSearchFallback(new TestLogger());
+            var rootDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
+            var envDir = Path.Combine(rootDir, "DirSpecifiedInEnvDir");
+
+            using (var envVars = new EnvironmentVariableScope())
+            {
+                // 1) env var not specified -> null
+                envVars.SetVariable(BuildVNextCoverageSearchFallback.AGENT_TEMP_DIRECTORY, null);
+                testSubject.GetAgentTempDirectory().Should().BeNull();
+
+                // 2) Env var set but dir does not exist -> null
+                envVars.SetVariable(BuildVNextCoverageSearchFallback.AGENT_TEMP_DIRECTORY, envDir);
+                testSubject.GetAgentTempDirectory().Should().Be(null);
+
+                // 3) Env var set and dir exists -> dir returned
+                Directory.CreateDirectory(envDir);
+                testSubject.GetAgentTempDirectory().Should().Be(envDir);
+            }
+        }
+
+        [TestMethod]
+        public void Fallback_FilesLocatedCorrectly()
+        {
+            // Arrange
+            var testSubject = new BuildVNextCoverageSearchFallback(new TestLogger());
+            var dir = TestUtils.CreateTestSpecificFolder(this.TestContext);
+            var subDir = Path.Combine(dir, "subDir", "subDir2");
+            Directory.CreateDirectory(subDir);
+
+            TestUtils.CreateTextFile(dir, "foo.coverageXXX", "");
+            TestUtils.CreateTextFile(dir, "abc.trx", "");
+            var expected1 = TestUtils.CreateTextFile(dir, "foo.coverage", "");
+            var expected2 = TestUtils.CreateTextFile(dir, "DUPLICATE.coverage", "");
+
+            TestUtils.CreateTextFile(dir, "BAR.coverage.XXX", "");
+            TestUtils.CreateTextFile(dir, "Duplicate.coverage", ""); // appears in both places - only one should be returned
+            var expected3 = TestUtils.CreateTextFile(subDir, "BAR.COVERAGE", ""); // should be found
+
+            using (var envVars = new EnvironmentVariableScope())
+            {
+                envVars.SetVariable(BuildVNextCoverageSearchFallback.AGENT_TEMP_DIRECTORY, dir);
+
+                // Act
+                var actual = testSubject.FindCoverageFiles();
+
+                // Assert
+                actual.Should().BeEquivalentTo(expected1, expected2, expected3);
+            }
+        }
+
+
+        [TestMethod]
+        public void Fallback_FileNameComparer_SimpleComparisons()
+        {
+            var testSubject = new BuildVNextCoverageSearchFallback.FileNameComparer();
+
+            // Identical string -> same
+            testSubject.Equals("c:\\File1.txt", "c:\\File1.txt").Should().BeTrue();
+
+            // Case only -> same
+            testSubject.Equals("c:\\File1.txt", "c:\\FILE1.txt").Should().BeTrue();
+
+            // Different folders -> same
+            testSubject.Equals("c:\\File1.txt", "c:\\aaa\\File1.txt").Should().BeTrue();
+            testSubject.Equals("c:\\aaa\\bbb\\File1.txt", "c:\\aaa\\File1.txt").Should().BeTrue();
+
+            // Different folders and path separators -> same
+            testSubject.Equals("c:/File1.txt", "c:/aaa/File1.txt").Should().BeTrue();
+            testSubject.Equals("c:/aaa/bbb/File1.txt", "c:/aaa/File1.txt").Should().BeTrue();
+
+            // Diferent name -> different
+            testSubject.Equals("c:\\File1.txt", "c:\\File2.txt").Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void Fallback_FileNameComparer_CorrectlyDeDupesList()
+        {
+            // Arrange
+            var comparer = new BuildVNextCoverageSearchFallback.FileNameComparer();
+            string[] input = {
+                "c:\\File1.txt",
+                "c:\\File1.txt",
+                "c:\\aaa\\FILE1.txt",
+                "c:\\aaa\\bbb\\file1.TXT",
+
+                "c:/aaa/FILE2.TXT",
+                "d:\\FILE2.txt",
+
+                "file3.txt"
+            };
+
+            // Act
+            var actual = input.Distinct(comparer).ToArray();
+
+            // Assert
+            actual.Should().BeEquivalentTo(
+                "c:\\File1.txt",
+                "c:/aaa/FILE2.TXT",
+                "file3.txt"
+                );
+        }
+    }
+}

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockBuildSettings.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockBuildSettings.cs
@@ -1,0 +1,50 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarScanner.MSBuild.TFS.Interfaces;
+
+namespace SonarScanner.MSBuild.TFS.Tests.Infrastructure
+{
+    internal class MockBuildSettings : ITeamBuildSettings
+    {
+        // Settable properties for testing
+
+        public BuildEnvironment BuildEnvironment { get; set; }
+
+        public string TfsUri { get; set; }
+
+        public string BuildUri { get; set; }
+
+        public string SourcesDirectory { get; set; }
+
+        public string AnalysisBaseDirectory { get; set; }
+
+        public string BuildDirectory { get; set; }
+
+        public string SonarConfigDirectory { get; set; }
+
+        public string SonarOutputDirectory { get; set; }
+
+        public string SonarBinDirectory { get; set; }
+
+        public string AnalysisConfigFilePath { get; set; }
+    }
+}
+

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockSearchFallback.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockSearchFallback.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Collections.Generic;
+
+namespace SonarScanner.MSBuild.TFS.Tests.Infrastructure
+{
+    internal class MockSearchFallback : IBuildVNextCoverageSearchFallback
+    {
+        private string[] filesToReturn = { };
+
+        public bool FallbackCalled { get; private set; }
+
+        public void SetReturnedFiles(params string[] files)
+        {
+            filesToReturn = files;
+        }
+
+        public IEnumerable<string> FindCoverageFiles()
+        {
+            this.FallbackCalled = true;
+            return filesToReturn;
+        }
+    }
+}

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/SonarScanner.MSBuild.TFS.Tests.csproj
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/SonarScanner.MSBuild.TFS.Tests.csproj
@@ -78,15 +78,19 @@
     <Compile Include="..\..\AssemblyInfo.Shared.cs">
       <Link>Properties\AssemblyInfo.Shared.cs</Link>
     </Compile>
+    <Compile Include="BuildVNextCoverageSearchFallbackTests.cs" />
+    <Compile Include="BuildVNextCoverageReportProcessorTests.cs" />
     <Compile Include="Classic\LegacyTeamBuildFactoryTests.cs" />
     <Compile Include="Classic\CoverageReportUrlProviderTests.cs" />
     <Compile Include="Classic\CoverageReportDownloaderTests.cs" />
     <Compile Include="Classic\LegacyBuildSummaryLoggerTests.cs" />
     <Compile Include="Classic\TfsLegacyCoverageReportProcessorTests.cs" />
     <Compile Include="Classic\BinaryToXmlCoverageReportConverterTests.cs" />
+    <Compile Include="Infrastructure\MockBuildSettings.cs" />
     <Compile Include="Infrastructure\MockReportDownloader.cs" />
     <Compile Include="Infrastructure\MockReportConverter.cs" />
     <Compile Include="Infrastructure\MockReportUrlProvider.cs" />
+    <Compile Include="Infrastructure\MockSearchFallback.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TeamBuildSettingsTests.cs" />
     <Compile Include="TrxFileReaderTests.cs" />

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -19,6 +19,7 @@
  */
 
 using System.Collections.Generic;
+using System.Linq;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.TFS.Interfaces;
 
@@ -26,14 +27,37 @@ namespace SonarScanner.MSBuild.TFS
 {
     public class BuildVNextCoverageReportProcessor : CoverageReportProcessorBase
     {
+        internal bool TrxFilesLocated { get; private set; }
+
+        private readonly IBuildVNextCoverageSearchFallback searchFallback;
+
         public BuildVNextCoverageReportProcessor(ICoverageReportConverter converter, ILogger logger)
+            : this(converter, logger, new BuildVNextCoverageSearchFallback(logger))
+        {
+        }
+
+        internal /* for testing */ BuildVNextCoverageReportProcessor(ICoverageReportConverter converter, ILogger logger,
+            IBuildVNextCoverageSearchFallback searchFallback)
             : base(converter, logger)
         {
+            this.searchFallback = searchFallback;
         }
 
         protected override bool TryGetVsCoverageFiles(AnalysisConfig config, ITeamBuildSettings settings, out IEnumerable<string> binaryFilePaths)
         {
             binaryFilePaths = new TrxFileReader(Logger).FindCodeCoverageFiles(settings.BuildDirectory);
+
+            // Fallback to workround VSTS-179: if the standard searches for .trx/.converage failed
+            // then try the fallback method to find coverage files
+            if (!TrxFilesLocated && (binaryFilePaths == null || !binaryFilePaths.Any()))
+            {
+                Logger.LogInfo("Did not find any binary coverage files in the expected location.");
+                binaryFilePaths = searchFallback.FindCoverageFiles();
+            }
+            else
+            {
+                Logger.LogDebug("Not using the fallback mechanism to detect binary coverage files.");
+            }
 
             return true; // there aren't currently any conditions under which we'd want to stop processing
         }
@@ -42,7 +66,16 @@ namespace SonarScanner.MSBuild.TFS
         {
             trxFilePaths = new TrxFileReader(Logger).FindTrxFiles(settings.BuildDirectory);
 
+            TrxFilesLocated = trxFilePaths != null && trxFilePaths.Any();
             return true;
         }
+
+        // We can't make the override internal, so this is a pass-through for testing
+        internal /* for testing */ bool TryGetVsCoverageFilesAccessor(AnalysisConfig config, ITeamBuildSettings settings, out IEnumerable<string> binaryFilePaths) =>
+            TryGetVsCoverageFiles(config, settings, out binaryFilePaths);
+
+        internal /* for testing */ bool TryGetTrxFilesAccessor(AnalysisConfig config, ITeamBuildSettings settings, out IEnumerable<string> trxFilePaths) =>
+            this.TryGetTrxFiles(config, settings, out trxFilePaths);
+
     }
 }

--- a/src/SonarScanner.MSBuild.TFS/IBuildVNextCoverageSearchFallback.cs
+++ b/src/SonarScanner.MSBuild.TFS/IBuildVNextCoverageSearchFallback.cs
@@ -1,0 +1,138 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using SonarScanner.MSBuild.Common;
+
+// HACK: Workaround for VSTS-179
+
+// v2 of the AzureDevOps VSTest task may delete the .trx files from disc after it has uploaded them
+// (it does this when using the distributed task runner (?) e.g. when running tests in parallel).
+// We normally read .trx files to locate the .coverage files but obviously we can't do this if the
+// files are not present.
+//
+// However, it doesn't delete the coverage files, but they will be written to a different location.
+// This code is a partial workaround for the bug - if the normal .trx/.coverage process didn't work
+// we'll fall back on searching for .coverage files in the secondary location.
+// The test results from the .trx file will still be missing, but the code coverage will be found,
+// which is more important.
+
+namespace SonarScanner.MSBuild.TFS
+{
+    internal interface IBuildVNextCoverageSearchFallback
+    {
+        IEnumerable<string> FindCoverageFiles();
+    }
+
+
+    internal class BuildVNextCoverageSearchFallback : IBuildVNextCoverageSearchFallback
+    {
+        internal const string AGENT_TEMP_DIRECTORY = "AGENT_TEMPDIRECTORY";
+
+        public BuildVNextCoverageSearchFallback(ILogger logger)
+        {
+            this.Logger = logger;
+        }
+
+        private ILogger Logger { get; }
+
+        public IEnumerable<string> FindCoverageFiles()
+        {
+            Logger.LogInfo("Falling back on locating coverage files in the agent temp directory.");
+
+            var agentTempDirectory = GetAgentTempDirectory();
+            if (agentTempDirectory == null)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            Logger.LogInfo($"Searching for coverage files in {agentTempDirectory}");
+            var files = Directory.GetFiles(agentTempDirectory, "*.coverage", SearchOption.AllDirectories);
+
+            if (files == null || files.Length == 0)
+            {
+                Logger.LogInfo($"No coverage files found in the agent temp directory.");
+                return Enumerable.Empty<string>();
+            }
+            else
+            {
+                LogDebugFileList("All matching files:", files);
+
+                // The same file might appear in multiple paths.
+                // We're assuming the files are identical so it doesn't matter which one we pick.
+                files = files.Distinct(new FileNameComparer()).ToArray();
+                LogDebugFileList("Unique coverage files:", files);
+                return files;
+            }
+        }
+
+        internal /* for testing */ string GetAgentTempDirectory()
+        {
+            var agentTempDirectory = Environment.GetEnvironmentVariable(AGENT_TEMP_DIRECTORY);
+            if (string.IsNullOrEmpty(agentTempDirectory))
+            {
+                Logger.LogDebug($"Env var {AGENT_TEMP_DIRECTORY} is not set.");
+                return null;
+            }
+
+            if (!Directory.Exists(agentTempDirectory))
+            {
+                Logger.LogDebug($"Calculated location for {AGENT_TEMP_DIRECTORY} does not exist: {agentTempDirectory}");
+                return null;
+            }
+
+            return agentTempDirectory;
+        }
+
+        private void LogDebugFileList(string headerMessage, string[] files)
+        {
+            Logger.LogDebug($"{headerMessage} count={files.Length}");
+            foreach (var file in files)
+            {
+                Logger.LogDebug($"\t{file}");
+            }
+        }
+
+        /// <summary>
+        /// Compares full file paths based on just the file name part
+        /// i.e. c:\aaa\bbb\file1.txt and c:\aaa\file1.txt are equal.
+        /// </summary>
+        internal class FileNameComparer : IEqualityComparer<string>
+        {
+            public bool Equals(string x, string y)
+            {
+                bool result = string.Equals(GetFileNameFromPath(x), GetFileNameFromPath(y), StringComparison.OrdinalIgnoreCase);
+                return result;
+            }
+
+            public int GetHashCode(string obj)
+            {
+                return GetFileNameFromPath(obj).GetHashCode();
+            }
+
+            private static string GetFileNameFromPath(string fullPath) =>
+                Path.GetFileName(fullPath).ToUpperInvariant();
+        }
+
+    }
+}

--- a/src/SonarScanner.MSBuild.TFS/Properties/InternalsVisibleTo.cs
+++ b/src/SonarScanner.MSBuild.TFS/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2019 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Runtime.CompilerServices;
+
+#if SignAssembly
+[assembly: InternalsVisibleTo("SonarScanner.MSBuild.TFS.Tests,PublicKey=002400000480000094000000060200000024000052534131000400000100010081b4345a022cc0f4b42bdc795a5a7a1623c1e58dc2246645d751ad41ba98f2749dc5c4e0da3a9e09febcb2cd5b088a0f041f8ac24b20e736d8ae523061733782f9c4cd75b44f17a63714aced0b29a59cd1ce58d8e10ccdb6012c7098c39871043b7241ac4ab9f6b34f183db716082cd57c1ff648135bece256357ba735e67dc6")]
+#else
+[assembly: InternalsVisibleTo("SonarScanner.MSBuild.TFS.Tests")]
+#endif


### PR DESCRIPTION
Fix #724