### PR TITLE
Add support for pure .NET Core Projects

### DIFF
--- a/Tests/SonarScanner.MSBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
@@ -43,7 +43,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
 
 
         [TestMethod]
-        public void PostProc_ExecutionFailsIfSonarScannerFails()
+        public void PostProc_ExecutionFailsIfScannerFails()
         {
             // Arrange
             var context = new PostProcTestContext(TestContext);
@@ -361,7 +361,6 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
 
         private static bool Execute(PostProcTestContext context, params string[] args)
         {
-
             var sonarProjectPropertiesValidator = new Mock<ISonarProjectPropertiesValidator>();
 
             IEnumerable<string> expectedValue;

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Tests/MSBuildPostProcessorTests.cs
@@ -28,6 +28,7 @@ using TestUtilities;
 using SonarScanner.MSBuild.Common.Interfaces;
 using SonarScanner.MSBuild.Shim;
 using SonarScanner.MSBuild.Shim.Interfaces;
+using System.IO;
 using System.Linq;
 
 namespace SonarScanner.MSBuild.PostProcessor.Tests
@@ -43,35 +44,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
 
 
         [TestMethod]
-        public void PostProc_ExecutionFailsIfScannerFails()
-        {
-            // Arrange
-            var context = new PostProcTestContext(TestContext);
-            context.Config.SonarOutputDir = Environment.CurrentDirectory;
-            context.Config.SonarConfigDir = Environment.CurrentDirectory;
-            context.Config.SonarQubeHostUrl = "http://sonarqube.com";
-            context.Config.SonarScannerWorkingDirectory = Environment.CurrentDirectory;
-            context.Scanner.ValueToReturn = false;
-            context.TfsProcessor.ValueToReturn = true;
-
-            // Act
-            var success = Execute(context);
-
-            // Assert
-            success.Should().BeFalse("Not expecting post-processor to have succeeded");
-
-            context.TfsProcessor.AssertExecuted();
-            context.Scanner.AssertExecuted();
-
-            context.Logger.AssertErrorsLogged(0);
-            context.Logger.AssertWarningsLogged(0);
-
-            // Verify that the method was called at least once
-            context.TargetsUninstaller.Verify(m => m.UninstallTargets());
-        }
-
-        [TestMethod]
-        public void PostProc_ExecutionSucceeds()
+        public void PostProc_NoProjectsToAnalyze_NoExecutionTriggered()
         {
             // Arrange
             var context = new PostProcTestContext(TestContext);
@@ -83,17 +56,13 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.TfsProcessor.ValueToReturn = true;
 
             // Act
-            var success = Execute(context);
+            var success = Execute_WithNoProject(context, true);
 
             // Assert
-            success.Should().BeTrue("Expecting post-processor to have succeeded");
+            success.Should().BeFalse("Expecting post-processor to have failed");
 
-            context.TfsProcessor.AssertExecuted();
-            context.Scanner.AssertExecuted();
-
-            context.Scanner.SuppliedCommandLineArgs.Should().Equal(
-                new string[] { "-Dsonar.scanAllFiles=true" },
-                "Unexpected command line args passed to the sonar-scanner");
+            context.TfsProcessor.AssertNotExecuted();
+            context.Scanner.AssertNotExecuted();
 
             context.Logger.AssertErrorsLogged(0);
             context.Logger.AssertWarningsLogged(0);
@@ -116,7 +85,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Scanner.ErrorToLog = "Errors";
 
             // Act
-            var success = Execute(context);
+            var success = Execute(context, true);
 
             // Assert
             success.Should().BeTrue("Expecting post-processor to have succeeded");
@@ -145,7 +114,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Config.SonarScannerWorkingDirectory = Environment.CurrentDirectory;
 
             // Act
-            var success = Execute(context, "/d:sonar.foo=bar");
+            var success = Execute(context, true, "/d:sonar.foo=bar");
 
             // Assert
             success.Should().BeFalse("Expecting post-processor to have failed");
@@ -191,7 +160,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             };
 
             // Act
-            var success = Execute(context, suppliedArgs);
+            var success = Execute(context, true, suppliedArgs);
 
             // Assert
             success.Should().BeTrue("Expecting post-processor to have succeeded");
@@ -222,7 +191,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.TfsProcessor.ValueToReturn = false;
 
             // Act
-            var success = Execute(context, args: new string[0]);
+            var success = Execute(context, true, args: new string[0]);
 
             // Assert
             success.Should().BeFalse();
@@ -247,7 +216,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.TfsProcessor.ValueToReturn = false;
 
             // Act
-            var success = Execute(context, args: "/d:sonar.login=foo");
+            var success = Execute(context, true, args: "/d:sonar.login=foo");
 
             // Assert
             success.Should().BeFalse();
@@ -272,7 +241,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Scanner.ValueToReturn = true;
 
             // Act
-            var success = Execute(context, args: new string[0]);
+            var success = Execute(context, true, args: new string[0]);
 
             // Assert
             success.Should().BeTrue();
@@ -292,7 +261,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             context.Scanner.ValueToReturn = true;
 
             // Act
-            var success = Execute(context, args: "/d:sonar.login=foo");
+            var success = Execute(context, true, args: "/d:sonar.login=foo");
 
             // Assert
             success.Should().BeTrue();
@@ -353,13 +322,13 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
             public TeamBuildSettings Settings { get; }
             public MockSonarScanner Scanner { get; }
             public TestLogger Logger { get; }
-
+             
             public MockTfsProcessor TfsProcessor { get; }
         }
 
         #region Private methods
 
-        private static bool Execute(PostProcTestContext context, params string[] args)
+        private bool Execute_WithNoProject(PostProcTestContext context, bool propertyWriteSucceeded, params string[] args)
         {
             var sonarProjectPropertiesValidator = new Mock<ISonarProjectPropertiesValidator>();
 
@@ -370,12 +339,58 @@ namespace SonarScanner.MSBuild.PostProcessor.Tests
 
             var proc = new MSBuildPostProcessor(context.Scanner, context.Logger, context.TargetsUninstaller.Object, context.TfsProcessor, sonarProjectPropertiesValidator.Object);
 
+            var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
+
+            var projectInfo = TestUtils.CreateProjectWithFiles(TestContext, "withFiles1", testDir);
+
+            List<ProjectData> listOfProjects = new List<ProjectData>();
+            listOfProjects.Add(new ProjectData(ProjectInfo.Load(projectInfo)));
+
             IEnumerable<ProjectData> expectedListOfProjects = Enumerable.Empty<ProjectData>();
 
             var propertiesFileGenerator = Mock.Of<IPropertiesFileGenerator>();
-            Mock.Get(propertiesFileGenerator).Setup(m => m.TryWriteProperties(It.IsAny<PropertiesWriter>(), out expectedListOfProjects)).Returns(false);
+            Mock.Get(propertiesFileGenerator).Setup(m => m.TryWriteProperties(It.IsAny<PropertiesWriter>(), out expectedListOfProjects)).Returns(propertyWriteSucceeded);
 
-            Mock.Get(propertiesFileGenerator).Setup(m => m.GenerateFile()).Returns(new ProjectInfoAnalysisResult());
+            var projectInfoAnalysisResult = new ProjectInfoAnalysisResult();
+            projectInfoAnalysisResult.Projects.AddRange(listOfProjects);
+            projectInfoAnalysisResult.RanToCompletion = true;
+            projectInfoAnalysisResult.FullPropertiesFilePath = null;
+
+            Mock.Get(propertiesFileGenerator).Setup(m => m.GenerateFile()).Returns(projectInfoAnalysisResult);
+            proc.SetPropertiesFileGenerator(propertiesFileGenerator);
+            var success = proc.Execute(args, context.Config, context.Settings);
+            return success;
+        }
+
+        private bool Execute(PostProcTestContext context, bool propertyWriteSucceeded, params string[] args)
+        {
+            var sonarProjectPropertiesValidator = new Mock<ISonarProjectPropertiesValidator>();
+
+            IEnumerable<string> expectedValue;
+
+            sonarProjectPropertiesValidator
+                .Setup(propValidator => propValidator.AreExistingSonarPropertiesFilesPresent(It.IsAny<string>(), It.IsAny<ICollection<ProjectData>>(), out expectedValue)).Returns(false);
+
+            var proc = new MSBuildPostProcessor(context.Scanner, context.Logger, context.TargetsUninstaller.Object, context.TfsProcessor, sonarProjectPropertiesValidator.Object);
+
+            var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
+
+            var projectInfo = TestUtils.CreateProjectWithFiles(TestContext, "withFiles1", testDir);
+
+            List<ProjectData> listOfProjects = new List<ProjectData>();
+            listOfProjects.Add(new ProjectData(ProjectInfo.Load(projectInfo)));
+
+            IEnumerable<ProjectData> expectedListOfProjects = listOfProjects;
+
+            var propertiesFileGenerator = Mock.Of<IPropertiesFileGenerator>();
+            Mock.Get(propertiesFileGenerator).Setup(m => m.TryWriteProperties(It.IsAny<PropertiesWriter>(), out expectedListOfProjects)).Returns(propertyWriteSucceeded);
+
+            var projectInfoAnalysisResult = new ProjectInfoAnalysisResult();
+            projectInfoAnalysisResult.Projects.AddRange(listOfProjects);
+            projectInfoAnalysisResult.RanToCompletion = true;
+            projectInfoAnalysisResult.FullPropertiesFilePath = Path.Combine(testDir, "sonar-project.properties");
+
+            Mock.Get(propertiesFileGenerator).Setup(m => m.GenerateFile()).Returns(projectInfoAnalysisResult);
             proc.SetPropertiesFileGenerator(propertiesFileGenerator);
             var success = proc.Execute(args, context.Config, context.Settings);
             return success;

--- a/Tests/SonarScanner.MSBuild.Shim.Tests/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Tests/PropertiesFileGeneratorTests.cs
@@ -363,7 +363,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
             };
 
             var projectGuid = Guid.NewGuid();
-            CreateProjectWithFiles("withFiles1", testDir, projectGuid, true, projectSettings);
+            TestUtils.CreateProjectWithFiles(TestContext, "withFiles1", testDir, projectGuid, true, projectSettings);
 
             var result = new PropertiesFileGenerator(config, logger, mockSarifFixer, new RuntimeInformationWrapper()).GenerateFile();
 

--- a/Tests/SonarScanner.MSBuild.Shim.Tests/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Tests/PropertiesFileGeneratorTests.cs
@@ -48,8 +48,8 @@ namespace SonarScanner.MSBuild.Shim.Tests
             var subDir1 = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "dir1");
             var subDir2 = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "dir2");
 
-            CreateEmptyFile(subDir1, "file1.txt");
-            CreateEmptyFile(subDir2, "file2.txt");
+            TestUtils.CreateEmptyFile(subDir1, "file1.txt");
+            TestUtils.CreateEmptyFile(subDir2, "file2.txt");
 
             var logger = new TestLogger();
             var config = new AnalysisConfig() { SonarOutputDir = testDir, SonarQubeHostUrl = "http://sonarqube.com" };
@@ -70,9 +70,9 @@ namespace SonarScanner.MSBuild.Shim.Tests
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
 
-            CreateProjectInfoInSubDir(testDir, "withoutFiles", Guid.NewGuid(), ProjectType.Product, false, "c:\\abc\\withoutfile.proj", "UTF-8"); // not excluded
-            CreateProjectWithFiles("withFiles1", testDir);
-            CreateProjectWithFiles("withFiles2", testDir);
+            TestUtils.CreateProjectInfoInSubDir(testDir, "withoutFiles", Guid.NewGuid(), ProjectType.Product, false, "c:\\abc\\withoutfile.proj", "UTF-8"); // not excluded
+            TestUtils.CreateProjectWithFiles(TestContext, "withFiles1", testDir);
+            TestUtils.CreateProjectWithFiles(TestContext, "withFiles2", testDir);
 
             var logger = new TestLogger();
             var config = CreateValidConfig(testDir);
@@ -93,27 +93,35 @@ namespace SonarScanner.MSBuild.Shim.Tests
         [TestMethod]
         public void FileGen_Duplicate_SameGuid_DifferentCase_ShouldNotIgnoreCase()
         {
-            // Casing can be ignored on windows OS
+            var projectName1 = "withFiles1";
+            var projectName2 = "withFiles2";
 
-            // Arrange
-            var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
+            var testRootDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "projects");
+            var project1Dir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, Path.Combine("projects", projectName1));
 
+            // Casing should not be ignored on non-windows OS
             var mockRuntimeInformation = new Mock<IRuntimeInformationWrapper>();
             mockRuntimeInformation.Setup(m => m.IsOS(System.Runtime.InteropServices.OSPlatform.Windows)).Returns(false);
 
             var guid = Guid.NewGuid();
 
-            CreateProjectInfoInSubDir(testDir, "withoutFiles", guid, ProjectType.Product, false, "c:\\abc\\withoutfile.proj", "UTF-8");
-            CreateProjectInfoInSubDir(testDir, "withoutFiles1", guid, ProjectType.Product, false, "C:\\abc\\withoutFile.proj", "UTF-8"); // not excluded
+            var contentProjectInfo1 = TestUtils.CreateProjectInfoInSubDir(testRootDir, projectName1, guid, ProjectType.Product, false, project1Dir + "\\withoutfile.proj", "UTF-8");
+            TestUtils.CreateProjectInfoInSubDir(testRootDir, projectName2, guid, ProjectType.Product, false, project1Dir + "\\withoutFile.proj", "UTF-8"); // not excluded
+
+            // Create content / managed files if required
+            var contentFile1 = TestUtils.CreateEmptyFile(project1Dir, "contentFile1.txt");
+            var contentFileList1 = TestUtils.CreateFile(project1Dir, "contentList.txt", contentFile1);
+
+            TestUtils.AddAnalysisResult(contentProjectInfo1, AnalysisType.FilesToAnalyze, contentFileList1);
 
             var logger = new TestLogger();
-            var config = CreateValidConfig(testDir);
+            var config = CreateValidConfig(testRootDir);
 
             // Act
             var result = new PropertiesFileGenerator(config, logger, new RoslynV1SarifFixer(logger), mockRuntimeInformation.Object).GenerateFile();
 
             // Assert
-            AssertExpectedStatus("withoutFiles", ProjectInfoValidity.DuplicateGuid, result);
+            AssertExpectedStatus(projectName1, ProjectInfoValidity.DuplicateGuid, result);
             AssertExpectedProjectCount(1, result);
 
             logger.Warnings.Should().HaveCount(2);
@@ -121,35 +129,45 @@ namespace SonarScanner.MSBuild.Shim.Tests
             logger.Warnings.Should().BeEquivalentTo(
                new[]
                {
-                    $"Duplicate ProjectGuid: \"{guid}\". The project will not be analyzed. Project file: \"c:\\abc\\withoutfile.proj\"",
-                    $"Duplicate ProjectGuid: \"{guid}\". The project will not be analyzed. Project file: \"C:\\abc\\withoutFile.proj\"",
+                    $"Duplicate ProjectGuid: \"{guid}\". The project will not be analyzed. Project file: \"{project1Dir}\\withoutfile.proj\"",
+                    $"Duplicate ProjectGuid: \"{guid}\". The project will not be analyzed. Project file: \"{project1Dir}\\withoutFile.proj\"",
                });
         }
 
         [TestMethod]
         public void FileGen_Duplicate_SameGuid_DifferentCase_ShouldIgnoreCase()
         {
-            // Casing can be ignored on windows OS
-
             // Arrange
-            var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
 
+            var projectName1 = "withFiles1";
+            var projectName2 = "withFiles2";
+
+            var testRootDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "projects");
+            var project1Dir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, Path.Combine("projects", projectName1));
+
+            // Casing can be ignored on windows OS
             var mockRuntimeInformation = new Mock<IRuntimeInformationWrapper>();
             mockRuntimeInformation.Setup(m => m.IsOS(System.Runtime.InteropServices.OSPlatform.Windows)).Returns(true);
 
             var guid = Guid.NewGuid();
 
-            CreateProjectInfoInSubDir(testDir, "withoutFiles", guid, ProjectType.Product, false, "c:\\abc\\withoutfile.proj", "UTF-8");
-            CreateProjectInfoInSubDir(testDir, "withoutFiles1", guid, ProjectType.Product, false, "C:\\abc\\withoutFile.proj", "UTF-8"); // not excluded
+            var contentProjectInfo1 = TestUtils.CreateProjectInfoInSubDir(testRootDir, projectName1, guid, ProjectType.Product, false, project1Dir + "\\withoutfile.proj", "UTF-8");
+            TestUtils.CreateProjectInfoInSubDir(testRootDir, projectName2, guid, ProjectType.Product, false, project1Dir + "\\withoutFile.proj", "UTF-8"); // not excluded
+
+            // Create content / managed files if required
+            var contentFile1 = TestUtils.CreateEmptyFile(project1Dir, "contentFile1.txt");
+            var contentFileList1 = TestUtils.CreateFile(project1Dir, "contentList.txt", contentFile1);
+
+            TestUtils.AddAnalysisResult(contentProjectInfo1, AnalysisType.FilesToAnalyze, contentFileList1);
 
             var logger = new TestLogger();
-            var config = CreateValidConfig(testDir);
+            var config = CreateValidConfig(testRootDir);
 
             // Act
             var result = new PropertiesFileGenerator(config, logger, new RoslynV1SarifFixer(logger), mockRuntimeInformation.Object).GenerateFile();
 
             // Assert
-            AssertExpectedStatus("withoutFiles", ProjectInfoValidity.NoFilesToAnalyze, result);
+            AssertExpectedStatus(projectName1, ProjectInfoValidity.Valid, result);
             AssertExpectedProjectCount(1, result);
 
         }
@@ -160,7 +178,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
 
-            CreateProjectWithFiles("withFiles1", testDir);
+            TestUtils.CreateProjectWithFiles(TestContext, "withFiles1", testDir);
 
             var logger = new TestLogger();
             var config = CreateValidConfig(testDir);
@@ -185,7 +203,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
 
-            CreateProjectWithFiles("withFiles1", testDir);
+            TestUtils.CreateProjectWithFiles(TestContext, "withFiles1", testDir);
 
             var logger = new TestLogger();
             var config = CreateValidConfig(testDir);
@@ -221,7 +239,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
                 new Property() { Id = PropertiesFileGenerator.ReportFilesCsharpPropertyKey, Value = testSarifPath }
             };
             var projectGuid = Guid.NewGuid();
-            CreateProjectWithFiles("withFiles1", testDir, projectGuid, true, projectSettings);
+            TestUtils.CreateProjectWithFiles(TestContext, "withFiles1", testDir, projectGuid, true, projectSettings);
 
             var logger = new TestLogger();
             var config = CreateValidConfig(testDir);
@@ -256,7 +274,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
                 new Property() { Id = PropertiesFileGenerator.ReportFilesCsharpPropertyKey, Value = testSarifPath }
             };
             var projectGuid = Guid.NewGuid();
-            CreateProjectWithFiles("withFiles1", testDir, projectGuid, true, projectSettings);
+            TestUtils.CreateProjectWithFiles(TestContext, "withFiles1", testDir, projectGuid, true, projectSettings);
 
             var logger = new TestLogger();
             var config = CreateValidConfig(testDir);
@@ -295,7 +313,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
                 new Property() { Id = PropertiesFileGenerator.ReportFilesVbnetPropertyKey, Value = testSarifPath }
             };
             var projectGuid = Guid.NewGuid();
-            CreateProjectWithFiles("withFiles1", testDir, projectGuid, true, projectSettings);
+            TestUtils.CreateProjectWithFiles(TestContext, "withFiles1", testDir, projectGuid, true, projectSettings);
 
             var logger = new TestLogger();
             var config = CreateValidConfig(testDir);
@@ -372,7 +390,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
                 new Property() { Id = PropertiesFileGenerator.ReportFilesCsharpPropertyKey, Value = testSarifPath }
             };
             var projectGuid = Guid.NewGuid();
-            CreateProjectWithFiles("withFiles1", testDir, projectGuid, true, projectSettings);
+            TestUtils.CreateProjectWithFiles(TestContext, "withFiles1", testDir, projectGuid, true, projectSettings);
 
             var logger = new TestLogger();
             var config = CreateValidConfig(testDir);
@@ -404,14 +422,14 @@ namespace SonarScanner.MSBuild.Shim.Tests
 
             var projectDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "project");
             var projectPath = Path.Combine(projectDir, "project.proj");
-            var projectInfo = CreateProjectInfoInSubDir(testDir, "projectName", Guid.NewGuid(), ProjectType.Product, false, "UTF-8", projectPath); // not excluded
+            var projectInfo = TestUtils.CreateProjectInfoInSubDir(testDir, "projectName", Guid.NewGuid(), ProjectType.Product, false, "UTF-8", projectPath); // not excluded
 
             // Create a content file, but not under the project directory
-            var contentFileList = CreateFile(projectDir, "contentList.txt", Path.Combine(testDir, "contentFile1.txt"));
-            AddAnalysisResult(projectInfo, AnalysisType.FilesToAnalyze, contentFileList);
+            var contentFileList = TestUtils.CreateFile(projectDir, "contentList.txt", Path.Combine(testDir, "contentFile1.txt"));
+            TestUtils.AddAnalysisResult(projectInfo, AnalysisType.FilesToAnalyze, contentFileList);
 
             var logger = new TestLogger();
-            var config = CreateValidConfig(testDir);
+            var config = CreateValidConfig(testDir);     
 
             // Act
             var result = new PropertiesFileGenerator(config, logger).GenerateFile();
@@ -434,21 +452,21 @@ namespace SonarScanner.MSBuild.Shim.Tests
 
             var project1Dir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "project1");
             var project1Path = Path.Combine(project1Dir, "project1.proj");
-            var project1Info = CreateProjectInfoInSubDir(testDir, "projectName1", Guid.NewGuid(), ProjectType.Product, false, project1Path, "UTF-8"); // not excluded
+            var project1Info = TestUtils.CreateProjectInfoInSubDir(testDir, "projectName1", Guid.NewGuid(), ProjectType.Product, false, project1Path, "UTF-8"); // not excluded
             var sharedFile = Path.Combine(testDir, "contentFile.txt");
-            CreateEmptyFile(testDir, "contentFile.txt");
+            TestUtils.CreateEmptyFile(testDir, "contentFile.txt");
 
             // Reference shared file, but not under the project directory
-            var contentFileList1 = CreateFile(project1Dir, "contentList.txt", sharedFile);
-            AddAnalysisResult(project1Info, AnalysisType.FilesToAnalyze, contentFileList1);
+            var contentFileList1 = TestUtils.CreateFile(project1Dir, "contentList.txt", sharedFile);
+            TestUtils.AddAnalysisResult(project1Info, AnalysisType.FilesToAnalyze, contentFileList1);
 
             var project2Dir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "project2");
             var project2Path = Path.Combine(project2Dir, "project2.proj");
-            var project2Info = CreateProjectInfoInSubDir(testDir, "projectName2", Guid.NewGuid(), ProjectType.Product, false, project2Path, "UTF-8"); // not excluded
+            var project2Info = TestUtils.CreateProjectInfoInSubDir(testDir, "projectName2", Guid.NewGuid(), ProjectType.Product, false, project2Path, "UTF-8"); // not excluded
 
             // Reference shared file, but not under the project directory
-            var contentFileList2 = CreateFile(project2Dir, "contentList.txt", sharedFile);
-            AddAnalysisResult(project2Info, AnalysisType.FilesToAnalyze, contentFileList2);
+            var contentFileList2 = TestUtils.CreateFile(project2Dir, "contentList.txt", sharedFile);
+            TestUtils.AddAnalysisResult(project2Info, AnalysisType.FilesToAnalyze, contentFileList2);
 
             var logger = new TestLogger();
             var config = CreateValidConfig(testDir);
@@ -474,22 +492,22 @@ namespace SonarScanner.MSBuild.Shim.Tests
 
             var project1Dir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "project1");
             var project1Path = Path.Combine(project1Dir, "project1.proj");
-            var project1Info = CreateProjectInfoInSubDir(testDir, "projectName1", uuids[0], ProjectType.Product, false, project1Path, "UTF-8"); // not excluded
+            var project1Info = TestUtils.CreateProjectInfoInSubDir(testDir, "projectName1", uuids[0], ProjectType.Product, false, project1Path, "UTF-8"); // not excluded
             var sharedFile = Path.Combine(testDir, "contentFile.txt");
             var sharedFileDifferentCase = Path.Combine(testDir, "ContentFile.TXT");
-            CreateEmptyFile(testDir, "contentFile.txt");
+            TestUtils.CreateEmptyFile(testDir, "contentFile.txt");
 
             // Reference shared file, but not under the project directory
-            var contentFileList1 = CreateFile(project1Dir, "contentList.txt", sharedFile);
-            AddAnalysisResult(project1Info, AnalysisType.FilesToAnalyze, contentFileList1);
+            var contentFileList1 = TestUtils.CreateFile(project1Dir, "contentList.txt", sharedFile);
+            TestUtils.AddAnalysisResult(project1Info, AnalysisType.FilesToAnalyze, contentFileList1);
 
             var project2Dir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "project2");
             var project2Path = Path.Combine(project2Dir, "project2.proj");
-            var project2Info = CreateProjectInfoInSubDir(testDir, "projectName2", uuids[1], ProjectType.Product, false, project2Path, "UTF-8"); // not excluded
+            var project2Info = TestUtils.CreateProjectInfoInSubDir(testDir, "projectName2", uuids[1], ProjectType.Product, false, project2Path, "UTF-8"); // not excluded
 
             // Reference shared file, but not under the project directory
-            var contentFileList2 = CreateFile(project2Dir, "contentList.txt", sharedFileDifferentCase);
-            AddAnalysisResult(project2Info, AnalysisType.FilesToAnalyze, contentFileList2);
+            var contentFileList2 = TestUtils.CreateFile(project2Dir, "contentList.txt", sharedFileDifferentCase);
+            TestUtils.AddAnalysisResult(project2Info, AnalysisType.FilesToAnalyze, contentFileList2);
 
             var logger = new TestLogger();
             var config = CreateValidConfig(testDir);
@@ -516,21 +534,21 @@ namespace SonarScanner.MSBuild.Shim.Tests
             var project1Dir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "project1");
             var project1Path = Path.Combine(project1Dir, "project1.proj");
             var project1Guid = Guid.NewGuid();
-            var project1Info = CreateProjectInfoInSubDir(testDir, "projectName1", project1Guid, ProjectType.Product, false, project1Path, "UTF-8"); // not excluded
+            var project1Info = TestUtils.CreateProjectInfoInSubDir(testDir, "projectName1", project1Guid, ProjectType.Product, false, project1Path, "UTF-8"); // not excluded
             var fileInProject1 = Path.Combine(project1Dir, "contentFile.txt");
-            CreateEmptyFile(project1Dir, "contentFile.txt");
+            TestUtils.CreateEmptyFile(project1Dir, "contentFile.txt");
 
             // Reference shared file, but not under the project directory
-            var contentFileList1 = CreateFile(project1Dir, "contentList.txt", fileInProject1);
-            AddAnalysisResult(project1Info, AnalysisType.FilesToAnalyze, contentFileList1);
+            var contentFileList1 = TestUtils.CreateFile(project1Dir, "contentList.txt", fileInProject1);
+            TestUtils.AddAnalysisResult(project1Info, AnalysisType.FilesToAnalyze, contentFileList1);
 
             var project2Dir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "project2");
             var project2Path = Path.Combine(project2Dir, "project2.proj");
-            var project2Info = CreateProjectInfoInSubDir(testDir, "projectName2", Guid.NewGuid(), ProjectType.Product, false, project2Path, "UTF-8"); // not excluded
+            var project2Info = TestUtils.CreateProjectInfoInSubDir(testDir, "projectName2", Guid.NewGuid(), ProjectType.Product, false, project2Path, "UTF-8"); // not excluded
 
             // Reference shared file, but not under the project directory
-            var contentFileList2 = CreateFile(project2Dir, "contentList.txt", fileInProject1);
-            AddAnalysisResult(project2Info, AnalysisType.FilesToAnalyze, contentFileList2);
+            var contentFileList2 = TestUtils.CreateFile(project2Dir, "contentList.txt", fileInProject1);
+            TestUtils.AddAnalysisResult(project2Info, AnalysisType.FilesToAnalyze, contentFileList2);
 
             var logger = new TestLogger();
             var config = CreateValidConfig(testDir);
@@ -555,10 +573,10 @@ namespace SonarScanner.MSBuild.Shim.Tests
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
             var projectBaseDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Project1");
-            var projectFullPath = CreateEmptyFile(projectBaseDir, "project1.proj");
+            var projectFullPath = TestUtils.CreateEmptyFile(projectBaseDir, "project1.proj");
 
-            var existingManagedFile = CreateEmptyFile(projectBaseDir, "File1.cs");
-            var existingContentFile = CreateEmptyFile(projectBaseDir, "Content1.txt");
+            var existingManagedFile = TestUtils.CreateEmptyFile(projectBaseDir, "File1.cs");
+            var existingContentFile = TestUtils.CreateEmptyFile(projectBaseDir, "Content1.txt");
 
             var missingManagedFile = Path.Combine(projectBaseDir, "MissingFile1.cs");
             var missingContentFile = Path.Combine(projectBaseDir, "MissingContent1.txt");
@@ -615,7 +633,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
             var analysisRootDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
             var logger = new TestLogger();
 
-            CreateProjectWithFiles("project1", analysisRootDir);
+            TestUtils.CreateProjectWithFiles(TestContext, "project1", analysisRootDir);
             var config = CreateValidConfig(analysisRootDir);
 
             // Add additional properties
@@ -663,7 +681,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
             var analysisRootDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
             var logger = new TestLogger();
 
-            CreateProjectWithFiles("project1", analysisRootDir, Guid.Empty);
+            TestUtils.CreateProjectWithFiles(TestContext, "project1", analysisRootDir, Guid.Empty);
             var config = CreateValidConfig(analysisRootDir);
 
             // Act
@@ -1030,7 +1048,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
         {
             var analysisRootDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, projectName);
 
-            CreateProjectWithFiles(projectName, analysisRootDir);
+            TestUtils.CreateProjectWithFiles(TestContext, projectName, analysisRootDir);
             var config = CreateValidConfig(analysisRootDir);
 
             config.LocalSettings = new AnalysisProperties();
@@ -1135,37 +1153,6 @@ namespace SonarScanner.MSBuild.Shim.Tests
             result.Should().Be(expectedValue);
         }
 
-        /// <summary>
-        /// Creates a project info under the specified analysis root directory
-        /// together with the supporting project and content files, along with additional properties (if specified)
-        /// </summary>
-        private void CreateProjectWithFiles(string projectName, string analysisRootPath, bool createContentFiles = true, AnalysisProperties additionalProperties = null)
-        {
-            CreateProjectWithFiles(projectName, analysisRootPath, Guid.NewGuid(), createContentFiles, additionalProperties);
-        }
-
-        /// <summary>
-        /// Creates a project info under the specified analysis root directory
-        /// together with the supporting project and content files, along with GUID and additional properties (if specified)
-        /// </summary>
-        private void CreateProjectWithFiles(string projectName, string analysisRootPath, Guid projectGuid, bool createContentFiles = true, AnalysisProperties additionalProperties = null)
-        {
-            // Create a project with content files in a new subdirectory
-            var projectDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, Path.Combine("projects", projectName));
-            var projectFilePath = Path.Combine(projectDir, Path.ChangeExtension(projectName, "proj"));
-
-            // Create a project info file in the correct location under the analysis root
-            var contentProjectInfo = CreateProjectInfoInSubDir(analysisRootPath, projectName, projectGuid, ProjectType.Product, false, projectFilePath, "UTF-8", additionalProperties); // not excluded
-
-            // Create content / managed files if required
-            if (createContentFiles)
-            {
-                var contentFile = CreateEmptyFile(projectDir, "contentFile1.txt");
-                var contentFileList = CreateFile(projectDir, "contentList.txt", contentFile);
-                AddAnalysisResult(contentProjectInfo, AnalysisType.FilesToAnalyze, contentFileList);
-            }
-        }
-
         private static AnalysisConfig CreateValidConfig(string outputDir)
         {
             var dummyProjectKey = Guid.NewGuid().ToString();
@@ -1183,54 +1170,6 @@ namespace SonarScanner.MSBuild.Shim.Tests
             return config;
         }
 
-        private static string CreateEmptyFile(string parentDir, string fileName)
-        {
-            return CreateFile(parentDir, fileName, string.Empty);
-        }
-
-        private static string CreateFile(string parentDir, string fileName, string content)
-        {
-            var fullPath = Path.Combine(parentDir, fileName);
-            File.WriteAllText(fullPath, content);
-            return fullPath;
-        }
-
-        /// <summary>
-        /// Creates a new project info file in a new subdirectory with the given additional properties.
-        /// </summary>
-        private static string CreateProjectInfoInSubDir(string parentDir,
-            string projectName, Guid projectGuid, ProjectType projectType, bool isExcluded, string fullProjectPath, string encoding,
-            AnalysisProperties additionalProperties = null)
-        {
-            var newDir = Path.Combine(parentDir, projectName);
-            Directory.CreateDirectory(newDir); // ensure the directory exists
-
-            var project = new ProjectInfo()
-            {
-                FullPath = fullProjectPath,
-                ProjectName = projectName,
-                ProjectGuid = projectGuid,
-                ProjectType = projectType,
-                IsExcluded = isExcluded,
-                Encoding = encoding
-            };
-
-            if (additionalProperties != null)
-            {
-                project.AnalysisSettings = additionalProperties;
-            }
-
-            var filePath = Path.Combine(newDir, FileConstants.ProjectInfoFileName);
-            project.Save(filePath);
-            return filePath;
-        }
-
-        private static void AddAnalysisResult(string projectInfoFile, AnalysisType resultType, string location)
-        {
-            var projectInfo = ProjectInfo.Load(projectInfoFile);
-            projectInfo.AddAnalyzerResult(resultType, location);
-            projectInfo.Save(projectInfoFile);
-        }
 
         private static string CreateFileList(string parentDir, string fileName, params string[] files)
         {

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/E2ETests/E2EAnalysisTests.cs
@@ -76,13 +76,13 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
                 TargetConstants.WriteProjectDataTarget);
 
             var projectSpecificOutputDir = CheckProjectSpecificOutputStructure(rootOutputFolder);
-            var actualProjectInfo = CheckProjectInfoExists(projectSpecificOutputDir);
+            CheckProjectInfoExists(projectSpecificOutputDir);
         }
 
         [TestMethod]
         [TestCategory("E2E"), TestCategory("Targets")]
         [Description("Tests that projects with missing project guids are handled correctly")]
-        public void E2E_MissingProjectGuid()
+        public void E2E_MissingProjectGuid_ShouldGenerateRandomOne()
         {
             // Projects with missing guids should have a warning emitted. The project info
             // should still be generated.
@@ -112,13 +112,10 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
 
             var projectSpecificOutputDir = CheckProjectSpecificOutputStructure(rootOutputFolder);
             var actualProjectInfo = CheckProjectInfoExists(projectSpecificOutputDir);
-            actualProjectInfo.ProjectGuid.Should().Be(Guid.Empty);
+            actualProjectInfo.ProjectGuid.Should().NotBeEmpty();
+            actualProjectInfo.ProjectGuid.Should().NotBe(Guid.Empty);
 
-            result.AssertExpectedErrorCount(0);
-            result.AssertExpectedWarningCount(1);
-
-            var warning = result.Warnings[0];
-            warning.Should().Contain(projectFilePath, "Expecting the warning to contain the full path to the bad project file");
+            result.AssertNoWarningsOrErrors();
         }
 
         [TestMethod]
@@ -208,7 +205,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
             // Check the list of files to be analyzed
             var expectedFilesToAnalyzeFilePath = AssertFileExists(projectSpecificOutputDir, ExpectedAnalysisFilesListFileName);
             var fileList = File.ReadLines(expectedFilesToAnalyzeFilePath);
-            fileList.Should().BeEquivalentTo(new string []
+            fileList.Should().BeEquivalentTo(new string[]
             {
                 rootInputFolder + "\\none1.txt",
                 rootInputFolder + "\\content1.txt",
@@ -311,7 +308,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
             var actualFilesToAnalyze = actualProjectInfo.AssertAnalysisResultExists("FilesToAnalyze");
             actualFilesToAnalyze.Location.Should().Be(expectedFilesToAnalyzeFilePath);
         }
-        
+
         [TestMethod]
         [TestCategory("E2E"), TestCategory("Targets")] // SONARMSBRU-104: files under the obj folder should be excluded from analysis
         public void E2E_IntermediateOutputFilesAreExcluded()
@@ -323,8 +320,8 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
             // Add files that should be analyzed
             var nonObjFolder = Path.Combine(rootInputFolder, "foo");
             Directory.CreateDirectory(nonObjFolder);
-            var compile1 = CreateEmptyFile(rootInputFolder,  "compile1.cs");
-            var foo_compile2 = CreateEmptyFile(nonObjFolder, "compile2.cs");
+            var compile1 = CreateEmptyFile(rootInputFolder, "compile1.cs");
+            CreateEmptyFile(nonObjFolder, "compile2.cs");
 
             // Add files under the obj folder that should not be analyzed
             var objFolder = Path.Combine(rootInputFolder, "obj");
@@ -337,7 +334,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
             var objFile = CreateEmptyFile(objFolder, "objFile1.cs");
 
             // File in obj\debug
-            var objDebugFile = CreateEmptyFile(objSubFolder1, "objDebugFile1.cs");
+            CreateEmptyFile(objSubFolder1, "objDebugFile1.cs");
 
             // File in obj\xxx
             var objFooFile = CreateEmptyFile(objSubFolder2, "objFooFile.cs");
@@ -417,7 +414,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.E2E
             fileList.Should().BeEquivalentTo(rootInputFolder + "\\code1.vb");
 
             // Check the projectInfo.xml file points to the file containing the list of files to analyze
-            var actualProjectInfo = CheckProjectInfoExists(projectSpecificOutputDir);
+            CheckProjectInfoExists(projectSpecificOutputDir);
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/WriteProjectInfoFileTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/WriteProjectInfoFileTests.cs
@@ -230,10 +230,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
             // Assert
             success.Should().BeTrue("Not expecting the task to fail as this would fail the build");
             engine.AssertNoErrors();
-            engine.Warnings.Should().HaveCount(1, "Expecting a build warning as the ProjectGuid is missing");
-
-            var firstWarning = engine.Warnings[0];
-            firstWarning.Message.Should().NotBeNull("Warning message should not be null");
+            engine.AssertNoWarnings();
 
             var projectInfoFilePath = Path.Combine(testFolder, ExpectedProjectInfoFileName);
             File.Exists(projectInfoFilePath).Should().BeTrue("Expecting the project info file to have been created");
@@ -430,41 +427,48 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         [TestMethod]
         public void GetProjectGuid_WhenProjectGuidAndSolutionConfigurationContentsAreNull_ReturnsNull()
         {
-            AssertProjectGuidIsNull(null, null);
+            AssertProjectGuidIsRandomlyGenerated(null, null, @"C:\NetCorePrj\MyNetCoreProject.csproj");
         }
 
         [TestMethod]
-        public void GetProjectGuid_WhenProjectGuidAndSolutionConfigurationContentsAreEmptyString_ReturnsNull()
+        public void GetProjectGuid_WhenProjectGuidAndSolutionConfigurationContentsAreEmptyString_ReturnsRandomGuid()
         {
-            AssertProjectGuidIsNull("", "");
+            AssertProjectGuidIsRandomlyGenerated("", "", @"C:\NetCorePrj\MyNetCoreProject.csproj");
         }
 
         [TestMethod]
         public void GetProjectGuid_WhenProjectGuidNullAndSolutionConfigurationContentsEmptyString_ReturnsNull()
         {
-            AssertProjectGuidIsNull(null, "");
+            AssertProjectGuidIsRandomlyGenerated(null, "", @"C:\NetCorePrj\MyNetCoreProject.csproj"); 
         }
 
         [TestMethod]
         public void GetProjectGuid_WhenProjectGuidEmptyStringAndSolutionConfigurationContentsNull_ReturnsNull()
         {
-            AssertProjectGuidIsNull("", null);
+            AssertProjectGuidIsRandomlyGenerated("", null, @"C:\NetCorePrj\MyNetCoreProject.csproj");
         }
 
-        private void AssertProjectGuidIsNull(string projectGuid, string solutionConfigurationContents)
+        private void AssertProjectGuidIsRandomlyGenerated(string projectGuid, string solutionConfigurationContents, string fullProjectPath)
         {
+            
             // Arrange
             var testSubject = new WriteProjectInfoFile
             {
+                FullProjectPath = fullProjectPath,
                 ProjectGuid = projectGuid,
                 SolutionConfigurationContents = solutionConfigurationContents
             };
+
+            var engine = new DummyBuildEngine();
+            testSubject.BuildEngine = engine;
+
 
             // Act
             var actual = testSubject.GetProjectGuid();
 
             // Assert
-            actual.Should().BeNull();
+            actual.Should().NotBeNullOrEmpty();
+            actual.Should().NotBe(Guid.Empty.ToString());
         }
 
         [TestMethod]

--- a/Tests/TestUtilities/TestUtils.cs
+++ b/Tests/TestUtilities/TestUtils.cs
@@ -185,6 +185,88 @@ namespace TestUtilities
             return fileName;
         }
 
+        /// <summary>
+        /// Creates a project info under the specified analysis root directory
+        /// together with the supporting project and content files, along with GUID and additional properties (if specified)
+        /// </summary>
+        public static string CreateProjectWithFiles(TestContext testContext, string projectName, string analysisRootPath, Guid projectGuid, bool createContentFiles = true, AnalysisProperties additionalProperties = null)
+        {
+            // Create a project with content files in a new subdirectory
+            var projectDir = CreateTestSpecificFolderWithSubPaths(testContext, Path.Combine("projects", projectName));
+            var projectFilePath = Path.Combine(projectDir, Path.ChangeExtension(projectName, "proj"));
+
+            // Create a project info file in the correct location under the analysis root
+            var contentProjectInfo = CreateProjectInfoInSubDir(analysisRootPath, projectName, projectGuid, ProjectType.Product, false, projectFilePath, "UTF-8", additionalProperties); // not excluded
+
+            // Create content / managed files if required
+            if (createContentFiles)
+            {
+                var contentFile = CreateEmptyFile(projectDir, "contentFile1.txt");
+                var contentFileList = CreateFile(projectDir, "contentList.txt", contentFile);
+                AddAnalysisResult(contentProjectInfo, AnalysisType.FilesToAnalyze, contentFileList);
+            }
+
+            return contentProjectInfo;
+        }
+
+        /// <summary>
+        /// Creates a project info under the specified analysis root directory
+        /// together with the supporting project and content files, along with additional properties (if specified)
+        /// </summary>
+        public static string CreateProjectWithFiles(TestContext testContext, string projectName, string analysisRootPath, bool createContentFiles = true, AnalysisProperties additionalProperties = null)
+        {
+            return CreateProjectWithFiles(testContext, projectName, analysisRootPath, Guid.NewGuid(), createContentFiles, additionalProperties);
+        }
+
+        public static string CreateEmptyFile(string parentDir, string fileName)
+        {
+            return CreateFile(parentDir, fileName, string.Empty);
+        }
+
+        public static string CreateFile(string parentDir, string fileName, string content)
+        {
+            var fullPath = Path.Combine(parentDir, fileName);
+            File.WriteAllText(fullPath, content);
+            return fullPath;
+        }
+
+        /// <summary>
+        /// Creates a new project info file in a new subdirectory with the given additional properties.
+        /// </summary>
+        public static string CreateProjectInfoInSubDir(string parentDir,
+            string projectName, Guid projectGuid, ProjectType projectType, bool isExcluded, string fullProjectPath, string encoding,
+            AnalysisProperties additionalProperties = null)
+        {
+            var newDir = Path.Combine(parentDir, projectName);
+            Directory.CreateDirectory(newDir); // ensure the directory exists
+
+            var project = new ProjectInfo()
+            {
+                FullPath = fullProjectPath,
+                ProjectName = projectName,
+                ProjectGuid = projectGuid,
+                ProjectType = projectType,
+                IsExcluded = isExcluded,
+                Encoding = encoding
+            };
+
+            if (additionalProperties != null)
+            {
+                project.AnalysisSettings = additionalProperties;
+            }
+
+            var filePath = Path.Combine(newDir, FileConstants.ProjectInfoFileName);
+            project.Save(filePath);
+            return filePath;
+        }
+
+        public static void AddAnalysisResult(string projectInfoFile, AnalysisType resultType, string location)
+        {
+            var projectInfo = ProjectInfo.Load(projectInfoFile);
+            projectInfo.AddAnalyzerResult(resultType, location);
+            projectInfo.Save(projectInfoFile);
+        }
+
         #endregion Public methods
 
         #region Private methods

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,7 @@ stages:
         inputs:
           versionSpec: '5.7.0'
       - task: CacheBeta@0
+        enabled: false
         displayName: Cache Maven local repo
         inputs:
           key: maven | pom.xml
@@ -109,7 +110,7 @@ stages:
           restoreSolution: '$(tfsProcessorSolution)'
           feedsToUse: 'select'
       - task: DotNetCoreCLI@2
-        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
         displayName: 'Build and prepare signing $(tfsProcessorSolution)'
         inputs:
           command: 'build'
@@ -142,7 +143,7 @@ stages:
           projects: '$(solution)'
           feedsToUse: 'select'
       - task: DotNetCoreCLI@2
-        condition: and(succeeded(), ne(variables['Build.SourceBranch'], 'refs/heads/master'))
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
         displayName: 'Build and prepare signing $(solution)'
         inputs:
           command: 'build'
@@ -189,6 +190,7 @@ stages:
           pwsh: true
       - task: PowerShell@2
         displayName: Sign assemblies
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
         env: 
           SIGNTOOL_PATH: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.17763.0\\x64\\signtool.exe'
           PFX_PASSWORD: $(pfxPassword)

--- a/src/SonarScanner.MSBuild.PostProcessor/MSBuildPostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/MSBuildPostProcessor.cs
@@ -97,7 +97,7 @@ namespace SonarScanner.MSBuild.PostProcessor
 
             var propertyResult = GenerateAndValidatePropertiesFile(config);
 
-            if (propertyResult != null)
+            if (propertyResult.FullPropertiesFilePath != null)
             {
 #if NET46
                 ProcessCoverageReport(config, Path.Combine(config.SonarConfigDir, FileConstants.ConfigFileName), propertyResult.FullPropertiesFilePath);

--- a/src/SonarScanner.MSBuild.PostProcessor/MSBuildPostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/MSBuildPostProcessor.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.Common.Interfaces;
 using SonarScanner.MSBuild.Common.TFS;
@@ -123,15 +124,18 @@ namespace SonarScanner.MSBuild.PostProcessor
 
             var result = this.propertiesFileGenerator.GenerateFile();
 
-            if(this.sonarProjectPropertiesValidator.AreExistingSonarPropertiesFilesPresent(config.SonarScannerWorkingDirectory, result.Projects, out var invalidFolders))
+            if (result.Projects.Any())
             {
-                logger.LogError(Resources.ERR_ConflictingSonarProjectProperties, string.Join(", ", invalidFolders));
-                result.RanToCompletion = false;
-            }
-            else
-            {
-                ProjectInfoReportBuilder.WriteSummaryReport(config, result, logger);
-                result.RanToCompletion = true;
+                if (this.sonarProjectPropertiesValidator.AreExistingSonarPropertiesFilesPresent(config.SonarScannerWorkingDirectory, result.Projects, out var invalidFolders))
+                {
+                    logger.LogError(Resources.ERR_ConflictingSonarProjectProperties, string.Join(", ", invalidFolders));
+                    result.RanToCompletion = false;
+                }
+                else
+                {
+                    ProjectInfoReportBuilder.WriteSummaryReport(config, result, logger);
+                    result.RanToCompletion = true;
+                }
             }
 
             return result;

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -85,13 +85,14 @@ namespace SonarScanner.MSBuild.Shim
                 logger.LogDebug(Resources.DEBUG_DumpSonarProjectProperties, contents);
 
                 result.FullPropertiesFilePath = projectPropertiesPath;
-                result.Projects.AddRange(projects);
             }
             else
             {
                 logger.LogInfo(Resources.MSG_PropertiesGenerationFailed);
-                result.RanToCompletion = false;
+                return null;
             }
+
+            result.Projects.AddRange(projects);
 
             return result;
         }

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -89,7 +89,6 @@ namespace SonarScanner.MSBuild.Shim
             else
             {
                 logger.LogInfo(Resources.MSG_PropertiesGenerationFailed);
-                return null;
             }
 
             result.Projects.AddRange(projects);

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -85,13 +85,13 @@ namespace SonarScanner.MSBuild.Shim
                 logger.LogDebug(Resources.DEBUG_DumpSonarProjectProperties, contents);
 
                 result.FullPropertiesFilePath = projectPropertiesPath;
+                result.Projects.AddRange(projects);
             }
             else
             {
                 logger.LogInfo(Resources.MSG_PropertiesGenerationFailed);
+                result.RanToCompletion = false;
             }
-
-            result.Projects.AddRange(projects);
 
             return result;
         }

--- a/src/SonarScanner.MSBuild.Tasks/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.Tasks/Resources.Designer.cs
@@ -298,7 +298,16 @@ namespace SonarScanner.MSBuild.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project does not have a valid ProjectGuid. Analysis results for this project will not be uploaded. Project file: {0}.
+        ///   Looks up a localized string similar to No ProjectGuid has been found in neither the csproj nor the solution (Project {0}). A random one has been generated ({1})..
+        /// </summary>
+        internal static string WPIF_GeneratingRandomGuid {
+            get {
+                return ResourceManager.GetString("WPIF_GeneratingRandomGuid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The project does not have a valid ProjectGuid. Analysis results for this project will not be uploaded to SonarQube. Project file: {0}.
         /// </summary>
         internal static string WPIF_MissingOrInvalidProjectGuid {
             get {

--- a/src/SonarScanner.MSBuild.Tasks/Resources.resx
+++ b/src/SonarScanner.MSBuild.Tasks/Resources.resx
@@ -217,4 +217,7 @@ Error: {1}</value>
   <data name="WriteZeroLengthFiles_WritingFile" xml:space="preserve">
     <value>Writing zero-length file:{0}</value>
   </data>
+  <data name="WPIF_GeneratingRandomGuid" xml:space="preserve">
+    <value>No ProjectGuid has been found in neither the csproj nor the solution (Project {0}). Generating a random one.</value>
+  </data>
 </root>

--- a/src/SonarScanner.MSBuild.Tasks/Resources.resx
+++ b/src/SonarScanner.MSBuild.Tasks/Resources.resx
@@ -218,6 +218,6 @@ Error: {1}</value>
     <value>Writing zero-length file:{0}</value>
   </data>
   <data name="WPIF_GeneratingRandomGuid" xml:space="preserve">
-    <value>No ProjectGuid has been found in neither the csproj nor the solution (Project {0}). Generating a random one.</value>
+    <value>No ProjectGuid has been found in neither the csproj nor the solution (Project {0}). A random one has been generated ({1}).</value>
   </data>
 </root>

--- a/src/SonarScanner.MSBuild.Tasks/WriteProjectInfoFile.cs
+++ b/src/SonarScanner.MSBuild.Tasks/WriteProjectInfoFile.cs
@@ -340,10 +340,12 @@ namespace SonarScanner.MSBuild.Tasks
                     .FirstOrDefault();
             }
 
-            Log.LogMessage(Resources.WPIF_GeneratingRandomGuid, FullProjectPath);
+            var generatedGuid = Guid.NewGuid().ToString();
+
+            Log.LogMessage(Resources.WPIF_GeneratingRandomGuid, FullProjectPath, generatedGuid);
 
             //Generating a new guid for projects without one
-            return Guid.NewGuid().ToString();
+            return generatedGuid;
 
             bool ArePathEquals(string filePath, FileInfo file) =>
                 filePath != null &&

--- a/src/SonarScanner.MSBuild.Tasks/WriteProjectInfoFile.cs
+++ b/src/SonarScanner.MSBuild.Tasks/WriteProjectInfoFile.cs
@@ -340,7 +340,10 @@ namespace SonarScanner.MSBuild.Tasks
                     .FirstOrDefault();
             }
 
-            return null;
+            Log.LogMessage(Resources.WPIF_GeneratingRandomGuid, FullProjectPath);
+
+            //Generating a new guid for projects without one
+            return Guid.NewGuid().ToString();
 
             bool ArePathEquals(string filePath, FileInfo file) =>
                 filePath != null &&


### PR DESCRIPTION
fixes #659

When no ProjectGuid has been found in whether the csproj or the solution, then we generate a random one. 

Further improvement, which will not be in the scope of this PR, is to ensure that a shared lib is analyzed only once. This is not currently the case since each "dotnet build" on a csproj that has this shared lib will create a directory for it.