### PR TITLE
Fix packages generation and names + Added .NET Core 3 package for Chocolatey

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,6 +173,7 @@ stages:
 
             $classicScannerZipPath = Get-Item "$artifactsFolder\\sonarscanner-msbuild-net46.zip"
             $dotnetScannerZipPath = Get-Item "$artifactsFolder\\sonarscanner-msbuild-netcoreapp2.0.zip"
+            $dotnetScannerZipPath3 = Get-Item "$artifactsFolder\\sonarscanner-msbuild-netcoreapp3.0.zip"
             $dotnetScannerGlobalToolPath = Get-Item "$artifactsFolder\\dotnet-sonarscanner.$leakPeriodVersion.nupkg"
 
             Write-Host "Generating the chocolatey packages"
@@ -188,11 +189,21 @@ stages:
               -Replace '-Checksum "not-set"', "-Checksum $dotnetZipHash" `
             | Set-Content $netcoreps1
 
+            $dotnetZipHash3 = (Get-FileHash $dotnetScannerZipPath3 -Algorithm SHA256).hash
+            $netcoreps13 = "nuspec\chocolatey\chocolateyInstall-netcoreapp3.0.ps1"
+            (Get-Content $netcoreps13) `
+              -Replace '-Checksum "not-set"', "-Checksum $dotnetZipHash3" `
+            | Set-Content $netcoreps13
+
             choco pack nuspec\chocolatey\sonarscanner-msbuild-net46.nuspec `
             --outputdirectory $artifactsFolder `
             --version $version
              
             choco pack nuspec\chocolatey\sonarscanner-msbuild-netcoreapp2.0.nuspec `
+            --outputdirectory $artifactsFolder `
+            --version $version
+
+            choco pack nuspec\chocolatey\sonarscanner-msbuild-netcoreapp3.0.nuspec `
             --outputdirectory $artifactsFolder `
             --version $version
 
@@ -203,7 +214,8 @@ stages:
              -Replace 'dotnetScannerZipPath', "$dotnetScannerZipPath" `
              -Replace 'dotnetScannerGlobalToolPath', "$dotnetScannerGlobalToolPath" `
              -Replace 'classicScannerChocoPath', "$artifactsFolder\\sonarscanner-msbuild-net46.$version.nupkg" `
-             -Replace 'dotnetScannerChocoPath', "$artifactsFolder\\sonarscanner-msbuild-netcoreapp2.0.$version.nupkg" `
+             -Replace 'dotnetcore2ScannerChocoPath', "$artifactsFolder\\sonarscanner-msbuild-netcoreapp2.0.$version.nupkg" `
+             -Replace 'dotnetcore3ScannerChocoPath', "$artifactsFolder\\sonarscanner-msbuild-netcoreapp3.0.$version.nupkg" `
             | Set-Content $pomFile
       - task: Maven@3
         displayName: Promote new version in pom
@@ -236,6 +248,15 @@ stages:
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.11'
           mavenOptions: $(MAVEN_OPTS)
+      - task: PowerShell@2
+        displayName: "Rename artifacts for GitHub Release"
+        inputs:
+          targetType: 'inline'
+          script: |
+            $artifactsFolder = "$env:BUILD_SOURCESDIRECTORY\\DeploymentArtifacts\\BuildAgentPayload\\Release"
+            Rename-Item -Path "$artifactsFolder\\sonarscanner-msbuild-net46.zip" -NewName sonarscanner-msbuild-$(SONAR_PROJECT_VERSION).$(Build.BuildId)-net46.zip
+            Rename-Item -Path "$artifactsFolder\\sonarscanner-msbuild-netcoreapp2.0.zip" -NewName sonarscanner-msbuild-$(SONAR_PROJECT_VERSION).$(Build.BuildId)-netcoreapp2.0.zip
+            Rename-Item -Path "$artifactsFolder\\sonarscanner-msbuild-netcoreapp3.0.zip" -NewName sonarscanner-msbuild-$(SONAR_PROJECT_VERSION).$(Build.BuildId)-netcoreapp3.0.zip
       - task: PublishPipelineArtifact@1
         displayName: 'Publish packages as artifacts'
         inputs:

--- a/nuspec/chocolatey/chocolateyInstall-netcoreapp3.0.ps1
+++ b/nuspec/chocolatey/chocolateyInstall-netcoreapp3.0.ps1
@@ -1,0 +1,5 @@
+﻿Install-ChocolateyZipPackage "sonarscanner-msbuild-netcoreapp3.0" `
+    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/$env:ChocolateyPackageVersion/sonar-scanner-msbuild-$env:ChocolateyPackageVersion-netcoreapp3.0.zip" `
+    -UnzipLocation "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" `
+    -ChecksumType 'sha256' `
+    -Checksum "not-set"

--- a/nuspec/chocolatey/sonarscanner-msbuild-netcoreapp3.0.nuspec
+++ b/nuspec/chocolatey/sonarscanner-msbuild-netcoreapp3.0.nuspec
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>sonarscanner-msbuild-netcoreapp3.0</id>
+    <version>1.0.0</version>
+    <title>SonarScanner for MSBuild .Net Core 3.0</title>
+    <authors>SonarSource,Microsoft</authors>
+    <owners>SonarSource</owners>
+    <projectUrl>http://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>
+    <projectSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild</projectSourceUrl>
+    <packageSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild/tree/master/nuspec/chocolatey</packageSourceUrl>
+    <iconUrl>https://cdn.rawgit.com/SonarSource/sonar-scanner-msbuild/cdd1f588/icon.png</iconUrl>
+    <licenseUrl>https://github.com/SonarSource/sonar-scanner-msbuild/blob/master/LICENSE.txt</licenseUrl>
+    <docsUrl>https://redirect.sonarsource.com/doc/install-configure-scanner-msbuild.html</docsUrl>
+    <mailingListUrl>https://community.sonarsource.com/</mailingListUrl>
+    <bugTrackerUrl>https://github.com/SonarSource/sonar-scanner-msbuild/issues</bugTrackerUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <summary>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</summary>
+    <description>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</description>
+    <tags>sonarqube sonarcloud msbuild scanner sonarsource sonar sonar-scanner sonarscanner</tags>
+    <copyright>SonarSource SA and Microsoft Corporation</copyright>
+    <releaseNotes>
+All release notes for SonarScanner MSBuild .Net Core can be found on the GitHub site - https://github.com/SonarSource/sonar-scanner-msbuild/releases
+    </releaseNotes>
+  </metadata>
+  <files>
+    <file src="chocolateyInstall-netcoreapp3.0.ps1" target="tools\chocolateyInstall.ps1" />
+  </files>
+</package>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.sonarsource.parent</groupId>
@@ -45,7 +45,7 @@
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <gitRepositoryName>sonar-scanner-msbuild</gitRepositoryName>
     <!-- Release: enable publication to Bintray -->
-    <artifactsToPublish>${project.groupId}:${project.artifactId}:zip:net46,${project.groupId}:${project.artifactId}:zip:netcoreapp2.0</artifactsToPublish>
+    <artifactsToPublish>${project.groupId}:${project.artifactId}:zip:net46,${project.groupId}:${project.artifactId}:zip:netcoreapp2.0,${project.groupId}:${project.artifactId}:zip:netcoreapp3.0</artifactsToPublish>
   </properties>
 
   <build>
@@ -76,7 +76,7 @@
                 <artifact>
                   <file>dotnetScannerGlobalToolPath</file>
                   <type>nupkg</type>
-                  <classifier>netcoreapp2.1</classifier>
+                  <classifier>netcoreapp2.1;netcoreapp3.0</classifier>
                 </artifact>
                 <artifact>
                   <file>classicScannerChocoPath</file>
@@ -84,15 +84,20 @@
                   <classifier>net46</classifier>
                 </artifact>
                 <artifact>
-                  <file>dotnetScannerChocoPath</file>
+                  <file>dotnetcore2ScannerChocoPath</file>
                   <type>nupkg</type>
                   <classifier>netcoreapp2.0</classifier>
+                </artifact>
+                <artifact>
+                  <file>dotnetcore3ScannerChocoPath</file>
+                  <type>nupkg</type>
+                  <classifier>netcoreapp3.0</classifier>
                 </artifact>
               </artifacts>
             </configuration>
           </execution>
         </executions>
-        </plugin>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/DotnetVersions.props
+++ b/src/DotnetVersions.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <ScannerNetStandardVersion>netstandard2.0</ScannerNetStandardVersion>
-    <ScannerNetCoreAppVersion>netcoreapp2.0</ScannerNetCoreAppVersion>
+    <ScannerNetCoreAppVersion>netcoreapp2.0;netcoreapp3.0</ScannerNetCoreAppVersion>
     <ScannerNetCoreGlobalToolVersion>netcoreapp2.1;netcoreapp3.0</ScannerNetCoreGlobalToolVersion>
     <ScannerNetFxVersion>net46</ScannerNetFxVersion>
   </PropertyGroup>

--- a/src/Packaging/Packaging.csproj
+++ b/src/Packaging/Packaging.csproj
@@ -271,7 +271,7 @@
   </Target>
 
   <!-- Don't create the zip for netcoreapp2.1 -->
-  <Target Name="ZipPayloadFiles" Condition=" '$(TargetFramework)' != '$(ScannerNetCoreGlobalToolVersion)' AND $(Configuration) == 'Release' ">
+  <Target Name="ZipPayloadFiles" Condition=" '$(TargetFramework)' != 'netcoreapp2.1' AND '$(Configuration)' == 'Release' ">
     <Message Importance="high" Text="Zipping ScannerCli:" />
     <Message Importance="high" Text="  Source: $(WorkDestinationDir)" />
     <Message Importance="high" Text="  Target: $(DestinationArtifactPath)" />


### PR DESCRIPTION
fixes #808 

In the process of packaging upcoming 4.8.0, package names were incorrect for some of them in the artifact. This has been correct. 
I took the benefit of this PR for adding .NET Core 3 package to Chocolatey as well, which was not provided nor packaged with the previous .NET Core 3 PR. 