### PR TITLE
set WebClient encoding to UTF-8

### DIFF
--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
@@ -64,6 +64,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             }
 
             this.client = new PersistentUserAgentWebClient($"ScannerMSBuild/{Utilities.ScannerVersion}");
+            this.client.Encoding = Encoding.UTF8;
 
             if (userName != null)
             {


### PR DESCRIPTION
While analyzing my project with (nearly) all rules I found that the rule for copyright header (S1451) is locally analyzed correctly (SonarAnalyzer.CSharp) but not in SonarQube/SonarCloud.

My name contains a german umlaut (ü) which was expected to be part of the copyright header.

I checked the API call at sonarcloud.io for details on S1451 rule using web browser. It contains the umlaut as expected.

I debugged sonar-scanner-msbuild and found that the rule configuration is corrupted after download.

Therefore I recommend to explicitly download using fixes encoding UTF-8.

I'm unsure how to create a valid unit test therefore...