### PR TITLE
Resolves #735

### DIFF
--- a/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageReportProcessorTests.cs
@@ -124,7 +124,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var coverageDir = Path.Combine(testResultsDir, "dummy", "In");
             Directory.CreateDirectory(coverageDir);
 
-           TestUtils.CreateTextFile(testResultsDir, "dummy.trx", TRX_PAYLOAD);
+            TestUtils.CreateTextFile(testResultsDir, "dummy.trx", TRX_PAYLOAD);
             TestUtils.CreateTextFile(coverageDir, "dummy.coverage", "");
 
             var converter = new MockReportConverter();
@@ -183,6 +183,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
         [TestMethod]
         public void ProcessCoverageReports_VsCoverageXmlPathProvided_CoverageXmlFileAlreadyPresent_NotShouldTryConverting()
         {
+
             // Arrange
             var mockSearchFallback = new MockSearchFallback();
             var testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
@@ -212,20 +213,26 @@ namespace SonarScanner.MSBuild.TFS.Tests
 
             testSubject.Initialise(analysisConfig, settings);
 
-            // Act
-            var result = testSubject.ProcessCoverageReports();
+            try
+            {
+                // Act
+                var result = testSubject.ProcessCoverageReports();
 
-            // Assert
-            result.Should().BeTrue();
-            converter.AssertConvertNotCalled();
-            testLogger.AssertWarningsLogged(0);
-
-            TestUtils.DeleteTextFile(coverageDir, "dummy.coveragexml");
+                // Assert
+                result.Should().BeTrue();
+                converter.AssertConvertNotCalled();
+                testLogger.AssertWarningsLogged(0);
+            }
+            finally
+            {
+                TestUtils.DeleteTextFile(coverageDir, "dummy.coveragexml");
+            }
         }
 
         [TestMethod]
         public void ProcessCoverageReports_NotVsCoverageXmlPathProvided_CoverageXmlFileAlreadyPresent_NotShouldTryConverting()
         {
+
             // Arrange
             var mockSearchFallback = new MockSearchFallback();
             var testDir = TestUtils.CreateTestSpecificFolder(this.TestContext);
@@ -255,16 +262,22 @@ namespace SonarScanner.MSBuild.TFS.Tests
             testSubject.Initialise(analysisConfig, settings);
 
             // Act
-            using (new AssertIgnoreScope())
+            try
             {
-                var result = testSubject.ProcessCoverageReports();
 
-                // Assert
-                result.Should().BeTrue();
+                using (new AssertIgnoreScope())
+                {
+                    var result = testSubject.ProcessCoverageReports();
+
+                    // Assert
+                    result.Should().BeTrue();
+                }
+                converter.AssertConvertNotCalled();
             }
-            converter.AssertConvertCalledAtLeastOnce();
-
-            TestUtils.DeleteTextFile(coverageDir, "dummy.coveragexml");
+            finally
+            {
+                TestUtils.DeleteTextFile(coverageDir, "dummy.coveragexml");
+            }
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageReportProcessorTests.cs
@@ -337,8 +337,9 @@ namespace SonarScanner.MSBuild.TFS.Tests
 
             TestUtils.CreateTextFile(coverageDir, "dummy.coverage", "");
 
-            var converter = new MockReportConverterFailing();
+            var converter = new MockReportConverter();
             converter.CanConvert = true;
+            converter.ShouldNotFailConversion = false;
 
             var testSubject = new BuildVNextCoverageReportProcessor(converter, testLogger, mockSearchFallback);
             var settings = new MockBuildSettings

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockReportConverter.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockReportConverter.cs
@@ -66,4 +66,49 @@ namespace SonarScanner.MSBuild.TFS.Tests.Infrastructure
 
         #endregion ICoverageReportConverter interface
     }
+
+    internal class MockReportConverterFailing : ICoverageReportConverter
+    {
+        private int convertCallCount;
+
+        #region Test helpers
+
+        public bool CanConvert { get; set; }
+
+        public bool ConversionResult { get; set; }
+
+        #endregion Test helpers
+
+        #region Assertions
+
+        public void AssertExpectedNumberOfConversions(int expected)
+        {
+            convertCallCount.Should().Be(expected, "ConvertToXml called an unexpected number of times");
+        }
+
+        public void AssertConvertCalledAtLeastOnce()
+        {
+            convertCallCount.Should().BeGreaterThan(0, "ConvertToXml called less than once.");
+        }
+
+        public void AssertConvertNotCalled()
+        {
+            convertCallCount.Should().Be(0, "Not expecting ConvertToXml to have been called");
+        }
+
+        #endregion Assertions
+
+        #region ICoverageReportConverter interface
+
+        bool ICoverageReportConverter.Initialize() => CanConvert;
+
+        bool ICoverageReportConverter.ConvertToXml(string inputFilePath, string outputFilePath)
+        {
+            convertCallCount++;
+
+            return false;
+        }
+
+        #endregion ICoverageReportConverter interface
+    }
 }

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockReportConverter.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/Infrastructure/MockReportConverter.cs
@@ -29,10 +29,20 @@ namespace SonarScanner.MSBuild.TFS.Tests.Infrastructure
         #region Test helpers
 
         public bool CanConvert { get; set; }
+        public bool ShouldNotFailConversion { get; set; }
 
         public bool ConversionResult { get; set; }
 
         #endregion Test helpers
+
+        #region Constructors
+
+        public MockReportConverter()
+        {
+            ShouldNotFailConversion = true;
+        }
+
+        #endregion
 
         #region Assertions
 
@@ -61,52 +71,7 @@ namespace SonarScanner.MSBuild.TFS.Tests.Infrastructure
         {
             convertCallCount++;
 
-            return true;
-        }
-
-        #endregion ICoverageReportConverter interface
-    }
-
-    internal class MockReportConverterFailing : ICoverageReportConverter
-    {
-        private int convertCallCount;
-
-        #region Test helpers
-
-        public bool CanConvert { get; set; }
-
-        public bool ConversionResult { get; set; }
-
-        #endregion Test helpers
-
-        #region Assertions
-
-        public void AssertExpectedNumberOfConversions(int expected)
-        {
-            convertCallCount.Should().Be(expected, "ConvertToXml called an unexpected number of times");
-        }
-
-        public void AssertConvertCalledAtLeastOnce()
-        {
-            convertCallCount.Should().BeGreaterThan(0, "ConvertToXml called less than once.");
-        }
-
-        public void AssertConvertNotCalled()
-        {
-            convertCallCount.Should().Be(0, "Not expecting ConvertToXml to have been called");
-        }
-
-        #endregion Assertions
-
-        #region ICoverageReportConverter interface
-
-        bool ICoverageReportConverter.Initialize() => CanConvert;
-
-        bool ICoverageReportConverter.ConvertToXml(string inputFilePath, string outputFilePath)
-        {
-            convertCallCount++;
-
-            return false;
+            return ShouldNotFailConversion;
         }
 
         #endregion ICoverageReportConverter interface

--- a/src/SonarScanner.MSBuild.TFS/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.TFS/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace SonarScanner.MSBuild.TFS {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Found corresponding Binary-to-XML conversion output file for {0}, no conversion will be attempted..
+        /// </summary>
+        internal static string COVXML_DIAG_FileAlreadyExist_NoConversionAttempted {
+            get {
+                return ResourceManager.GetString("COVXML_DIAG_FileAlreadyExist_NoConversionAttempted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Property &apos;sonar.cs.vscoveragexml.reportsPaths&apos; provided, skipping the search for coveragexml file in default folders....
         /// </summary>
         internal static string COVXML_DIAG_SkippingCoverageCheckPropertyProvided {

--- a/src/SonarScanner.MSBuild.TFS/Resources.resx
+++ b/src/SonarScanner.MSBuild.TFS/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="COVXML_DIAG_FileAlreadyExist_NoConversionAttempted" xml:space="preserve">
+    <value>Found corresponding Binary-to-XML conversion output file for {0}, no conversion will be attempted.</value>
+  </data>
   <data name="COVXML_DIAG_SkippingCoverageCheckPropertyProvided" xml:space="preserve">
     <value>Property 'sonar.cs.vscoveragexml.reportsPaths' provided, skipping the search for coveragexml file in default folders...</value>
   </data>


### PR DESCRIPTION
New - Behavior of the CoverageReport conversion method has slightly changed : now if we detect an existing .coveragexml file beside the coverage file, the method won't fail and the file will be added to the coverage report list at the end. If the converrsion failed itself (so no coveragexml file found, and trying to convert a provided coverage file), then the method will fail, as before.

A unit test has been modified according to that change.