### PR TITLE
Update global tool version to also target netcoreapp3.0

### DIFF
--- a/src/DotnetVersions.props
+++ b/src/DotnetVersions.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ScannerNetStandardVersion>netstandard2.0</ScannerNetStandardVersion>
     <ScannerNetCoreAppVersion>netcoreapp2.0</ScannerNetCoreAppVersion>
-    <ScannerNetCoreGlobalToolVersion>netcoreapp2.1</ScannerNetCoreGlobalToolVersion>
+    <ScannerNetCoreGlobalToolVersion>netcoreapp2.1;netcoreapp3.0</ScannerNetCoreGlobalToolVersion>
     <ScannerNetFxVersion>net46</ScannerNetFxVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
When using the SonarQube dotnet global tool in SDK 3.0 docker images it fails as the tool only targets netcoreapp2.1.

By targeting netcoreapp3.0 a nuget with multiple binaries will be published thus supporting both runtimes.

Relates to #797