### PR TITLE
Move FilesToAnalyze to CONF directory and write it immediately

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/Infrastructure/TargetConstants.cs
@@ -31,7 +31,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests
         public const string ImportBeforeInfoTarget = "SonarQubeImportBeforeInfo";
 
         public const string CategoriseProjectTarget = "SonarQubeCategoriseProject";
-        public const string CalculateFilesToAnalyzeTarget = "CalculateSonarQubeFilesToAnalyze";
+        public const string WriteFilesToAnalyzeTarget = "SonarWriteFilesToAnalyze";
         public const string CreateProjectSpecificDirs = "CreateProjectSpecificDirs";
         public const string WriteProjectDataTarget = "WriteSonarQubeProjectData";
 

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/WriteProjectInfoFileTargetTests.cs
@@ -49,7 +49,6 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
             // The content file list should not be created if there are no files
 
             // Arrange
-            var rootInputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Inputs");
             var rootOutputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Outputs");
 
             var filePath = CreateProjectFile(null, null, rootOutputFolder);
@@ -122,7 +121,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
 
             // Arrange
             var rootOutputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Outputs");
-            
+
             // Note: the included/excluded files don't actually have to exist
             string projectXml = $@"
 <ItemGroup>
@@ -369,7 +368,6 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
             // correctly set for "normal" projects
 
             // Arrange
-            var rootInputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Inputs");
             var rootOutputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Outputs");
             var analysisConfig = new AnalysisConfig
             {
@@ -398,16 +396,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
             // both values should be set to true.
 
             // Arrange
-            var rootInputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Inputs");
             var rootOutputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Outputs");
-            var analysisConfig = new AnalysisConfig
-            {
-                LocalSettings = new AnalysisProperties
-                {
-                    new Property { Id = IsTestFileByName.TestRegExSettingId, Value = "pattern that won't match anything" }
-                }
-            };
-
             string projectXml = $@"
 <PropertyGroup>
   <AssemblyName>f.fAKes</AssemblyName>
@@ -429,16 +418,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
         public void WriteProjectInfo_ProjectWithCodePage()
         {
             // Arrange
-            var rootInputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Inputs");
             var rootOutputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Outputs");
-            var analysisConfig = new AnalysisConfig
-            {
-                LocalSettings = new AnalysisProperties
-                {
-                    new Property { Id = IsTestFileByName.TestRegExSettingId, Value = "pattern that won't match anything" }
-                }
-            };
-
             string projectXml = $@"
 <PropertyGroup>
   <CodePage>1250</CodePage>
@@ -458,7 +438,6 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
         public void WriteProjectInfo_ProjectWithNoCodePage()
         {
             // Arrange
-            var rootInputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Inputs");
             var rootOutputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Outputs");
 
             string projectXml = $@"
@@ -482,7 +461,6 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
         {
             // Check analysis settings are correctly passed from the targets to the task
             // Arrange
-            var rootInputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Inputs");
             var rootOutputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Outputs");
 
             string projectXml = $@"
@@ -623,22 +601,21 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
         #endregion Miscellaneous tests
 
         #region Private methods
-        
+
         private ProjectInfo ExecuteWriteProjectInfo(string projectFilePath, string rootOutputFolder, bool noWarningOrErrors = true)
         {
             // Act
             var result = BuildRunner.BuildTargets(TestContext, projectFilePath,
                 // The "write" target depends on a couple of other targets having executed first to set properties appropriately
                 TargetConstants.CategoriseProjectTarget,
-                TargetConstants.CalculateFilesToAnalyzeTarget,
                 TargetConstants.CreateProjectSpecificDirs,
+                TargetConstants.WriteFilesToAnalyzeTarget,
                 TargetConstants.WriteProjectDataTarget);
 
             // Assert
-            result.AssertTargetSucceeded(TargetConstants.CalculateFilesToAnalyzeTarget);
             result.AssertTargetSucceeded(TargetConstants.CreateProjectSpecificDirs);
+            result.AssertTargetSucceeded(TargetConstants.WriteFilesToAnalyzeTarget);
             result.AssertTargetSucceeded(TargetConstants.WriteProjectDataTarget);
-
             result.AssertTargetExecuted(TargetConstants.WriteProjectDataTarget);
 
             if (noWarningOrErrors)

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -249,7 +249,7 @@
   <!-- This target is a utility target: it won't be executed unless a target that
        depends on it is executed.
   -->
-  <Target Name="CalculateSonarQubeFilesToAnalyze"
+  <Target Name="SonarWriteFilesToAnalyze"
         Condition=" $(SonarQubeTempPath) != '' ">
 
     <!-- Include all of contents of the specified item groups, but exclude
@@ -277,9 +277,25 @@
       <!-- Set a property indicating whether there are any files to analyze -->
       <AnalysisFilesExist Condition=" @(SonarQubeAnalysisFiles) != '' ">true</AnalysisFilesExist>
     </PropertyGroup>
+
+    <!-- Write of file lists -->
+    <PropertyGroup>
+      <!-- Set the file name for the list file -->
+      <AnalysisFileList>$(ProjectSpecificConfDir)\FilesToAnalyze.txt</AnalysisFileList>
+    </PropertyGroup>
+
+    <Message Condition="$(AnalysisFilesExist)!='true'" Importance="normal" Text="Sonar: ($(MSBuildProjectFile)) No files were found to analyse" />
+    <Message Condition="$(AnalysisFilesExist)=='true'" Importance="normal" Text="Sonar: ($(MSBuildProjectFile)) Number of files to analyse: @(SonarQubeAnalysisFiles->Count()). The list of files to be analyzed is in $(AnalysisFileList)." />
+
+    <!-- Write out a list of files to analyze that will be passed to the sonar-scanner -->
+    <WriteLinesToFile Condition=" $(AnalysisFilesExist) == 'true' "
+            File="$(AnalysisFileList)"
+            Lines="%(SonarQubeAnalysisFiles.FullPath)"
+            Overwrite="false"
+            Encoding="Unicode" />
   </Target>
 
-  <Target Name="CreateProjectSpecificDirs" BeforeTargets="OverrideRoslynCodeAnalysisProperties;WriteSonarQubeProjectData"  Condition=" $(SonarQubeTempPath) != '' ">
+  <Target Name="CreateProjectSpecificDirs" BeforeTargets="OverrideRoslynCodeAnalysisProperties;WriteSonarQubeProjectData;SonarWriteFilesToAnalyze"  Condition=" $(SonarQubeTempPath) != '' ">
     <!-- **************************************************************************** -->
     <!-- Create the project-specific directories for conf and out -->
 
@@ -302,26 +318,9 @@
   -->
   <!-- **************************************************************************** -->
   <Target Name="WriteSonarQubeProjectData"
-          DependsOnTargets="SonarQubeCategoriseProject;CalculateSonarQubeFilesToAnalyze;CreateProjectSpecificDirs"
+          DependsOnTargets="SonarQubeCategoriseProject;SonarWriteFilesToAnalyze;CreateProjectSpecificDirs"
           AfterTargets="Build"
           Condition=" $(SonarQubeTempPath) != '' ">
-
-    <!-- **************************************************************************** -->
-    <!-- Write of file lists -->
-    <PropertyGroup>
-      <!-- Set the file name for the list file -->
-      <AnalysisFileList>$(ProjectSpecificOutDir)\FilesToAnalyze.txt</AnalysisFileList>
-    </PropertyGroup>
-
-    <Message Condition="$(AnalysisFilesExist)!='true'" Importance="normal" Text="Sonar: ($(MSBuildProjectFile)) No files were found to analyse" />
-    <Message Condition="$(AnalysisFilesExist)=='true'" Importance="normal" Text="Sonar: ($(MSBuildProjectFile)) Number of files to analyse: @(SonarQubeAnalysisFiles->Count()). The list of files to be analyzed is in $(AnalysisFileList)." />
-
-    <!-- Write out a list of files to analyze that will be passed to the sonar-scanner -->
-    <WriteLinesToFile Condition=" $(AnalysisFilesExist) == 'true' "
-            File="$(AnalysisFileList)"
-            Lines="%(SonarQubeAnalysisFiles.FullPath)"
-            Overwrite="false"
-            Encoding="Unicode" />
 
     <!-- Record the list of files as an analysis result -->
     <ItemGroup Condition=" $(AnalysisFilesExist) == 'true' ">
@@ -484,8 +483,8 @@
     <PropertyGroup Condition=" $(ErrorLog) == $(SonarCompileErrorLog) ">
       <!-- Keep the path so that we could set SonarQubeSetting with sonar.language.roslyn.reportFilePaths -->
       <RazorSonarCompileErrorLog>$(TargetDir)$(TargetName)$(RazorTargetNameSuffix)$(TargetExt).RoslynCA.json</RazorSonarCompileErrorLog>
-      <ErrorLog>$(RazorSonarCompileErrorLog)</ErrorLog> 
-      <RazorCompilationErrorLog>$(RazorSonarCompileErrorLog)</RazorCompilationErrorLog> 
+      <ErrorLog>$(RazorSonarCompileErrorLog)</ErrorLog>
+      <RazorCompilationErrorLog>$(RazorSonarCompileErrorLog)</RazorCompilationErrorLog>
     </PropertyGroup>
   </Target>
 

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -278,7 +278,7 @@
       <AnalysisFilesExist Condition=" @(SonarQubeAnalysisFiles) != '' ">true</AnalysisFilesExist>
     </PropertyGroup>
 
-    <!-- Write of file lists -->
+    <!-- Write the list of files  -->
     <PropertyGroup>
       <!-- Set the file name for the list file -->
       <AnalysisFileList>$(ProjectSpecificConfDir)\FilesToAnalyze.txt</AnalysisFileList>


### PR DESCRIPTION
Related to #959 

Move FilesToAnalyze.txt to `conf/0` directory, as it will be need by the new XML file `conf/0/SonarProjectConfig.xml`
Save the file directly after generating the list. The new Target will depend on it and execute it before the build.

If somebody would have a target that depends on `CalculateSonarQubeFilesToAnalyze` and executes before `WriteSonarQubeProjectData` target that would update our `SonarQubeAnalysisFiles` list, this would break such unsupported scenario as users looses the point to inject in. 

This is not a concern, as confirmed by @duncanp-sonar:

>Hi Pavel. The S4MSB targets files were not designed to be publicly extensible in the sense that users can rely on the order in which our targets fire, or even that specific targets exists. So we should feel free to change them as necessary.
The tweaks/interactions that we do support are all documented at the top of targets file, and are all at the data level i.e. "set property/item group/metadata X to get result Y" - nothing about targets.
Specifically in relation to `CalculateSonarQubeFilesToAnalyze`, if the user wants to include extra files in the list they should do it by either adding items directly to the group SonarQubeAnalysisFiles, or by adding a group of items by modifying SQAdditionalAnalysisFileItemTypes. Or just by adding the files to an item group that is already included e.g. None (edited) 