### PR TITLE
Upgrade orchestrator to v3.27.0.2172

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.26.0.2111</version>
+      <version>3.27.0.2172</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
fixes #780 

Looks like the only depreciation that we have after the upgrade is the .setComponentKey(componentKey) in the new ComponentWsRequest() class (sonar-ws), but haven't find any alternative yet. 