### PR TITLE
Use fixed version number in Chocolatey package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,20 +180,23 @@ stages:
             $classicZipHash = (Get-FileHash $classicScannerZipPath -Algorithm SHA256).hash
             $net46ps1 = "nuspec\chocolatey\chocolateyInstall-net46.ps1"
             (Get-Content $net46ps1) `
-             -Replace '-Checksum "not-set"', "-Checksum $classicZipHash" `
+              -Replace '-Checksum "not-set"', "-Checksum $classicZipHash" `
+              -Replace "__PackageVersion__", "$version" `
             | Set-Content $net46ps1
 
             $dotnetZipHash = (Get-FileHash $dotnetScannerZipPath -Algorithm SHA256).hash
             $netcoreps1 = "nuspec\chocolatey\chocolateyInstall-netcoreapp2.0.ps1"
             (Get-Content $netcoreps1) `
               -Replace '-Checksum "not-set"', "-Checksum $dotnetZipHash" `
-            | Set-Content $netcoreps1
+              -Replace "__PackageVersion__", "$version" `
+              | Set-Content $netcoreps1
 
             $dotnetZipHash3 = (Get-FileHash $dotnetScannerZipPath3 -Algorithm SHA256).hash
             $netcoreps13 = "nuspec\chocolatey\chocolateyInstall-netcoreapp3.0.ps1"
             (Get-Content $netcoreps13) `
               -Replace '-Checksum "not-set"', "-Checksum $dotnetZipHash3" `
-            | Set-Content $netcoreps13
+              -Replace "__PackageVersion__", "$version" `
+              | Set-Content $netcoreps13
 
             choco pack nuspec\chocolatey\sonarscanner-msbuild-net46.nuspec `
             --outputdirectory $artifactsFolder `

--- a/nuspec/chocolatey/chocolateyInstall-net46.ps1
+++ b/nuspec/chocolatey/chocolateyInstall-net46.ps1
@@ -1,5 +1,5 @@
 ﻿Install-ChocolateyZipPackage "sonarscanner-msbuild-net46" `
-    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/$env:ChocolateyPackageVersion/sonar-scanner-msbuild-$env:ChocolateyPackageVersion-net46.zip" `
+    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/__PackageVersion__/sonar-scanner-msbuild-__PackageVersion__-net46.zip" `
     -UnzipLocation "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" `
     -ChecksumType 'sha256' `
     -Checksum "not-set"

--- a/nuspec/chocolatey/chocolateyInstall-netcoreapp2.0.ps1
+++ b/nuspec/chocolatey/chocolateyInstall-netcoreapp2.0.ps1
@@ -1,5 +1,5 @@
 ﻿Install-ChocolateyZipPackage "sonarscanner-msbuild-netcoreapp2.0" `
-    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/$env:ChocolateyPackageVersion/sonar-scanner-msbuild-$env:ChocolateyPackageVersion-netcoreapp2.0.zip" `
+    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/__PackageVersion__/sonar-scanner-msbuild-__PackageVersion__-netcoreapp2.0.zip" `
     -UnzipLocation "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" `
     -ChecksumType 'sha256' `
     -Checksum "not-set"

--- a/nuspec/chocolatey/chocolateyInstall-netcoreapp3.0.ps1
+++ b/nuspec/chocolatey/chocolateyInstall-netcoreapp3.0.ps1
@@ -1,5 +1,5 @@
 ﻿Install-ChocolateyZipPackage "sonarscanner-msbuild-netcoreapp3.0" `
-    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/$env:ChocolateyPackageVersion/sonar-scanner-msbuild-$env:ChocolateyPackageVersion-netcoreapp3.0.zip" `
+    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/__PackageVersion__/sonar-scanner-msbuild-__PackageVersion__-netcoreapp3.0.zip" `
     -UnzipLocation "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" `
     -ChecksumType 'sha256' `
     -Checksum "not-set"


### PR DESCRIPTION
Use fixed version number in Chocolatey package instead of using the `ChocolateyPackageVersion` environment variable, which allows to internalize the package with `choco download` as asked for [here](https://chocolatey.org/packages/sonarscanner-msbuild-net46#comment-4722817110).