### PR TITLE
Targets: Clear RazorCompilationErrorLog when ErrorLog is cleared.

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RazorTargetTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RazorTargetTests.cs
@@ -62,6 +62,25 @@ namespace SonarScanner.Integration.Tasks.IntegrationTests.TargetsTests
             AssertErrorLogIsSetBySonarQubeTargets(result);
         }
 
+        [TestMethod]
+        public void Razor_ExcludedProject_NoErrorLog()
+        {
+            var rootInputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Inputs");
+            var projectSnippet = $@"
+<PropertyGroup>
+  <SonarQubeTempPath>{rootInputFolder}</SonarQubeTempPath>
+  <SonarQubeExclude>true</SonarQubeExclude>
+</PropertyGroup>";
+            var filePath = CreateProjectFile(null, projectSnippet, TargetConstants.OverrideRoslynAnalysisTarget);
+
+            // Act
+            var result = BuildRunner.BuildTargets(TestContext, filePath, TargetConstants.OverrideRoslynAnalysisTarget);
+
+            // Assert
+            result.AssertTargetExecuted(TargetConstants.OverrideRoslynAnalysisTarget);
+            AssertExpectedErrorLog(result, string.Empty);
+        }
+
         private static void AssertErrorLogIsSetBySonarQubeTargets(BuildLog result)
         {
             var targetDir = result.GetCapturedPropertyValue(TargetProperties.TargetDir);

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -449,6 +449,7 @@
 
     <PropertyGroup Condition=" $(SonarQubeDisableRoslynCodeAnalysis) == 'true' ">
       <ErrorLog></ErrorLog>
+      <RazorCompilationErrorLog></RazorCompilationErrorLog>
       <!-- The ResolvedCodeAnalysisRuleSet property is not changed, which means the ruleset and the analyzers are not modified for test projects. -->
     </PropertyGroup>
     <!-- else -->


### PR DESCRIPTION
When `SonarQubeExclude` is true, we reset `ErrorLog` property. We should do the same for the Razor one at the same time to avoid Razor-only reports.