### PR TITLE
Load all rules from QP at once

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/DataModel/QualityProfile.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/DataModel/QualityProfile.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -33,8 +33,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             Language = language;
             Organization = organization;
             this.projectIds = new HashSet<string>();
-            InactiveRules = new List<SonarRule>();
-            ActiveRules = new List<SonarRule>();
+            Rules = new List<SonarRule>();
         }
 
         public QualityProfile AddProject(string projectKey, string projectBranch = null)
@@ -51,13 +50,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
         public QualityProfile AddRule(SonarRule rule)
         {
-            ActiveRules.Add(rule);
-            return this;
-        }
-
-        public QualityProfile AddInactiveRule(SonarRule rule)
-        {
-            InactiveRules.Add(rule);
+            Rules.Add(rule);
             return this;
         }
 
@@ -65,7 +58,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         public string Language { get; }
         public string Organization { get; }
         public IEnumerable<string> Projects { get { return this.projectIds; } }
-        public IList<SonarRule> ActiveRules { get; }
-        public IList<SonarRule> InactiveRules { get; }
+        public IList<SonarRule> Rules { get; }
     }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/DataModel/ServerDataModel.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/DataModel/ServerDataModel.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -61,18 +61,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             profile = new QualityProfile(id, language, organization);
             this.qualityProfiles.Add(profile);
             return profile;
-        }
-
-        public void AddActiveRuleToProfile(string qProfile, SonarRule rule)
-        {
-            var profile = FindProfile(qProfile);
-            profile.ActiveRules.Add(rule);
-        }
-
-        public void AddInactiveRuleToProfile(string qProfile, SonarRule rule)
-        {
-            var profile = FindProfile(qProfile);
-            profile.InactiveRules.Add(rule);
         }
 
         public void AddEmbeddedZipFile(string pluginKey, string embeddedFileName, params string[] contentFileNames)

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/MockRoslynAnalyzerProvider.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/MockRoslynAnalyzerProvider.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -37,8 +37,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
         #region IAnalyzerProvider methods
 
-        AnalyzerSettings IAnalyzerProvider.SetupAnalyzer(TeamBuildSettings teamBuildSettings, IAnalysisPropertyProvider sonarProperties,
-            IEnumerable<SonarRule> activeRules, IEnumerable<SonarRule> inactiveRules, string language)
+        AnalyzerSettings IAnalyzerProvider.SetupAnalyzer(TeamBuildSettings teamBuildSettings, IAnalysisPropertyProvider sonarProperties, IEnumerable<SonarRule> rules, string language)
         {
             teamBuildSettings.Should().NotBeNull();
             sonarProperties.Should().NotBeNull();

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/MockSonarQubeServer.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/Infrastructure/MockSonarQubeServer.cs
@@ -77,31 +77,17 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             return Task.CompletedTask;
         }
 
-        Task<IList<SonarRule>> ISonarQubeServer.GetActiveRules(string qprofile)
+        Task<IList<SonarRule>> ISonarQubeServer.GetRules(string qProfile)
         {
             LogMethodCalled();
-
-            qprofile.Should().NotBeNullOrEmpty("Quality profile is required");
-
-            var profile = Data.QualityProfiles.FirstOrDefault(qp => string.Equals(qp.Id, qprofile));
-            if (profile == null)
-            {
-                return Task.FromResult<IList<SonarRule>>(null);
-            }
-            return Task.FromResult(profile.ActiveRules);
-        }
-
-        Task<IList<SonarRule>> ISonarQubeServer.GetInactiveRules(string qprofile, string language)
-        {
-            LogMethodCalled();
-            qprofile.Should().NotBeNullOrEmpty("Quality profile is required");
-            var profile = Data.QualityProfiles.FirstOrDefault(qp => string.Equals(qp.Id, qprofile));
+            qProfile.Should().NotBeNullOrEmpty("Quality profile is required");
+            var profile = Data.QualityProfiles.FirstOrDefault(qp => string.Equals(qp.Id, qProfile));
             if (profile == null)
             {
                 return Task.FromResult<IList<SonarRule>>(null);
             }
 
-            return Task.FromResult(profile.InactiveRules);
+            return Task.FromResult(profile.Rules);
         }
 
         Task<IEnumerable<string>> ISonarQubeServer.GetAllLanguages()

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/PreProcessorTests.cs
@@ -120,8 +120,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             mockServer.AssertMethodCalled("GetProperties", 1);
             mockServer.AssertMethodCalled("GetAllLanguages", 1);
             mockServer.AssertMethodCalled("TryGetQualityProfile", 2); // C# and VBNet
-            mockServer.AssertMethodCalled("GetActiveRules", 2); // C# and VBNet
-            mockServer.AssertMethodCalled("GetInactiveRules", 2); // C# and VBNet
+            mockServer.AssertMethodCalled("GetRules", 2); // C# and VBNet
 
             AssertAnalysisConfig(settings.AnalysisConfigFilePath, 2, logger);
         }
@@ -184,8 +183,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             mockServer.AssertMethodCalled("GetProperties", 1);
             mockServer.AssertMethodCalled("GetAllLanguages", 1);
             mockServer.AssertMethodCalled("TryGetQualityProfile", 2); // C# and VBNet
-            mockServer.AssertMethodCalled("GetActiveRules", 2); // C# and VBNet
-            mockServer.AssertMethodCalled("GetInactiveRules", 2); // C# and VBNet
+            mockServer.AssertMethodCalled("GetRules", 2); // C# and VBNet
 
             AssertAnalysisConfig(settings.AnalysisConfigFilePath, 2, logger);
         }
@@ -255,8 +253,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             mockServer.AssertMethodCalled("GetProperties", 1);
             mockServer.AssertMethodCalled("GetAllLanguages", 1);
             mockServer.AssertMethodCalled("TryGetQualityProfile", 2); // C# and VBNet
-            mockServer.AssertMethodCalled("GetActiveRules", 2); // C# and VBNet
-            mockServer.AssertMethodCalled("GetInactiveRules", 2); // C# and VBNet
+            mockServer.AssertMethodCalled("GetRules", 2); // C# and VBNet
 
             AssertAnalysisConfig(settings.AnalysisConfigFilePath, 2, logger);
         }
@@ -375,8 +372,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             mockServer.AssertMethodCalled("GetProperties", 1);
             mockServer.AssertMethodCalled("GetAllLanguages", 1);
             mockServer.AssertMethodCalled("TryGetQualityProfile", 0); // No valid plugin
-            mockServer.AssertMethodCalled("GetActiveRules", 0); // No valid plugin
-            mockServer.AssertMethodCalled("GetInactiveRules", 0); // No valid plugin
+            mockServer.AssertMethodCalled("GetRules", 0); // No valid plugin
 
             AssertAnalysisConfig(settings.AnalysisConfigFilePath, 0, logger);
 
@@ -444,8 +440,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             mockServer.AssertMethodCalled("GetProperties", 1);
             mockServer.AssertMethodCalled("GetAllLanguages", 1);
             mockServer.AssertMethodCalled("TryGetQualityProfile", 2); // C# and VBNet
-            mockServer.AssertMethodCalled("GetActiveRules", 0); // no quality profile assigned to project
-            mockServer.AssertMethodCalled("GetInactiveRules", 0);
+            mockServer.AssertMethodCalled("GetRules", 0); // no quality profile assigned to project
 
             AssertAnalysisConfig(settings.AnalysisConfigFilePath, 0, logger);
 
@@ -458,7 +453,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         public void PreProc_EndToEnd_Success_LocalSettingsAreUsedInSonarLintXML()
         {
             // Checks that local settings are used when creating the SonarLint.xml file,
-            // overriding 
+            // overriding
 
             // Arrange
             var workingDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/RoslynAnalyzerProviderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/RoslynAnalyzerProviderTests.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -53,8 +53,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         {
             // Arrange
             var logger = new TestLogger();
-            IList<SonarRule> activeRules = new List<SonarRule>();
-            IList<SonarRule> inactiveRules = new List<SonarRule>();
+            var rules = Enumerable.Empty<SonarRule>();
             var pluginKey = RoslynAnalyzerProvider.CSharpPluginKey;
             var sonarProperties = new ListPropertiesProvider();
             var settings = CreateSettings(TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext));
@@ -62,15 +61,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             var testSubject = CreateTestSubject(logger);
 
             // Act and assert
-            Action act = () => testSubject.SetupAnalyzer(null, sonarProperties, activeRules, inactiveRules, pluginKey);
+            Action act = () => testSubject.SetupAnalyzer(null, sonarProperties, rules, pluginKey);
             act.Should().ThrowExactly<ArgumentNullException>();
-            act = () => testSubject.SetupAnalyzer(settings, null, activeRules, inactiveRules, pluginKey);
+            act = () => testSubject.SetupAnalyzer(settings, null, rules, pluginKey);
             act.Should().ThrowExactly<ArgumentNullException>();
-            act = () => testSubject.SetupAnalyzer(settings, sonarProperties, null, inactiveRules, pluginKey);
+            act = () => testSubject.SetupAnalyzer(settings, sonarProperties, null, pluginKey);
             act.Should().ThrowExactly<ArgumentNullException>();
-            act = () => testSubject.SetupAnalyzer(settings, sonarProperties, activeRules, null, pluginKey);
-            act.Should().ThrowExactly<ArgumentNullException>();
-            act = () => testSubject.SetupAnalyzer(settings, sonarProperties, activeRules, inactiveRules, null);
+            act = () => testSubject.SetupAnalyzer(settings, sonarProperties, rules, null);
             act.Should().ThrowExactly<ArgumentNullException>();
         }
 
@@ -79,8 +76,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         {
             // Arrange
             var logger = new TestLogger();
-            IList<SonarRule> activeRules = new List<SonarRule>();
-            IList<SonarRule> inactiveRules = new List<SonarRule>();
+            var rules = Enumerable.Empty<SonarRule>();
             var pluginKey = "csharp";
             var sonarProperties = new ListPropertiesProvider();
             var settings = CreateSettings(TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext));
@@ -88,7 +84,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             var testSubject = CreateTestSubject(logger);
 
             // Act and assert
-            testSubject.SetupAnalyzer(settings, sonarProperties, activeRules, inactiveRules, pluginKey).Should().NotBeNull();
+            testSubject.SetupAnalyzer(settings, sonarProperties, rules, pluginKey).Should().NotBeNull();
         }
 
         [TestMethod]
@@ -97,8 +93,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             // Arrange
             var rootFolder = CreateTestFolders();
             var logger = new TestLogger();
-            IList<SonarRule> activeRules = createActiveRules();
-            IList<SonarRule> inactiveRules = createInactiveRules();
+            var rules = createRules();
             var language = RoslynAnalyzerProvider.CSharpLanguage;
 
             // missing properties to get plugin related properties
@@ -119,7 +114,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             var testSubject = new RoslynAnalyzerProvider(mockInstaller, logger);
 
             // Act
-            var actualSettings = testSubject.SetupAnalyzer(settings, sonarProperties, activeRules, inactiveRules, language);
+            var actualSettings = testSubject.SetupAnalyzer(settings, sonarProperties, rules, language);
 
             // Assert
             CheckSettingsInvariants(actualSettings);
@@ -140,8 +135,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             // Arrange
             var rootFolder = CreateTestFolders();
             var logger = new TestLogger();
-            IList<SonarRule> activeRules = createActiveRules();
-            IList<SonarRule> inactiveRules = createInactiveRules();
+            var rules = createRules();
             var language = RoslynAnalyzerProvider.CSharpLanguage;
             var mockInstaller = new MockAnalyzerInstaller
             {
@@ -211,7 +205,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             var testSubject = new RoslynAnalyzerProvider(mockInstaller, logger);
 
             // Act
-            var actualSettings = testSubject.SetupAnalyzer(settings, sonarProperties, activeRules, inactiveRules, language);
+            var actualSettings = testSubject.SetupAnalyzer(settings, sonarProperties, rules, language);
 
             // Assert
             CheckSettingsInvariants(actualSettings);
@@ -239,16 +233,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
         #region Private methods
 
-        private List<SonarRule> createInactiveRules()
-        {
-            var list = new List<SonarRule>
-            {
-                new SonarRule("csharpsquid", "S1000", false)
-            };
-            return list;
-        }
-
-        private List<SonarRule> createActiveRules()
+        private List<SonarRule> createRules()
         {
             /*
             <Rules AnalyzerId=""SonarLint.CSharp"" RuleNamespace=""SonarLint.CSharp"">
@@ -269,6 +254,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             rules.Add(ruleWithParameter);
             rules.Add(new SonarRule("csharpsquid", "S1125", true));
             rules.Add(new SonarRule("roslyn.wintellect", "Wintellect003", true));
+            rules.Add(new SonarRule("csharpsquid", "S1000", false));
 
             return rules;
         }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/RoslynAnalyzerProviderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/RoslynAnalyzerProviderTests.cs
@@ -54,18 +54,18 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             // Arrange
             var logger = new TestLogger();
             var rules = Enumerable.Empty<SonarRule>();
-            var pluginKey = RoslynAnalyzerProvider.CSharpPluginKey;
+            var language = RoslynAnalyzerProvider.CSharpLanguage;
             var sonarProperties = new ListPropertiesProvider();
             var settings = CreateSettings(TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext));
 
             var testSubject = CreateTestSubject(logger);
 
             // Act and assert
-            Action act = () => testSubject.SetupAnalyzer(null, sonarProperties, rules, pluginKey);
+            Action act = () => testSubject.SetupAnalyzer(null, sonarProperties, rules, language);
             act.Should().ThrowExactly<ArgumentNullException>();
-            act = () => testSubject.SetupAnalyzer(settings, null, rules, pluginKey);
+            act = () => testSubject.SetupAnalyzer(settings, null, rules, language);
             act.Should().ThrowExactly<ArgumentNullException>();
-            act = () => testSubject.SetupAnalyzer(settings, sonarProperties, null, pluginKey);
+            act = () => testSubject.SetupAnalyzer(settings, sonarProperties, null, language);
             act.Should().ThrowExactly<ArgumentNullException>();
             act = () => testSubject.SetupAnalyzer(settings, sonarProperties, rules, null);
             act.Should().ThrowExactly<ArgumentNullException>();

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/RoslynRuleSetGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/RoslynRuleSetGeneratorTests.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -42,18 +42,14 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         public void RoslynRuleSet_GeneratorArgumentChecks()
         {
             var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider());
-            IEnumerable<SonarRule> activeRules = new List<SonarRule>();
-            IEnumerable<SonarRule> inactiveRules = new List<SonarRule>();
+            IEnumerable<SonarRule> rules = Enumerable.Empty<SonarRule>();
             var language = "cs";
 
-            Action act1 = () => generator.Generate(null, activeRules, inactiveRules);
+            Action act1 = () => generator.Generate(null, rules);
             act1.Should().ThrowExactly<ArgumentNullException>();
 
-            Action act2 = () => generator.Generate(language, activeRules, null);
+            Action act2 = () => generator.Generate(language, null);
             act2.Should().ThrowExactly<ArgumentNullException>();
-
-            Action act3 = () => generator.Generate(language, null, inactiveRules);
-            act3.Should().ThrowExactly<ArgumentNullException>();
         }
 
         [TestMethod]
@@ -61,14 +57,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
         {
             // Arrange
             var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider());
-            var activeRules = new List<SonarRule>
+            var rules = new List<SonarRule>
             {
                 new SonarRule("repo", "key"),
             };
-            var inactiveRules = new List<SonarRule>();
 
             // Act
-            var ruleSet = generator.Generate("cs", activeRules, inactiveRules);
+            var ruleSet = generator.Generate("cs", rules);
 
             // Assert
             ruleSet.Rules.Should().BeEmpty(); // No analyzers
@@ -87,7 +82,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 ["sonaranalyzer-cs.ruleNamespace"] = "SonarAnalyzer.CSharp",
             }));
 
-            var activeRules = new List<SonarRule>
+            var rules = new List<SonarRule>
             {
                 new SonarRule("csharpsquid", "rule1", isActive: true),
                 new SonarRule("csharpsquid", "rule2", isActive: true),
@@ -95,7 +90,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
             // Act
             generator.ActiveRuleAction = RuleAction.None;
-            var ruleSet = generator.Generate("cs", activeRules, Enumerable.Empty<SonarRule>());
+            var ruleSet = generator.Generate("cs", rules);
 
             // Assert
             ruleSet.Rules.Should().HaveCount(1);
@@ -112,7 +107,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 ["sonaranalyzer-cs.ruleNamespace"] = "SonarAnalyzer.CSharp",
             }));
 
-            var activeRules = new List<SonarRule>
+            var rules = new List<SonarRule>
             {
                 new SonarRule("csharpsquid", "rule1", isActive: true),
                 new SonarRule("csharpsquid", "rule2", isActive: true),
@@ -120,7 +115,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
             // Act
             generator.ActiveRuleAction = RuleAction.Info;
-            var ruleSet = generator.Generate("cs", activeRules, Enumerable.Empty<SonarRule>());
+            var ruleSet = generator.Generate("cs", rules);
 
             // Assert
             ruleSet.Rules.Should().HaveCount(1);
@@ -137,7 +132,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 ["sonaranalyzer-cs.ruleNamespace"] = "SonarAnalyzer.CSharp",
             }));
 
-            var activeRules = new List<SonarRule>
+            var rules = new List<SonarRule>
             {
                 new SonarRule("csharpsquid", "rule1", isActive: true),
                 new SonarRule("csharpsquid", "rule2", isActive: true),
@@ -145,7 +140,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
             // Act
             generator.ActiveRuleAction = RuleAction.Warning;
-            var ruleSet = generator.Generate("cs", activeRules, Enumerable.Empty<SonarRule>());
+            var ruleSet = generator.Generate("cs", rules);
 
             // Assert
             ruleSet.Rules.Should().HaveCount(1);
@@ -161,8 +156,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 ["sonaranalyzer-cs.analyzerId"] = "SonarAnalyzer.CSharp",
                 ["sonaranalyzer-cs.ruleNamespace"] = "SonarAnalyzer.CSharp",
             }));
-
-            var activeRules = new List<SonarRule>
+            var rules = new List<SonarRule>
             {
                 new SonarRule("csharpsquid", "rule1", isActive: true),
                 new SonarRule("csharpsquid", "rule2", isActive: true),
@@ -170,7 +164,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
             // Act
             generator.ActiveRuleAction = RuleAction.Error;
-            var ruleSet = generator.Generate("cs", activeRules, Enumerable.Empty<SonarRule>());
+            var ruleSet = generator.Generate("cs", rules);
 
             // Assert
             ruleSet.Rules.Should().HaveCount(1);
@@ -187,7 +181,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 ["sonaranalyzer-cs.ruleNamespace"] = "SonarAnalyzer.CSharp",
             }));
 
-            var activeRules = new List<SonarRule>
+            var rules = new List<SonarRule>
             {
                 new SonarRule("csharpsquid", "rule1", isActive: true),
                 new SonarRule("csharpsquid", "rule2", isActive: true),
@@ -195,7 +189,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
             // Act
             generator.ActiveRuleAction = RuleAction.Hidden;
-            var ruleSet = generator.Generate("cs", activeRules, Enumerable.Empty<SonarRule>());
+            var ruleSet = generator.Generate("cs", rules);
 
             // Assert
             ruleSet.Rules.Should().HaveCount(1);
@@ -224,7 +218,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 ["sonaranalyzer-cs.ruleNamespace"] = "SonarAnalyzer.CSharp",
             }));
 
-            var inactiveRules = new List<SonarRule>
+            var rules = new List<SonarRule>
             {
                 new SonarRule("csharpsquid", "rule1", isActive: false),
                 new SonarRule("csharpsquid", "rule2", isActive: false),
@@ -232,7 +226,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
 
             // Act
             generator.ActiveRuleAction = RuleAction.Error;
-            var ruleSet = generator.Generate("cs", Enumerable.Empty<SonarRule>(), inactiveRules);
+            var ruleSet = generator.Generate("cs", rules);
 
             // Assert
             ruleSet.Rules.Should().HaveCount(1);
@@ -245,17 +239,14 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             // Arrange
             var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider());
 
-            var activeRules = new[]
+            var rules = new[]
             {
                 new SonarRule("other.repo", "other.rule1", true),
-            };
-            var inactiveRules = new[]
-            {
                 new SonarRule("other.repo", "other.rule2", false),
             };
 
             // Act
-            var ruleSet = generator.Generate("cs", activeRules, inactiveRules);
+            var ruleSet = generator.Generate("cs", rules);
 
             // Assert
             ruleSet.Rules.Should().BeEmpty();
@@ -273,19 +264,16 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 ["custom2.ruleNamespace"] = "CustomNamespace2",
             }));
 
-            var activeRules = new[]
+            var rules = new[]
             {
                 new SonarRule("roslyn.custom1", "active1", true),
                 new SonarRule("roslyn.custom2", "active2", true),
-            };
-            var inactiveRules = new[]
-            {
                 new SonarRule("roslyn.custom1", "inactive1", false),
                 new SonarRule("roslyn.custom2", "inactive2", false),
             };
 
             // Act
-            var ruleSet = generator.Generate("cs", activeRules, inactiveRules);
+            var ruleSet = generator.Generate("cs", rules);
 
             // Assert
             ruleSet.Rules.Should().HaveCount(2);
@@ -313,21 +301,18 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
             }));
 
-            var activeRules = new[]
+            var rules = new[]
             {
                 new SonarRule("csharpsquid", "active1", true),
                 // Even though this rule is for VB it will be added as C#, see NOTE below
                 new SonarRule("vbnet", "active2", true),
-            };
-            var inactiveRules = new[]
-            {
                 new SonarRule("csharpsquid", "inactive1", false),
                 // Even though this rule is for VB it will be added as C#, see NOTE below
                 new SonarRule("vbnet", "inactive2", false),
             };
 
             // Act
-            var ruleSet = generator.Generate("cs", activeRules, inactiveRules);
+            var ruleSet = generator.Generate("cs", rules);
 
             // Assert
             ruleSet.Rules.Should().HaveCount(1);
@@ -352,7 +337,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
             var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider());
 
             // Act
-            var ruleSet = generator.Generate("cs", Enumerable.Empty<SonarRule>(), Enumerable.Empty<SonarRule>());
+            var ruleSet = generator.Generate("cs", Enumerable.Empty<SonarRule>());
 
             // Assert
             ruleSet.Description.Should().Be("This rule set was automatically generated from SonarQube");
@@ -369,13 +354,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
             }));
 
-            var activeRules = new[]
+            var rules = new[]
             {
                 new SonarRule("csharpsquid", "active1", true),
             };
 
             // Act & Assert
-            var action = new Action(() => generator.Generate("cs", activeRules, Enumerable.Empty<SonarRule>()));
+            var action = new Action(() => generator.Generate("cs", rules));
             action.Should().ThrowExactly<AnalysisException>().And
                 .Message.Should().StartWith(
                     "Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");
@@ -390,13 +375,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
             }));
 
-            var activeRules = new[]
+            var rules = new[]
             {
                 new SonarRule("csharpsquid", "active1", true),
             };
 
             // Act & Assert
-            var action = new Action(() => generator.Generate("cs", activeRules, Enumerable.Empty<SonarRule>()));
+            var action = new Action(() => generator.Generate("cs", rules));
             action.Should().ThrowExactly<AnalysisException>().And
                 .Message.Should().StartWith(
                     "Property does not exist: sonaranalyzer-cs.ruleNamespace. This property should be set by the plugin in SonarQube.");
@@ -412,13 +397,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Tests
                 { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
             }));
 
-            var activeRules = new[]
+            var rules = new[]
             {
                 new SonarRule("csharpsquid", "active1", true),
             };
 
             // Act & Assert
-            var action = new Action(() => generator.Generate("cs", activeRules, Enumerable.Empty<SonarRule>()));
+            var action = new Action(() => generator.Generate("cs", rules));
             action.Should().ThrowExactly<AnalysisException>().And
                 .Message.Should().StartWith(
                     "Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/SonarWebServiceTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/SonarWebServiceTest.cs
@@ -180,7 +180,7 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
 
             this.downloader.ConfigureGetLicenseInformationMock(HttpStatusCode.Unauthorized, "", false);
 
-            var result = this.ws.IsServerLicenseValid().Result;
+            _ = this.ws.IsServerLicenseValid().Result;
 
             this.logger.AssertErrorLogged("The token you provided doesn't have sufficient rights to check license.");
         }
@@ -223,7 +223,7 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
             //multiple QPs for a project, taking the default one
             this.downloader.Pages["http://myhost:222/api/qualityprofiles/search?project=foo+bar"] =
                "{ profiles: [{\"key\":\"profile1k\",\"name\":\"profile1\",\"language\":\"cs\", \"isDefault\": false}, {\"key\":\"profile4k\",\"name\":\"profile4\",\"language\":\"cs\", \"isDefault\": true}]}";
-            var result = this.ws.TryGetQualityProfile("foo bar", null, null, "cs").Result;
+            _ = this.ws.TryGetQualityProfile("foo bar", null, null, "cs").Result;
         }
 
         [TestMethod]
@@ -396,9 +396,9 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
         }
 
         [TestMethod]
-        public void GetActiveRules_UseParamAsKey()
+        public void GetRules_UseParamAsKey()
         {
-            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&activation=true&qprofile=qp&p=1"] =
+            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile=qp&p=1"] =
                 @"{ total: 1, p: 1, ps: 1,
             rules: [{
                 key: ""vbnet:S2368"",
@@ -428,7 +428,7 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
             }
             }";
 
-            var actual = this.ws.GetActiveRules("qp").Result;
+            var actual = this.ws.GetRules("qp").Result;
             actual.Should().ContainSingle();
 
             actual[0].RepoKey.Should().Be("vbnet");
@@ -439,12 +439,12 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
         }
 
         [TestMethod]
-        public void GetActiveRules_ShouldNotGo_Beyond_10k_Results()
+        public void GetRules_ShouldNotGoBeyond_10k_Results()
         {
 
             for (int page = 1; page <= 21; page++)
             {
-                this.downloader.Pages[$"http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&activation=true&qprofile=qp&p={page}"] = $@"
+                this.downloader.Pages[$"http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile=qp&p={page}"] = $@"
                     {{
                     total: 10500,
                     p: {page},
@@ -501,16 +501,15 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
                 }}";
             }
 
-
-            var rules = this.ws.GetActiveRules("qp").Result;
+            var rules = this.ws.GetRules("qp").Result;
 
             rules.Should().HaveCount(40);
         }
 
         [TestMethod]
-        public void GetActiveRules()
+        public void GetRules()
         {
-            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&activation=true&qprofile=qp&p=1"] =
+            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile=qp&p=1"] =
             @" { total: 3, p: 1, ps: 2,
             rules: [{
                 key: ""vbnet:S2368"",
@@ -537,7 +536,16 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
                 }
                 ],
                 type: ""CODE_SMELL""
-            }],
+            },
+            {
+                key: ""vbnet:S1234"",
+                repo: ""vbnet"",
+                name: ""This rule is not active"",
+                severity: ""MAJOR"",
+                lang: ""vbnet"",
+                params: [ ],
+                type: ""CODE_SMELL""
+            },],
 
             actives: {
                 ""vbnet:S2368"": [
@@ -564,7 +572,7 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
             }
             }";
 
-            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&activation=true&qprofile=qp&p=2"] =
+            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile=qp&p=2"] =
             @" { total: 3, p: 2, ps: 2,
             rules: [{
                 key: ""vbnet:S2346"",
@@ -588,14 +596,15 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
             }
             }";
 
-            var actual = this.ws.GetActiveRules("qp").Result;
-            actual.Should().HaveCount(3);
+            var actual = this.ws.GetRules("qp").Result;
+            actual.Should().HaveCount(4);
 
             actual[0].RepoKey.Should().Be("vbnet");
             actual[0].RuleKey.Should().Be("S2368");
             actual[0].InternalKeyOrKey.Should().Be("S2368");
             actual[0].TemplateKey.Should().BeNull();
             actual[0].Parameters.Should().HaveCount(0);
+            actual[0].IsActive.Should().BeTrue();
 
             actual[1].RepoKey.Should().Be("common-vbnet");
             actual[1].RuleKey.Should().Be("InsufficientCommentDensity");
@@ -603,86 +612,28 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
             actual[1].TemplateKey.Should().Be("dummy.template.key");
             actual[1].Parameters.Should().HaveCount(1);
             actual[1].Parameters.First().Should().Be(new KeyValuePair<string, string>("minimumCommentDensity", "50"));
+            actual[1].IsActive.Should().BeTrue();
 
             actual[2].RepoKey.Should().Be("vbnet");
-            actual[2].RuleKey.Should().Be("S2346");
-            actual[2].InternalKeyOrKey.Should().Be("S2346");
+            actual[2].RuleKey.Should().Be("S1234");
+            actual[2].InternalKeyOrKey.Should().Be("S1234");
             actual[2].TemplateKey.Should().BeNull();
-            actual[2].Parameters.Should().HaveCount(0);
+            actual[2].Parameters.Should().BeNull();
+            actual[2].IsActive.Should().BeFalse();
+
+            actual[3].RepoKey.Should().Be("vbnet");
+            actual[3].RuleKey.Should().Be("S2346");
+            actual[3].InternalKeyOrKey.Should().Be("S2346");
+            actual[3].TemplateKey.Should().BeNull();
+            actual[3].Parameters.Should().HaveCount(0);
+            actual[3].IsActive.Should().BeTrue();
         }
 
         [TestMethod]
-        public void GetActiveRules_WhenActivesDoesNotContainRule_ThrowsJsonException()
+        public void GetActiveRules_WhenActivesContainsRuleWithMultipleBodies_UseFirst()
         {
             // Arrange
-            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&activation=true&qprofile=qp&p=1"] =
-                @"{ total: 1, p: 1, ps: 1,
-            rules: [{
-                key: ""key1"",
-                repo: ""vbnet"",
-                name: ""Public methods should not have multidimensional array parameters"",
-                severity: ""MAJOR"",
-                lang: ""vbnet"",
-                params: [ ],
-                type: ""CODE_SMELL""
-            }],
-
-            actives: {
-                ""key2"": [
-                {
-                    qProfile: ""qp"",
-                    inherit: ""NONE"",
-                    severity: ""MAJOR"",
-                    params: [
-                    {
-                      key: ""CheckId"",
-                      value: ""OverwrittenId"",
-                      type: ""FLOAT""
-                    }
-                    ]
-                }
-                ]
-            }
-            }";
-
-            Func<Task> act = async () => await this.ws.GetActiveRules("qp");
-
-            // Act &  Assert
-            act.Should().ThrowExactly<JsonException>().WithMessage("Malformed json response, \"actives\" field should contain rule 'key1'");
-        }
-
-        [TestMethod]
-        public void GetActiveRules_WhenActivesContainsRuleWithEmptyBody_ThrowsJsonException()
-        {
-            // Arrange
-            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&activation=true&qprofile=qp&p=1"] =
-                @"{ total: 1, p: 1, ps: 1,
-            rules: [{
-                key: ""key1"",
-                repo: ""vbnet"",
-                name: ""Public methods should not have multidimensional array parameters"",
-                severity: ""MAJOR"",
-                lang: ""vbnet"",
-                params: [ ],
-                type: ""CODE_SMELL""
-            }],
-
-            actives: {
-                ""key1"": []
-            }
-            }";
-
-            Func<Task> act = async () => await this.ws.GetActiveRules("qp");
-
-            // Act &  Assert
-            act.Should().ThrowExactly<JsonException>().WithMessage("Malformed json response, \"actives\" field should contain rule 'key1'");
-        }
-
-        [TestMethod]
-        public void GetActiveRules_WhenActivesContainsRuleWithMultipleBodies_ThrowsJsonException()
-        {
-            // Arrange
-            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&activation=true&qprofile=qp&p=1"] =
+            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile=qp&p=1"] =
                 @"{ total: 1, p: 1, ps: 1,
             rules: [{
                 key: ""key1"",
@@ -703,7 +654,7 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
                     params: [
                     {
                       key: ""CheckId"",
-                      value: ""OverwrittenId"",
+                      value: ""OverwrittenId-First"",
                       type: ""FLOAT""
                     }
                     ]
@@ -715,7 +666,7 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
                     params: [
                     {
                       key: ""CheckId"",
-                      value: ""OverwrittenId"",
+                      value: ""OverwrittenId-Second"",
                       type: ""FLOAT""
                     }
                     ]
@@ -724,16 +675,18 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
             }
             }";
 
-            Func<Task> act = async () => await this.ws.GetActiveRules("qp");
+            var actual = this.ws.GetRules("qp").Result;
 
-            // Act &  Assert
-            act.Should().ThrowExactly<JsonException>().WithMessage("Malformed json response, \"actives\" field should contain rule 'key1'");
+            // Assert
+            actual.Should().HaveCount(1);
+            actual.Single().IsActive.Should().BeTrue();
+            actual.Single().RuleKey.Should().Be("OverwrittenId-First");
         }
 
         [TestMethod]
-        public void GetInactiveRulesAndEscapeUrl()
+        public void GetRules_NoActives()
         {
-            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params&ps=500&activation=false&qprofile=my%23qp&p=1&languages=cs"] = @"
+            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile=qp&p=1"] = @"
             {
             total: 3,
             p: 1,
@@ -748,65 +701,91 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
                     ""key"": ""csharpsquid:S1117"",
                     ""repo"": ""csharpsquid"",
                     ""type"": ""CODE_SMELL""
-                },
-                {
-                    ""key"": ""csharpsquid:S1764"",
-                    ""repo"": ""csharpsquid"",
-                    ""type"": ""BUG""
                 }
             ]}";
 
-            var rules = this.ws.GetInactiveRules("my#qp", "cs").Result;
+            var rules = this.ws.GetRules("qp").Result;
 
-            rules.Should().HaveCount(3);
+            rules.Should().HaveCount(2);
 
             rules[0].RepoKey.Should().Be("csharpsquid");
             rules[0].RuleKey.Should().Be("S2757");
             rules[0].InternalKeyOrKey.Should().Be("S2757");
+            rules[0].Parameters.Should().BeNull();
+            rules[0].IsActive.Should().BeFalse();
 
             rules[1].RepoKey.Should().Be("csharpsquid");
             rules[1].RuleKey.Should().Be("S1117");
             rules[1].InternalKeyOrKey.Should().Be("S1117");
-
-            rules[2].RepoKey.Should().Be("csharpsquid");
-            rules[2].RuleKey.Should().Be("S1764");
-            rules[2].InternalKeyOrKey.Should().Be("S1764");
+            rules[1].Parameters.Should().BeNull();
+            rules[1].IsActive.Should().BeFalse();
         }
 
         [TestMethod]
-        public void GetInactiveRules_ShouldNotGo_Beyond_10k_Results()
+        public void GetRules_EmptyActives()
         {
-
-            for (int page = 1; page <= 21; page++)
+            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile=qp&p=1"] = @"
             {
-                this.downloader.Pages[$"http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params&ps=500&activation=false&qprofile=my%23qp&p={page}&languages=cs"] = $@"
-                    {{
-                    total: 10500,
-                    p: {page},
-                    ps: 500,
-                    rules: [
-                        {{
-                            ""key"": ""csharpsquid:S2757"",
-                            ""repo"": ""csharpsquid"",
-                            ""type"": ""BUG""
-                        }},
-                        {{
-                            ""key"": ""csharpsquid:S1117"",
-                            ""repo"": ""csharpsquid"",
-                            ""type"": ""CODE_SMELL""
-                        }},
-                        {{
-                            ""key"": ""csharpsquid:S1764"",
-                            ""repo"": ""csharpsquid"",
-                            ""type"": ""BUG""
-                        }}
-                    ]}}";
-            }
+            total: 3,
+            p: 1,
+            ps: 500,
+            rules: [
+                {
+                    ""key"": ""csharpsquid:S2757"",
+                    ""repo"": ""csharpsquid"",
+                    ""type"": ""BUG""
+                },
+                {
+                    ""key"": ""csharpsquid:S1117"",
+                    ""repo"": ""csharpsquid"",
+                    ""type"": ""CODE_SMELL""
+                }
+            ],
 
+            actives: {}
+            }";
 
-            var rules = this.ws.GetInactiveRules("my#qp", "cs").Result;
+            var rules = this.ws.GetRules("qp").Result;
 
-            rules.Should().HaveCount(60); //3 rules times 20 pages, even if total is 10k
+            rules.Should().HaveCount(2);
+
+            rules[0].RepoKey.Should().Be("csharpsquid");
+            rules[0].RuleKey.Should().Be("S2757");
+            rules[0].InternalKeyOrKey.Should().Be("S2757");
+            rules[0].Parameters.Should().BeNull();
+            rules[0].IsActive.Should().BeFalse();
+
+            rules[1].RepoKey.Should().Be("csharpsquid");
+            rules[1].RuleKey.Should().Be("S1117");
+            rules[1].InternalKeyOrKey.Should().Be("S1117");
+            rules[1].Parameters.Should().BeNull();
+            rules[1].IsActive.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void GetRules_EscapeUrl()
+        {
+            this.downloader.Pages["http://myhost:222/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile=my%23qp&p=1"] = @"
+            {
+            total: 3,
+            p: 1,
+            ps: 500,
+            rules: [
+                {
+                    ""key"": ""csharpsquid:S2757"",
+                    ""repo"": ""csharpsquid"",
+                    ""type"": ""BUG""
+                },
+            ]}";
+
+            var rules = this.ws.GetRules("my#qp").Result;
+
+            rules.Should().HaveCount(1);
+
+            rules[0].RepoKey.Should().Be("csharpsquid");
+            rules[0].RuleKey.Should().Be("S2757");
+            rules[0].InternalKeyOrKey.Should().Be("S2757");
+            rules[0].IsActive.Should().BeFalse();
         }
 
         [TestMethod]

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IAnalyzerProvider.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IAnalyzerProvider.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -33,7 +33,6 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// </summary>
         /// <param name="projectKey">Identifier for the project being analyzed</param>
         /// <returns>The settings required to configure the build for Roslyn a analyzer</returns>
-        AnalyzerSettings SetupAnalyzer(TeamBuildSettings teamBuildSettings, IAnalysisPropertyProvider sonarProperties,
-            IEnumerable<SonarRule> activeRules, IEnumerable<SonarRule> inactiveRules, string language);
+        AnalyzerSettings SetupAnalyzer(TeamBuildSettings teamBuildSettings, IAnalysisPropertyProvider sonarProperties, IEnumerable<SonarRule> rules, string language);
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarQubeServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarQubeServer.cs
@@ -30,6 +30,11 @@ namespace SonarScanner.MSBuild.PreProcessor
     /// </summary>
     public interface ISonarQubeServer
     {
+        /// <summary>
+        /// Retrieves rules from the quality profile with the given ID, including their parameters and template keys.
+        /// </summary>
+        /// <param name="qProfile">Quality profile id.</param>
+        /// <returns>List of all rules</returns>
         Task<IList<SonarRule>> GetRules(string qProfile);
 
         /// <summary>

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarQubeServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarQubeServer.cs
@@ -30,9 +30,7 @@ namespace SonarScanner.MSBuild.PreProcessor
     /// </summary>
     public interface ISonarQubeServer
     {
-        Task<IList<SonarRule>> GetInactiveRules(string qprofile, string language);
-
-        Task<IList<SonarRule>> GetActiveRules(string qprofile);
+        Task<IList<SonarRule>> GetRules(string qProfile);
 
         /// <summary>
         /// Get all keys of all available languages

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -280,29 +280,11 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fetching active rules for quality profile &apos;{0}&apos; from {1}....
-        /// </summary>
-        internal static string MSG_FetchingActiveRules {
-            get {
-                return ResourceManager.GetString("MSG_FetchingActiveRules", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Fetching analysis configuration settings....
         /// </summary>
         internal static string MSG_FetchingAnalysisConfiguration {
             get {
                 return ResourceManager.GetString("MSG_FetchingAnalysisConfiguration", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Fetching rules not active in quality profile &apos;{0}&apos; for language &apos;{1}&apos; from {2}....
-        /// </summary>
-        internal static string MSG_FetchingInactiveRules {
-            get {
-                return ResourceManager.GetString("MSG_FetchingInactiveRules", resourceCulture);
             }
         }
         
@@ -321,6 +303,15 @@ namespace SonarScanner.MSBuild.PreProcessor {
         internal static string MSG_FetchingQualityProfile {
             get {
                 return ResourceManager.GetString("MSG_FetchingQualityProfile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fetching rules for quality profile &apos;{0}&apos; from {1}....
+        /// </summary>
+        internal static string MSG_FetchingRules {
+            get {
+                return ResourceManager.GetString("MSG_FetchingRules", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -192,20 +192,17 @@ Use '/?' or '/h' to see the help message.</value>
   <data name="MSG_ExtractingFiles" xml:space="preserve">
     <value>Extracting files to {0}...</value>
   </data>
-  <data name="MSG_FetchingActiveRules" xml:space="preserve">
-    <value>Fetching active rules for quality profile '{0}' from {1}...</value>
-  </data>
   <data name="MSG_FetchingAnalysisConfiguration" xml:space="preserve">
     <value>Fetching analysis configuration settings...</value>
-  </data>
-  <data name="MSG_FetchingInactiveRules" xml:space="preserve">
-    <value>Fetching rules not active in quality profile '{0}' for language '{1}' from {2}...</value>
   </data>
   <data name="MSG_FetchingProjectProperties" xml:space="preserve">
     <value>Fetching properties for project '{0}' from {1}...</value>
   </data>
   <data name="MSG_FetchingQualityProfile" xml:space="preserve">
     <value>Fetching quality profile for project '{0}' from {1}...</value>
+  </data>
+  <data name="MSG_FetchingRules" xml:space="preserve">
+    <value>Fetching rules for quality profile '{0}' from {1}...</value>
   </data>
   <data name="MSG_Forbidden_BrowsePermission" xml:space="preserve">
     <value>To analyze private projects make sure the scanner user has 'Browse' permission.</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/ActiveRule.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/ActiveRule.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -53,11 +53,12 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn.Model
             IsActive = isActive;
         }
 
-        public SonarRule(string repoKey, string ruleKey, string internalKey, bool isActive)
+        public SonarRule(string repoKey, string ruleKey, string internalKey, string templateKey, bool isActive)
         {
             RepoKey = repoKey;
             RuleKey = ruleKey;
             InternalKey = internalKey;
+            TemplateKey = templateKey;
             IsActive = isActive;
         }
     }

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
@@ -37,12 +37,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
         private const string ROSLYN_REPOSITORY_PREFIX = "roslyn.";
 
         public const string CSharpLanguage = "cs";
-        public const string CSharpPluginKey = "csharp";
-        public const string CSharpRepositoryKey = "csharp";
-
         public const string VBNetLanguage = "vbnet";
-        public const string VBNetPluginKey = "vbnet";
-        public const string VBNetRepositoryKey = "vbnet";
 
         private readonly IAnalyzerInstaller analyzerInstaller;
         private readonly ILogger logger;

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
@@ -138,7 +138,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
 
             foreach (var partialRepoKey in partialRepoKeys)
             {
-                if (!this.sonarProperties.TryGetValue($"{partialRepoKey}.pluginKey", out var pluginkey) ||
+                if (!this.sonarProperties.TryGetValue($"{partialRepoKey}.pluginKey", out var pluginKey) ||
                     !this.sonarProperties.TryGetValue($"{partialRepoKey}.pluginVersion", out var pluginVersion) ||
                     !this.sonarProperties.TryGetValue($"{partialRepoKey}.staticResourceName", out var staticResourceName))
                 {
@@ -149,7 +149,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
                     continue;
                 }
 
-                plugins.Add(new Plugin(pluginkey, pluginVersion, staticResourceName));
+                plugins.Add(new Plugin(pluginKey, pluginVersion, staticResourceName));
             }
 
             if (plugins.Count == 0)

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynRuleSetGenerator.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynRuleSetGenerator.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -43,10 +43,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn.Model
 
         public RuleAction ActiveRuleAction
         {
-            get
-            {
-                return activeRuleAction;
-            }
+            get => activeRuleAction;
             set
             {
                 activeRuleAction = value;
@@ -59,22 +56,12 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn.Model
         /// The ruleset can be empty if there are no active rules belonging to the repo keys "vbnet", "csharpsquid" or "roslyn.*".
         /// </summary>
         /// <exception cref="AnalysisException">if required properties that should be associated with the repo key are missing.</exception>
-        public RuleSet Generate(string language, IEnumerable<SonarRule> activeRules, IEnumerable<SonarRule> inactiveRules)
+        public RuleSet Generate(string language, IEnumerable<SonarRule> rules)
         {
-            if (activeRules == null)
-            {
-                throw new ArgumentNullException(nameof(activeRules));
-            }
-            if (inactiveRules == null)
-            {
-                throw new ArgumentNullException(nameof(inactiveRules));
-            }
-            if (language == null)
-            {
-                throw new ArgumentNullException(nameof(language));
-            }
+            _ = language ?? throw new ArgumentNullException(nameof(language));
+            _ = rules ?? throw new ArgumentNullException(nameof(rules));
 
-            var rulesElements = activeRules.Concat(inactiveRules)
+            var rulesElements = rules
                 .GroupBy(
                     rule => GetPartialRepoKey(rule, language),
                     rule => rule)

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
@@ -96,63 +96,22 @@ namespace SonarScanner.MSBuild.PreProcessor
         }
 
         /// <summary>
-        /// Retrieves rule keys of rules having a given language and that are not activated in a given profile.
-        ///
+        /// Retrieves rules from the quality profile with the given ID, including their parameters and template keys.
         /// </summary>
-        /// <param name="qprofile">Quality profile key.</param>
-        /// <param name="language">Rule Language.</param>
-        /// <returns>Non-activated rule keys, including repo. Example: csharpsquid:S1100</returns>
-        public async Task<IList<SonarRule>> GetInactiveRules(string qprofile, string language)
-        {
-            var fetched = 0;
-            var total = 0;
-            var ruleList = new List<SonarRule>();
-
-
-            for (int page = 1; page <= 20; page++)
-            {
-                var ws = GetUrl("/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params&ps=500&activation=false&qprofile={0}&p={1}&languages={2}", qprofile, page.ToString(), language);
-                this.logger.LogDebug(Resources.MSG_FetchingInactiveRules, qprofile, language, ws);
-
-                ruleList.AddRange(await DoLogExceptions(async () =>
-                {
-                    var contents = await this.downloader.Download(ws);
-                    var json = JObject.Parse(contents);
-                    total = json["total"].ToObject<int>();
-                    fetched += json["ps"].ToObject<int>();
-                    var rules = json["rules"].Children<JObject>();
-
-                    return rules.Select(r => new SonarRule(r["repo"].ToString(), ParseRuleKey(r["key"].ToString()), false));
-                }, ws));
-
-                if (fetched >= total)
-                {
-                    break;
-                }
-
-            }
-
-            return ruleList;
-        }
-
-        /// <summary>
-        /// Retrieves active rules from the quality profile with the given ID, including their parameters and template keys.
-        ///
-        /// </summary>
-        /// <param name="qprofile">Quality profile id.</param>
+        /// <param name="qProfile">Quality profile id.</param>
         /// <returns>List of active rules</returns>
-        public async Task<IList<SonarRule>> GetActiveRules(string qprofile)
+        public async Task<IList<SonarRule>> GetRules(string qProfile)
         {
             var fetched = 0;
             var total = 0;
-            var activeRuleList = new List<SonarRule>();
-
-            for (int page = 1; page <= 20; page++)
+            var page = 1;
+            var allRules = new List<SonarRule>();
+            while ((page == 1 && total == 0) || fetched < total)
             {
-                var ws = GetUrl("/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&activation=true&qprofile={0}&p={1}", qprofile, page.ToString());
-                this.logger.LogDebug(Resources.MSG_FetchingActiveRules, qprofile, ws);
+                var ws = GetUrl("/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile={0}&p={1}", qProfile, page.ToString());
+                this.logger.LogDebug(Resources.MSG_FetchingRules, qProfile, ws);
 
-                activeRuleList.AddRange(await DoLogExceptions(async () =>
+                allRules.AddRange(await DoLogExceptions(async () =>
                 {
                     var contents = await this.downloader.Download(ws);
                     var json = JObject.Parse(contents);
@@ -161,19 +120,12 @@ namespace SonarScanner.MSBuild.PreProcessor
                     var rules = json["rules"].Children<JObject>();
                     var actives = json["actives"];
 
-                    return rules.Select(r =>
-                    {
-                        return FilterRule(r, actives);
-                    });
+                    return rules.Select(x => CreateRule(x, actives));
                 }, ws));
 
-                if (fetched >= total)
-                {
-                    break;
-                }
+                page++;
             }
-
-            return activeRuleList;
+            return allRules;
         }
 
         private async Task<bool> IsSonarCloud()
@@ -233,37 +185,19 @@ namespace SonarScanner.MSBuild.PreProcessor
             }
         }
 
-        private static SonarRule FilterRule(JObject r, JToken actives)
+        private static SonarRule CreateRule(JObject r, JToken actives)
         {
-            var activeRulesForRuleKey = actives.Value<JArray>(r["key"].ToString());
-
-            if (activeRulesForRuleKey == null ||
-                activeRulesForRuleKey.Count != 1)
+            var active = actives.Value<JArray>(r["key"].ToString()).FirstOrDefault();
+            var rule = new SonarRule(r["repo"].ToString(), ParseRuleKey(r["key"].ToString()), r["internalKey"]?.ToString(), r["templateKey"]?.ToString(), active != null);
+            if (active != null)
             {
-                // Because of the parameters we use we expect to have only actives rules. So rules and actives
-                // should both contain the same number of elements (i.e. the same rules).
-                throw new JsonException($"Malformed json response, \"actives\" field should contain rule '{r["key"].ToString()}'");
+                rule.Parameters = active["params"].Children<JObject>().ToDictionary(pair => pair["key"].ToString(), pair => pair["value"].ToString());
+                if (rule.Parameters.ContainsKey("CheckId"))
+                {
+                    rule.RuleKey = rule.Parameters["CheckId"];
+                }
             }
-
-            var activeRule = new SonarRule(r["repo"].ToString(), ParseRuleKey(r["key"].ToString()), true);
-            if (r["internalKey"] != null)
-            {
-                activeRule.InternalKey = r["internalKey"].ToString();
-            }
-            if (r["templateKey"] != null)
-            {
-                activeRule.TemplateKey = r["templateKey"].ToString();
-            }
-
-            var activeRuleParams = activeRulesForRuleKey[0]["params"].Children<JObject>();
-            activeRule.Parameters = activeRuleParams.ToDictionary(pair => pair["key"].ToString(), pair => pair["value"].ToString());
-
-            if (activeRule.Parameters.ContainsKey("CheckId"))
-            {
-                activeRule.RuleKey = activeRule.Parameters["CheckId"];
-            }
-
-            return activeRule;
+            return rule;
         }
 
         /// <summary>

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
@@ -102,11 +102,12 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// <returns>List of active rules</returns>
         public async Task<IList<SonarRule>> GetRules(string qProfile)
         {
+            const int limit = 10000;
             var fetched = 0;
-            var total = 0;
+            var total = 1;  // Initial value to enter the loop
             var page = 1;
             var allRules = new List<SonarRule>();
-            while ((page == 1 && total == 0) || fetched < total)
+            while (fetched < total && fetched < limit)
             {
                 var ws = GetUrl("/api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile={0}&p={1}", qProfile, page.ToString());
                 this.logger.LogDebug(Resources.MSG_FetchingRules, qProfile, ws);
@@ -187,7 +188,7 @@ namespace SonarScanner.MSBuild.PreProcessor
 
         private static SonarRule CreateRule(JObject r, JToken actives)
         {
-            var active = actives.Value<JArray>(r["key"].ToString()).FirstOrDefault();
+            var active = actives?.Value<JArray>(r["key"].ToString())?.FirstOrDefault();
             var rule = new SonarRule(r["repo"].ToString(), ParseRuleKey(r["key"].ToString()), r["internalKey"]?.ToString(), r["templateKey"]?.ToString(), active != null);
             if (active != null)
             {

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
@@ -95,11 +95,6 @@ namespace SonarScanner.MSBuild.PreProcessor
             return new Tuple<bool, string>(qualityProfileKey != null, qualityProfileKey);
         }
 
-        /// <summary>
-        /// Retrieves rules from the quality profile with the given ID, including their parameters and template keys.
-        /// </summary>
-        /// <param name="qProfile">Quality profile id.</param>
-        /// <returns>List of active rules</returns>
         public async Task<IList<SonarRule>> GetRules(string qProfile)
         {
             const int limit = 10000;

--- a/src/SonarScanner.MSBuild.PreProcessor/TeamBuildPreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/TeamBuildPreProcessor.cs
@@ -205,15 +205,12 @@ namespace SonarScanner.MSBuild.PreProcessor
                         continue;
                     }
 
-                    // Fetch rules (active and not active)
-                    var activeRules = await server.GetActiveRules(qualityProfile.Item2);
-
-                    if (!activeRules.Any())
+                    // Fetch rules
+                    var rules = await server.GetRules(qualityProfile.Item2);
+                    if (!rules.Any(x => x.IsActive))
                     {
                         this.logger.LogDebug(Resources.RAP_NoActiveRules, plugin.Language);
                     }
-
-                    var inactiveRules = await server.GetInactiveRules(qualityProfile.Item2, plugin.Language);
 
                     // Generate Roslyn analyzers settings and rulesets
                     var analyzerProvider = this.factory.CreateRoslynAnalyzerProvider();
@@ -225,7 +222,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                     // See bug 699: https://github.com/SonarSource/sonar-scanner-msbuild/issues/699
                     var serverProperties = new ListPropertiesProvider(argumentsAndRuleSets.ServerSettings);
                     var allProperties = new AggregatePropertiesProvider(args.AggregateProperties, serverProperties);
-                    var analyzer = analyzerProvider.SetupAnalyzer(settings, allProperties, activeRules, inactiveRules, plugin.Language);
+                    var analyzer = analyzerProvider.SetupAnalyzer(settings, allProperties, rules, plugin.Language);
 
                     if (analyzer != null)
                     {


### PR DESCRIPTION
This is preparation for #980

Old state:
* Load active rules.
* Load inactive rules (second request to the server API).
* Propagate two sets of rules
* Merge the lists and process it.

New state:
* Load all rules. 
* Propagate single set.
* Process it.