### PR TITLE
Dedupe coverage files on file content

### DIFF
--- a/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
@@ -73,7 +73,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var expected2 = TestUtils.CreateTextFile(dir, "DUPLICATE.coverage", "4");
 
             TestUtils.CreateTextFile(dir, "BAR.coverage.XXX", "");
-            TestUtils.CreateTextFile(dir, "Duplicate.coverage", ""); // appears in both places - only one should be returned
+            TestUtils.CreateTextFile(dir, "Duplicate.coverage", "4"); // appears in both places - only one should be returned
             var expected3 = TestUtils.CreateTextFile(subDir, "BAR.COVERAGE", "5"); // should be found
 
             using (var envVars = new EnvironmentVariableScope())

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
@@ -67,14 +67,14 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var subDir = Path.Combine(dir, "subDir", "subDir2");
             Directory.CreateDirectory(subDir);
 
-            TestUtils.CreateTextFile(dir, "foo.coverageXXX", "");
-            TestUtils.CreateTextFile(dir, "abc.trx", "");
-            var expected1 = TestUtils.CreateTextFile(dir, "foo.coverage", "");
-            var expected2 = TestUtils.CreateTextFile(dir, "DUPLICATE.coverage", "");
+            TestUtils.CreateTextFile(dir, "foo.coverageXXX", "1");
+            TestUtils.CreateTextFile(dir, "abc.trx", "2");
+            var expected1 = TestUtils.CreateTextFile(dir, "foo.coverage", "3");
+            var expected2 = TestUtils.CreateTextFile(dir, "DUPLICATE.coverage", "4");
 
             TestUtils.CreateTextFile(dir, "BAR.coverage.XXX", "");
             TestUtils.CreateTextFile(dir, "Duplicate.coverage", ""); // appears in both places - only one should be returned
-            var expected3 = TestUtils.CreateTextFile(subDir, "BAR.COVERAGE", ""); // should be found
+            var expected3 = TestUtils.CreateTextFile(subDir, "BAR.COVERAGE", "5"); // should be found
 
             using (var envVars = new EnvironmentVariableScope())
             {
@@ -140,7 +140,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             testSubject.Equals(
                 new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path1.txt", "contenthash"),
                 new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path2.txt", "contenthash2")
-            ).Should().BeTrue();
+            ).Should().BeFalse();
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
@@ -105,6 +105,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
             var expected2 = TestUtils.CreateTextFile(dir, fileTwo, fileTwo);
             var expected3 = TestUtils.CreateTextFile(dir, fileThree, fileThree);
             TestUtils.CreateTextFile(dir, fileOneDuplicate, fileOne); // Same content as fileOne, should not be expected
+            TestUtils.CreateTextFile(subDir, fileOne, fileOne); // Same content and filename, but in other dir, as fileOne, should not be expected
 
             using (var envVars = new EnvironmentVariableScope())
             {
@@ -126,20 +127,20 @@ namespace SonarScanner.MSBuild.TFS.Tests
 
             // Identical content hash, identical file name -> same
             testSubject.Equals(
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path1.txt", "contenthash"),
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path1.txt", "contenthash")
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path1.txt", new byte[]{ 1, 2 }),
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path1.txt", new byte[]{ 1, 2 })
             ).Should().BeTrue();
 
             // Identical content hash, different file name -> same
             testSubject.Equals(
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path1.txt", "contenthash"),
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path2.txt", "contenthash")
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path1.txt", new byte[]{ 1, 2 }),
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path2.txt", new byte[]{ 1, 2 })
             ).Should().BeTrue();
 
             // Different content hash, identical file name -> different
             testSubject.Equals(
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path1.txt", "contenthash"),
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path2.txt", "contenthash2")
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path1.txt", new byte[]{ 1, 2 }),
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("c:\\path2.txt", new byte[]{ 1, 3 })
             ).Should().BeFalse();
         }
 
@@ -149,12 +150,12 @@ namespace SonarScanner.MSBuild.TFS.Tests
             // Arrange
             var comparer = new BuildVNextCoverageSearchFallback.FileHashComparer();
             BuildVNextCoverageSearchFallback.FileWithContentHash[] input = {
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("", "contenthash1"),
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("", "contenthash1"),
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("", "contenthash2"),
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("", "contenthash2"),
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("", "contenthash3"),
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("", "contenthash3")
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("", new byte[]{ 1 }),
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("", new byte[]{ 1 }),
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("", new byte[]{ 1, 2 }),
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("", new byte[]{ 1, 2 }),
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("", new byte[]{ 1, 2, 3 }),
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("", new byte[]{ 1, 2, 3 })
             };
 
             // Act
@@ -162,9 +163,9 @@ namespace SonarScanner.MSBuild.TFS.Tests
 
             // Assert
             actual.Should().BeEquivalentTo(
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("", "contenthash1"),
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("", "contenthash2"),
-                new BuildVNextCoverageSearchFallback.FileWithContentHash("", "contenthash3")
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("", new byte[]{ 1 }),
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("", new byte[]{ 1, 2 }),
+                new BuildVNextCoverageSearchFallback.FileWithContentHash("", new byte[]{ 1, 2, 3 })
             );
         }
     }

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
@@ -121,7 +121,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
 
 
         [TestMethod]
-        public void Fallback_FileNameComparer_SimpleComparisons()
+        public void Fallback_FileHashComparer_SimpleComparisons()
         {
             var testSubject = new BuildVNextCoverageSearchFallback.FileHashComparer();
 
@@ -145,7 +145,7 @@ namespace SonarScanner.MSBuild.TFS.Tests
         }
 
         [TestMethod]
-        public void Fallback_FileNameComparer_CorrectlyDeDupesList()
+        public void Fallback_FileHashComparer_CorrectlyDeDupesList()
         {
             // Arrange
             var comparer = new BuildVNextCoverageSearchFallback.FileHashComparer();

--- a/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Tests/BuildVNextCoverageSearchFallbackTests.cs
@@ -20,15 +20,17 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TestUtilities;
 
 namespace SonarScanner.MSBuild.TFS.Tests
 {
     [TestClass]
-    public class BuildVNextCoverageSeachFallbackTests
+    public class BuildVNextCoverageSearchFallbackTests
     {
         public TestContext TestContext { get; set; }
 

--- a/src/SonarScanner.MSBuild.TFS/IBuildVNextCoverageSearchFallback.cs
+++ b/src/SonarScanner.MSBuild.TFS/IBuildVNextCoverageSearchFallback.cs
@@ -84,7 +84,7 @@ namespace SonarScanner.MSBuild.TFS
                 using (var bufferedStream = new BufferedStream(fileStream))
                 using (var sha = new SHA256Managed())
                 {
-                    var contentHash = sha.ComputeHash(bufferedStream).ToString();
+                    var contentHash = sha.ComputeHash(bufferedStream);
 
                     return new FileWithContentHash(fullFilePath, contentHash);
                 }
@@ -133,18 +133,19 @@ namespace SonarScanner.MSBuild.TFS
         {
             public bool Equals(FileWithContentHash x, FileWithContentHash y)
             {
-                return string.Equals(x.ContentHash, y.ContentHash, StringComparison.Ordinal);
+                return x.ContentHash.SequenceEqual(y.ContentHash);
             }
 
             public int GetHashCode(FileWithContentHash obj)
             {
-                return obj.ContentHash.GetHashCode();
+                // We solely rely on `Equals`
+                return 0;
             }
         }
 
         internal class FileWithContentHash
         {
-            public FileWithContentHash(string fullFilePath, string contentHash)
+            public FileWithContentHash(string fullFilePath, byte[] contentHash)
             {
                 FullFilePath = fullFilePath;
                 ContentHash = contentHash;
@@ -152,7 +153,7 @@ namespace SonarScanner.MSBuild.TFS
 
             public string FullFilePath { get; }
 
-            public string ContentHash { get; }
+            public byte[] ContentHash { get; }
         }
     }
 }

--- a/src/SonarScanner.MSBuild.TFS/IBuildVNextCoverageSearchFallback.cs
+++ b/src/SonarScanner.MSBuild.TFS/IBuildVNextCoverageSearchFallback.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using SonarScanner.MSBuild.Common;
 
 // HACK: Workaround for VSTS-179
@@ -74,16 +75,28 @@ namespace SonarScanner.MSBuild.TFS
                 Logger.LogInfo($"No coverage files found in the agent temp directory.");
                 return Enumerable.Empty<string>();
             }
-            else
-            {
-                LogDebugFileList("All matching files:", files);
 
-                // The same file might appear in multiple paths.
-                // We're assuming the files are identical so it doesn't matter which one we pick.
-                files = files.Distinct(new FileNameComparer()).ToArray();
-                LogDebugFileList("Unique coverage files:", files);
-                return files;
-            }
+            LogDebugFileList("All matching files:", files);
+
+            var fileWithContentHashes = files.Select(fullFilePath =>
+            {
+                using (var fileStream = new FileStream(fullFilePath, FileMode.Open))
+                using (var bufferedStream = new BufferedStream(fileStream))
+                using (var sha = new SHA256Managed())
+                {
+                    var contentHash = sha.ComputeHash(bufferedStream).ToString();
+
+                    return new FileWithContentHash(fullFilePath, contentHash);
+                }
+            });
+
+            files = fileWithContentHashes
+                .Distinct(new FileHashComparer())
+                .Select(s => s.FullFilePath)
+                .ToArray();
+
+            LogDebugFileList("Unique coverage files:", files);
+            return files;
         }
 
         internal /* for testing */ string GetAgentTempDirectory()
@@ -114,25 +127,32 @@ namespace SonarScanner.MSBuild.TFS
         }
 
         /// <summary>
-        /// Compares full file paths based on just the file name part
-        /// i.e. c:\aaa\bbb\file1.txt and c:\aaa\file1.txt are equal.
+        /// Compares file name and content hash tuples based on their hashes
         /// </summary>
-        internal class FileNameComparer : IEqualityComparer<string>
+        internal class FileHashComparer : IEqualityComparer<FileWithContentHash>
         {
-            public bool Equals(string x, string y)
+            public bool Equals(FileWithContentHash x, FileWithContentHash y)
             {
-                bool result = string.Equals(GetFileNameFromPath(x), GetFileNameFromPath(y), StringComparison.OrdinalIgnoreCase);
-                return result;
+                return string.Equals(x.ContentHash, y.ContentHash, StringComparison.OrdinalIgnoreCase);
             }
 
-            public int GetHashCode(string obj)
+            public int GetHashCode(FileWithContentHash obj)
             {
-                return GetFileNameFromPath(obj).GetHashCode();
+                return obj.ContentHash.GetHashCode();
             }
-
-            private static string GetFileNameFromPath(string fullPath) =>
-                Path.GetFileName(fullPath).ToUpperInvariant();
         }
 
+        internal class FileWithContentHash
+        {
+            public FileWithContentHash(string fullFilePath, string contentHash)
+            {
+                FullFilePath = fullFilePath;
+                ContentHash = contentHash;
+            }
+
+            public string FullFilePath { get; }
+
+            public string ContentHash { get; }
+        }
     }
 }

--- a/src/SonarScanner.MSBuild.TFS/IBuildVNextCoverageSearchFallback.cs
+++ b/src/SonarScanner.MSBuild.TFS/IBuildVNextCoverageSearchFallback.cs
@@ -133,7 +133,7 @@ namespace SonarScanner.MSBuild.TFS
         {
             public bool Equals(FileWithContentHash x, FileWithContentHash y)
             {
-                return string.Equals(x.ContentHash, y.ContentHash, StringComparison.OrdinalIgnoreCase);
+                return string.Equals(x.ContentHash, y.ContentHash, StringComparison.Ordinal);
             }
 
             public int GetHashCode(FileWithContentHash obj)


### PR DESCRIPTION
Changing the way duplicate .coverage files are discovered as explained in #848 

Need to verify whether the possible performance impact is acceptable before merging.