### PR TITLE
Empty .sonarqube folder at the end of the end step.

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/SonarScanner.MSBuild.Tasks.IntegrationTests.csproj
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/SonarScanner.MSBuild.Tasks.IntegrationTests.csproj
@@ -41,17 +41,20 @@
     <Reference Include="FluentAssertions, Version=5.9.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FluentAssertions.5.9.0\lib\net47\FluentAssertions.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Build.16.3.0\lib\net472\Microsoft.Build.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Build.16.9.0\lib\net472\Microsoft.Build.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Build.Framework.16.3.0\lib\net472\Microsoft.Build.Framework.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Build.Framework.16.9.0\lib\net472\Microsoft.Build.Framework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build.Tasks.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Build.Tasks.Core.16.3.0\lib\net472\Microsoft.Build.Tasks.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Build.Tasks.Core.16.9.0\lib\net472\Microsoft.Build.Tasks.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Build.Utilities.Core, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Build.Utilities.Core.16.3.0\lib\net472\Microsoft.Build.Utilities.Core.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Build.Utilities.Core.16.9.0\lib\net472\Microsoft.Build.Utilities.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\Assemblies\Microsoft.VisualStudio.QualityTools.UnitTestFramework.dll</HintPath>
@@ -64,8 +67,8 @@
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.2.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.7.1\lib\net461\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.5.0.0\lib\net461\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
@@ -104,8 +107,17 @@
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Encodings.Web.4.7.0\lib\netstandard2.0\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Text.Json.4.7.0\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System.Threading.Tasks.Dataflow, Version=4.6.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Tasks.Dataflow.4.11.1\lib\net461\System.Threading.Tasks.Dataflow.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/app.config
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/app.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <!--
@@ -16,7 +16,7 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Framework" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="4.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
-     </dependentAssembly>
+      </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Build.Engine" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="4.0.0.0-15.1.0.0" newVersion="15.1.0.0" />
@@ -34,7 +34,7 @@
 
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
 
-        <bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
 
       </dependentAssembly>
 
@@ -70,6 +70,14 @@
 
       </dependentAssembly>
 
+      <dependentAssembly>
+
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+
+      </dependentAssembly>
+
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/packages.config
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/packages.config
@@ -2,15 +2,16 @@
 <packages>
   <package id="FluentAssertions" version="5.9.0" targetFramework="net472" />
   <package id="FluentAssertions.Analyzers" version="0.11.4" targetFramework="net461" />
-  <package id="Microsoft.Build" version="16.3.0" targetFramework="net472" />
-  <package id="Microsoft.Build.Framework" version="16.3.0" targetFramework="net472" />
-  <package id="Microsoft.Build.Runtime" version="16.3.0" targetFramework="net472" />
-  <package id="Microsoft.Build.Tasks.Core" version="16.3.0" targetFramework="net472" />
-  <package id="Microsoft.Build.Utilities.Core" version="16.3.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net472" />
+  <package id="Microsoft.Build" version="16.9.0" targetFramework="net472" />
+  <package id="Microsoft.Build.Framework" version="16.9.0" targetFramework="net472" />
+  <package id="Microsoft.Build.Runtime" version="16.9.0" targetFramework="net472" />
+  <package id="Microsoft.Build.Tasks.Core" version="16.9.0" targetFramework="net472" />
+  <package id="Microsoft.Build.Utilities.Core" version="16.9.0" targetFramework="net472" />
   <package id="Microsoft.VisualStudio.Setup.Configuration.Interop" version="1.16.30" targetFramework="net472" developmentDependency="true" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Collections" version="4.3.0" targetFramework="net48" />
-  <package id="System.Collections.Immutable" version="1.7.1" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="5.0.0" targetFramework="net472" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net48" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net48" />
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net472" />
@@ -24,8 +25,11 @@
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net48" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net472" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net46" />
+  <package id="System.Text.Encodings.Web" version="4.7.0" targetFramework="net472" />
+  <package id="System.Text.Json" version="4.7.0" targetFramework="net472" />
   <package id="System.Threading" version="4.3.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Dataflow" version="4.11.1" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net472" />
   <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net48" />
   <package id="System.Threading.Thread" version="4.3.0" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />

--- a/Tests/SonarScanner.MSBuild.Tests/BootstrapperClassTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tests/BootstrapperClassTests.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -258,6 +258,29 @@ namespace SonarScanner.Bootstrapper.Tests
 
                 // Act
                 CheckExecutionSucceeds(AnalysisPhase.PreProcessing, false, null, "/d:sonar.host.url=http://anotherHost");
+
+                // Assert
+                File.Exists(filePath).Should().BeFalse();
+            }
+        }
+
+        [TestMethod]
+        public void Exe_PostProcCleansTemp()
+        {
+            // Arrange
+            BootstrapperTestUtils.EnsureDefaultPropertiesFileDoesNotExist();
+
+            using (InitializeNonTeamBuildEnvironment(RootDir))
+            {
+                // Create dummy file in Temp
+                var filePath = Path.Combine(TempDir, "myfile");
+                Directory.CreateDirectory(TempDir);
+                var stream = File.Create(filePath);
+                stream.Close();
+                File.Exists(filePath).Should().BeTrue();
+
+                // Act
+                CheckExecutionSucceeds(AnalysisPhase.PostProcessing, false, null, "/d:sonar.host.url=http://anotherHost");
 
                 // Assert
                 File.Exists(filePath).Should().BeFalse();

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.31.0.2646</version>
+      <version>3.35.0.2707</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -156,9 +156,19 @@ public class ScannerMSBuildTest {
       .setProperty("sonar.login", token)
       .setEnvironmentVariable("SONAR_SCANNER_OPTS", "-Dhttp.nonProxyHosts= -Dhttp.proxyHost=localhost -Dhttp.proxyPort=" + httpProxyPort));
 
-    assertThat(result.getLastStatus()).isNotEqualTo(0);
+    assertThat(result.getLastStatus()).isNotZero();
     assertThat(result.getLogs()).contains("407");
     assertThat(seenByProxy).isEmpty();
+
+    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir)
+      .addArgument("begin")
+      .setProjectKey(localProjectKey)
+      .setProjectName("sample")
+      .setProperty("sonar.projectBaseDir", Paths.get(projectDir.toAbsolutePath().toString(), "ProjectUnderTest").toString())
+      .setProjectVersion("1.0")
+      .setProperty("sonar.login", token));
+
+    TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild");
 
     ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir)
       .addArgument("end")

--- a/scripts/ci-build.ps1
+++ b/scripts/ci-build.ps1
@@ -21,6 +21,12 @@ function CleanAndRecreate-BuildDirectories([string]$tfm) {
     }
 }
 
+function CleanAndDelete-SonarQubeFolder() {
+	if (Test-Path(".sonarqube")) {
+        Remove-Item ".sonarqube\*" -Recurse -Force
+    }
+}
+
 try {
     Write-Host $PSScriptRoot
     
@@ -32,6 +38,7 @@ try {
     CleanAndRecreate-BuildDirectories "netcoreapp2.0"
     CleanAndRecreate-BuildDirectories "netcoreapp3.0"
     CleanAndRecreate-BuildDirectories "net5.0"
+	CleanAndDelete-SonarQubeFolder
     Download-ScannerCli
 
     Build-TFSProcessor

--- a/src/SonarScanner.MSBuild/BootstrapperClass.cs
+++ b/src/SonarScanner.MSBuild/BootstrapperClass.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -166,6 +166,7 @@ namespace SonarScanner.MSBuild
             {
                 var postProcessor = this.processorFactory.CreatePostProcessor();
                 succeeded = postProcessor.Execute(this.bootstrapSettings.ChildCmdLineArgs.ToArray(), config, teamBuildSettings);
+                CleanSonarQubeDirectory();
             }
 
             return succeeded ? SuccessCode : ErrorCode;

--- a/src/SonarScanner.MSBuild/Program.cs
+++ b/src/SonarScanner.MSBuild/Program.cs
@@ -19,11 +19,13 @@
  */
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild
 {
+    [ExcludeFromCodeCoverage]
     public static class Program
     {
         public const int ErrorCode = 1;

--- a/src/SonarScanner.MSBuild/Program.cs
+++ b/src/SonarScanner.MSBuild/Program.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -42,9 +42,9 @@ namespace SonarScanner.MSBuild
         {
             Utilities.LogAssemblyVersion(logger, Resources.AssemblyDescription);
 #if NET46
-            logger.LogInfo("Using the .NET Framework version of the Scanner for MSBuild");
+            logger.LogInfo("Using the .NET Framework version of the SonarScanner for .NET");
 #else
-            logger.LogInfo("Using the .NET Core version of the Scanner for MSBuild");
+            logger.LogInfo("Using the .NET Core version of the SonarScanner for .NET");
 #endif
 
             logger.SuspendOutput();


### PR DESCRIPTION
fixes #964 

This is to avoid further builds of an analyzed one to be analyzed. 

In some cases, the .sonarqube folder fail to be emptied, so the workaround defined in the issue shall be applied. 