### PR TITLE
Fix - Reverted setting / TryConvertCoverageReports bloc to avoid regression

### DIFF
--- a/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageReportProcessorTests.cs
@@ -145,8 +145,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
 
             // Assert
             result.Should().BeTrue();
-            converter.AssertConvertNotCalled();
-            testLogger.AssertWarningsLogged(0);
+            converter.AssertExpectedNumberOfConversions(1);
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageReportProcessorTests.cs
@@ -136,7 +136,9 @@ namespace SonarScanner.MSBuild.TFS.Tests
                 BuildDirectory = testDir
             };
 
-            analysisConfig.LocalSettings.Add(new Property { Id = SonarProperties.VsCoverageXmlReportsPaths, Value = String.Empty });
+            var coveragePathValue = "ThisIsADummyPath";
+
+            analysisConfig.LocalSettings.Add(new Property { Id = SonarProperties.VsCoverageXmlReportsPaths, Value = coveragePathValue });
 
             testSubject.Initialise(analysisConfig, settings);
 
@@ -146,6 +148,8 @@ namespace SonarScanner.MSBuild.TFS.Tests
             // Assert
             result.Should().BeTrue();
             converter.AssertExpectedNumberOfConversions(1);
+
+            Assert.AreEqual(analysisConfig.GetSettingOrDefault(SonarProperties.VsCoverageXmlReportsPaths, true, null), coveragePathValue);
         }
 
         [TestMethod]

--- a/src/SonarScanner.MSBuild.TFS/CoverageReportProcessorBase.cs
+++ b/src/SonarScanner.MSBuild.TFS/CoverageReportProcessorBase.cs
@@ -80,24 +80,14 @@ namespace SonarScanner.MSBuild.TFS
                 }
             }
 
-            var success = true;
-
-            if (config.GetSettingOrDefault(SonarProperties.VsCoverageXmlReportsPaths, true, null) != null)
+            var success = TryGetVsCoverageFiles(this.config, this.settings, out var vscoveragePaths);
+            if (success &&
+                vscoveragePaths.Any() &&
+                TryConvertCoverageReports(vscoveragePaths, out var coverageReportPaths) &&
+                coverageReportPaths.Any() &&
+                config.GetSettingOrDefault(SonarProperties.VsCoverageXmlReportsPaths, true, null) == null)
             {
-                Logger.LogInfo(Resources.COVXML_DIAG_SkippingCoverageCheckPropertyProvided);
-            }
-            else
-            {
-                success = TryGetVsCoverageFiles(this.config, this.settings, out var vscoveragePaths);
-
-                if(success && vscoveragePaths.Any())
-                {
-                    if (TryConvertCoverageReports(vscoveragePaths, out var coverageReportPaths) &&
-                    coverageReportPaths.Any())
-                    {
-                        this.config.LocalSettings.Add(new Property { Id = SonarProperties.VsCoverageXmlReportsPaths, Value = string.Join(",", coverageReportPaths) });
-                    }
-                }
+                this.config.LocalSettings.Add(new Property { Id = SonarProperties.VsCoverageXmlReportsPaths, Value = string.Join(",", coverageReportPaths) });
 
             }
 


### PR DESCRIPTION
As per the documentation (https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Extension+for+VSTS-TFS) we ask users to provide the property sonar.cs.vscoveragexml.reportsPaths set if they want code coverage to be uploaded to SonarCloud. Thus, with the previous fix, the scanner won't try to convert any coverage file if this setting is present, which can broke existing builds for users.