### PR TITLE
Clarify error message for not found MSBuild path

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -246,7 +246,7 @@ public class TestUtils {
     Path msBuildPath = Paths.get(msBuildPathStr).toAbsolutePath();
     if (!Files.exists(msBuildPath)) {
       throw new IllegalStateException("Unable to find MSBuild at " + msBuildPath.toString()
-        + ". Please configure property 'msbuild.path' or 'MSBUILD_PATH'.");
+        + ". Please configure property 'msbuild.path' or 'MSBUILD_PATH' environment variable to the full path to MSBuild.exe.");
     }
     return msBuildPath;
   }


### PR DESCRIPTION
Environment variable was already taken in account while checking for … msbuild path. Just clarified the error message to provide the full msbuild path with the exe in that environment variable.

fixes #767 