### PR TITLE
Drop support for single-valued "sonar.cs.roslyn.reportFilePath" and "…

### DIFF
--- a/SonarScanner.MSBuild.sln
+++ b/SonarScanner.MSBuild.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SonarScanner.MSBuild.PostPr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SonarScanner.MSBuild", "src\SonarScanner.MSBuild\SonarScanner.MSBuild.csproj", "{B9F6FCA4-CD6C-4426-9835-D86160B30072}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SonarScanner.MSBuild.Shim.Tests", "Tests\SonarScanner.MSBuild.Shim.Tests\SonarScanner.MSBuild.Shim.Tests.csproj", "{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -175,6 +177,18 @@ Global
 		{B9F6FCA4-CD6C-4426-9835-D86160B30072}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{B9F6FCA4-CD6C-4426-9835-D86160B30072}.Release|x86.ActiveCfg = Release|Any CPU
 		{B9F6FCA4-CD6C-4426-9835-D86160B30072}.Release|x86.Build.0 = Release|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Debug|x86.Build.0 = Debug|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Release|x86.ActiveCfg = Release|Any CPU
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -187,6 +201,7 @@ Global
 		{81E8D103-270F-4363-87D1-72BE7FC4F94A} = {E04A4D31-AC10-4F56-9678-5D538932578C}
 		{3410EA30-5F7A-4E0F-B5F6-8E83077A20DB} = {E04A4D31-AC10-4F56-9678-5D538932578C}
 		{BF55995C-B05B-44D0-B80E-2366CC5ACCDE} = {E04A4D31-AC10-4F56-9678-5D538932578C}
+		{F43FC14B-5249-46F4-9E89-F4AAFDDB27ED} = {E04A4D31-AC10-4F56-9678-5D538932578C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F1322FF5-8DA8-4714-ABD1-B289A655E630}

--- a/Tests/SonarScanner.MSBuild.Shim.Tests/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Tests/PropertiesFileGeneratorTests.cs
@@ -328,19 +328,19 @@ namespace SonarScanner.MSBuild.Shim.Tests
             var logger = new TestLogger();
             var config = CreateValidConfig(testDir);
 
-            var testSarifPath = Path.Combine(testDir, "testSarif.json");
+            var testSarifPath1 = Path.Combine(testDir, "testSarif1.json");
             var testSarifPath2 = Path.Combine(testDir, "testSarif2.json");
             var testSarifPath3 = Path.Combine(testDir, "testSarif3.json");
 
             // Mock SARIF fixer simulates fixable SARIF with fixed name
 
-            var mockSarifFixer = new MockRoslynV1SarifFixer(testSarifPath);
+            var mockSarifFixer = new MockRoslynV1SarifFixer(testSarifPath1);
 
             var projectSettings = new AnalysisProperties
             {
                 new Property() {
                     Id = PropertiesFileGenerator.ReportFilesVbnetPropertyKey,
-                    Value = String.Join(PropertiesFileGenerator.RoslynReportPathsDelimiter.ToString(), testSarifPath, testSarifPath2, testSarifPath3)
+                    Value = String.Join(PropertiesFileGenerator.RoslynReportPathsDelimiter.ToString(), testSarifPath1, testSarifPath2, testSarifPath3)
                 }
             };
 
@@ -353,7 +353,7 @@ namespace SonarScanner.MSBuild.Shim.Tests
             provider.AssertSettingExists
                 (projectGuid.ToString().ToUpper() + "." + PropertiesFileGenerator.ReportFilesVbnetPropertyKey,
                 //MockRoslynSarifFixer takes only one path as a param, so the same one will be output 3 times instead of the 3 different ones.
-                String.Join(PropertiesFileGenerator.RoslynReportPathsDelimiter.ToString(), testSarifPath, testSarifPath, testSarifPath));
+                String.Join(PropertiesFileGenerator.RoslynReportPathsDelimiter.ToString(), testSarifPath1, testSarifPath1, testSarifPath1));
 
         }
 

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -23,7 +23,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
-using Microsoft.Build.Construction;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarScanner.MSBuild.Common;
 using TestUtilities;
@@ -33,8 +32,8 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
     [TestClass]
     public class RoslynTargetsTests
     {
-        private const string RoslynAnalysisResultsSettingName = "sonar.cs.roslyn.reportFilePath";
-        private const string AnalyzerWorkDirectoryResultsSettingName = "sonar.cs.analyzer.projectOutPath";
+        private const string RoslynAnalysisResultsSettingName = "sonar.cs.roslyn.reportFilePaths";
+        private const string AnalyzerWorkDirectoryResultsSettingName = "sonar.cs.analyzer.projectOutPaths";
         private const string ErrorLogFilePattern = "{0}.RoslynCA.json";
 
         public TestContext TestContext { get; set; }

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -390,16 +390,9 @@ namespace SonarScanner.MSBuild.Shim
                 {
                     var fixedPath = fixer.LoadAndFixFile(reportPath, language);
 
-                    if (!reportPath.Equals(fixedPath)) // only need to alter the property if there was a change
+                    if (fixedPath != null)
                     {
-                        if (fixedPath != null)
-                        {
-                            listOfPaths.Add(fixedPath);
-                        }
-                    }
-                    else
-                    {
-                        listOfPaths.Add(reportPath);
+                        listOfPaths.Add(fixedPath);
                     }
                 }
 

--- a/src/SonarScanner.MSBuild.Shim/PropertiesWriter.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesWriter.cs
@@ -192,11 +192,11 @@ namespace SonarScanner.MSBuild.Shim
             string property = null;
             if (ProjectLanguages.IsCSharpProject(project.Project.ProjectLanguage))
             {
-                property = "sonar.cs.roslyn.reportFilePaths";
+                property = PropertiesFileGenerator.ReportFilesCsharpPropertyKey;
             }
             else if (ProjectLanguages.IsVbProject(project.Project.ProjectLanguage))
             {
-                property = "sonar.vbnet.roslyn.reportFilePaths";
+                property = PropertiesFileGenerator.ReportFilesVbnetPropertyKey;
             }
 
             sb.AppendLine($"{project.Guid}.{property}=\\");

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -498,13 +498,13 @@
     </ItemGroup>
 
     <ItemGroup>
-      <SonarQubeSetting Include="sonar.$(SQLanguage).roslyn.reportFilePath"
+      <SonarQubeSetting Include="sonar.$(SQLanguage).roslyn.reportFilePaths"
          Condition=" @(SonarReportFilePath) != '' ">
         <!-- Join the paths with |  -->
         <!-- This delimiter needs to be the same as PropertiesFileGenerator.RoslynReportPathsDelimiter -->
         <Value>@(SonarReportFilePath->'%(identity)','|')</Value>
       </SonarQubeSetting>
-      <SonarQubeSetting Include="sonar.$(SQLanguage).analyzer.projectOutPath"
+      <SonarQubeSetting Include="sonar.$(SQLanguage).analyzer.projectOutPaths"
          Condition=" $(SonarCompileErrorLog) != '' AND  $([System.IO.File]::Exists($(SonarCompileErrorLog))) == 'true' ">
         <Value>$(ProjectSpecificOutDir)</Value>
       </SonarQubeSetting>


### PR DESCRIPTION
…sonar.cs.analyzer.projectOutPath" (and VB.Net siblings)

fixes #888 