### PR TITLE
Do not analyze test code for SQ<=8.8

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.UnitTests/SonarProductTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.UnitTests/SonarProductTests.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SonarScanner.MSBuild.Common.UnitTests
+{
+    [TestClass]
+    public class SonarProductTests
+    {
+        [DataTestMethod]
+        [DataRow(null, "SonarQube")]
+        [DataRow("https://localhost:9000", "SonarQube")]
+        [DataRow("https://next.sonarqube.com", "SonarQube")]
+        [DataRow("sonarcloud.io", "SonarCloud")]
+        [DataRow("https://sonarcloud.io", "SonarCloud")]
+        [DataRow("https://SonarCloud.io", "SonarCloud")]
+        [DataRow("https://SONARCLOUD.IO.custom.dns.proxy", "SonarCloud")]
+        [DataRow("https://sonarcloud.custom.dns.proxy", "SonarQube")]
+        public void GetSonarProductToLog(string host, string expectedName) =>
+            SonarProduct.GetSonarProductToLog(host).Should().Be(expectedName);
+
+        [DataTestMethod]
+        [DataRow(true, "https://sonarcloud.io", "8.0")]
+        [DataRow(true, "https://SonarCloud.io", "8.0")]
+        [DataRow(true, "https://SONARCLOUD.IO.custom.dns.proxy", "8.0")]
+        [DataRow(true, null, "8.0")]
+        [DataRow(true, null, "8.0.0.18955")]
+        [DataRow(true, null, "8.0.1")]
+        [DataRow(false, "https://localhost:9000", "6.7")]
+        [DataRow(false, "https://localhost:9000", "7.9")]
+        [DataRow(false, null, "7.9")]
+        [DataRow(false, null, "8.0.0.29455", DisplayName = "SQ 8.0 build version")]
+        [DataRow(false, null, "9.0")]
+        [DataRow(false, null, "10.0")]
+        public void IsSonarCloud(bool expected, string host, string version) =>
+            SonarProduct.IsSonarCloud(host, new Version(version)).Should().Be(expected);
+    }
+}

--- a/Tests/SonarScanner.MSBuild.Common.UnitTests/SonarProductTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.UnitTests/SonarProductTests.cs
@@ -46,12 +46,15 @@ namespace SonarScanner.MSBuild.Common.UnitTests
         [DataRow(true, null, "8.0")]
         [DataRow(true, null, "8.0.0.18955")]
         [DataRow(true, null, "8.0.1")]
+        [DataRow(true, "https://sonarcloud.io", "8.0.0.29455", DisplayName = "SC with same build as SQ 8.0")]
+        [DataRow(false, "https://something.io", "8.0.0.29455", DisplayName = "SQ 8.0 build version")]
         [DataRow(false, "https://localhost:9000", "6.7")]
         [DataRow(false, "https://localhost:9000", "7.9")]
         [DataRow(false, null, "7.9")]
-        [DataRow(false, null, "8.0.0.29455", DisplayName = "SQ 8.0 build version")]
         [DataRow(false, null, "9.0")]
         [DataRow(false, null, "10.0")]
+        [DataRow(false, "https://sonarcloud.io", "7.0")]    // SC is defined as "Version 8.0"
+        [DataRow(false, "https://sonarcloud.io", "9.0")]    // SC is defined as "Version 8.0"
         public void IsSonarCloud(bool expected, string host, string version) =>
             SonarProduct.IsSonarCloud(host, new Version(version)).Should().Be(expected);
     }

--- a/Tests/SonarScanner.MSBuild.Common.UnitTests/SonarScanner.MSBuild.Common.UnitTests.csproj
+++ b/Tests/SonarScanner.MSBuild.Common.UnitTests/SonarScanner.MSBuild.Common.UnitTests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Infrastructure\OutputRecorder.cs" />
     <Compile Include="MsBuildPathSettingsTests.cs" />
     <Compile Include="ProcessRunnerTests.cs" />
+    <Compile Include="SonarProductTests.cs" />
     <Compile Include="ProjectInfoTests.cs" />
     <Compile Include="ProjectInfo\ProjectInfoExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -707,7 +707,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
             var config = new AnalysisConfig
             {
                 SonarQubeHostUrl = "http://sonarqube.com",
-                SonarQubeVersion = "7.3", // legacy behaviour i.e. overwrite existing analyzer settings
+                SonarQubeVersion = "8.9", // Latest behavior, test code is analyzed by default.
                 LocalSettings = new AnalysisProperties
                 {
                     new Property { Id = "sonar.dotnet.excludeTestProjects", Value = excludeTestProject }
@@ -744,7 +744,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
                     }
             };
 
-            // Create the project
+            // Create the project. 'sonar.cs.roslyn.ignoreIssues' is 'true' by default. Additional analyzers will be removed.
             var projectSnippet = $@"
 <PropertyGroup>
     <Language>{msBuildLanguage}</Language>

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -54,7 +54,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
         public void Settings_ValidSetup_ForAnalyzedProject(string msBuildLanguage, bool isTestProject, string excludeTestProjects)
         {
             // Arrange and Act
-            var result = Execute_Settings_ValidSetup(isTestProject, msBuildLanguage, excludeTestProjects);
+            var result = Execute_Settings_ValidSetup(msBuildLanguage, isTestProject, excludeTestProjects);
 
             // Assert
             AssertExpectedResolvedRuleset(result, $@"d:\{msBuildLanguage}-normal.ruleset");
@@ -76,7 +76,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
         public void Settings_ValidSetup_ForExcludedTestProject(string msBuildLanguage)
         {
             // Arrange and Act
-            var result = Execute_Settings_ValidSetup(true, msBuildLanguage, "true");
+            var result = Execute_Settings_ValidSetup(msBuildLanguage, true, "true");
 
             // Assert
             AssertExpectedResolvedRuleset(result, $@"d:\{msBuildLanguage}-deactivated.ruleset");
@@ -701,7 +701,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
 
         #region Setup
 
-        private BuildLog Execute_Settings_ValidSetup(bool isTestProject, string msBuildLanguage, string excludeTestProject)
+        private BuildLog Execute_Settings_ValidSetup(string msBuildLanguage, bool isTestProject, string excludeTestProject)
         {
             // Create a valid config file containing analyzer settings for both VB and C#
             var config = new AnalysisConfig

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
@@ -185,7 +185,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         }
 
         [TestMethod]
-        public void ConfigExists_NewBehaviour_SettingsMerged()
+        public void ConfigExists_SettingsMerged()
         {
             // Expecting both the additional files and the analyzers to be merged
 
@@ -338,7 +338,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         }
 
         [TestMethod]
-        public void ConfigExists_ForTestProject_WhenUnknownLanguage_NewBehaviour_SonarAnalyzerSettingsUsed()
+        public void ConfigExists_ForTestProject_WhenUnknownLanguage_SonarAnalyzerSettingsUsed()
         {
             // Arrange and Act
             var executedTask = Execute_ConfigExists("7.4", "unknownLang", true, null);
@@ -359,7 +359,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
                 SonarQubeHostUrl = "https://localhost:9000",
                 ServerSettings = new AnalysisProperties
                 {
-                    // Server settings should be ignored
+                    // Server settings should be ignored. "true" value should break existing tests.
                     new Property { Id = "sonar.cs.roslyn.ignoreIssues", Value = "true" },
                     new Property { Id = "sonar.vbnet.roslyn.ignoreIssues", Value = "true" },
                     // Server settings should be ignored - it should never come from the server

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
@@ -356,7 +356,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
             var config = new AnalysisConfig
             {
                 SonarQubeVersion = sonarQubeVersion,
-                SonarQubeHostUrl = "https://localhost:9000",
+                SonarQubeHostUrl = "https://localhost:9000", // This will be classified as SonarCloud with proper sonarQubeVersion
                 ServerSettings = new AnalysisProperties
                 {
                     // Server settings should be ignored. "true" value should break existing tests.

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
@@ -290,12 +290,16 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         }
 
         [DataTestMethod]
-        [DataRow("7.3", "cs", @"c:\csharp-normal.ruleset", /* not set */ null, DisplayName = "Legacy CS")]
-        [DataRow("7.4", "cs", @"c:\csharp-normal.ruleset", "false")]
-        [DataRow("7.4", "cs", @"c:\csharp-normal.ruleset", "FALSE")]
-        [DataRow("7.4", "cs", @"c:\csharp-normal.ruleset", "UnexpectedParamValue")]
-        [DataRow("7.3", "vbnet", @"c:\vbnet-normal.ruleset", /* not set */ null, DisplayName = "Legacy VB")]
-        [DataRow("7.4", "vbnet", @"c:\vbnet-normal.ruleset", /* not set */ null)]
+        [DataRow("8.0.0.18955", "cs", @"c:\csharp-normal.ruleset", /* not set */ null, DisplayName = "SonarCloud build version CS")]
+        [DataRow("8.9", "cs", @"c:\csharp-normal.ruleset", /* not set */ null)]
+        [DataRow("8.9", "cs", @"c:\csharp-normal.ruleset", "false")]
+        [DataRow("9.0", "cs", @"c:\csharp-normal.ruleset", "FALSE")]
+        [DataRow("10.0", "cs", @"c:\csharp-normal.ruleset", "UnexpectedParamValue")]
+        [DataRow("8.0.0.18955", "vbnet", @"c:\vbnet-normal.ruleset", /* not set */ null, DisplayName = "SonarCloud build version VB")]
+        [DataRow("8.9", "vbnet", @"c:\vbnet-normal.ruleset", /* not set */ null)]
+        [DataRow("8.9", "vbnet", @"c:\vbnet-normal.ruleset", "false")]
+        [DataRow("9.0", "vbnet", @"c:\vbnet-normal.ruleset", "FALSE")]
+        [DataRow("10.0", "vbnet", @"c:\vbnet-normal.ruleset", "UnexpectedParamValue")]
         public void ConfigExists_ForTestProject_WhenAnalyzed_SonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string expectedRuleset, string excludeTestProject)
         {
             // Arrange and Act
@@ -309,10 +313,19 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         }
 
         [DataTestMethod]
-        [DataRow("7.3", "cs", @"c:\csharp-deactivated.ruleset", "true", DisplayName = "Legacy CS")]
-        [DataRow("7.4", "cs", @"c:\csharp-deactivated.ruleset", "TRUE")]
-        [DataRow("7.3", "vbnet", @"c:\vbnet-deactivated.ruleset", "True", DisplayName = "Legacy VB")]
-        [DataRow("7.4", "vbnet", @"c:\vbnet-deactivated.ruleset", "tRUE")]
+        [DataRow("7.3", "cs", @"c:\csharp-deactivated.ruleset", /* not set */ null, DisplayName = "Legacy CS")]
+        [DataRow("7.4", "cs", @"c:\csharp-deactivated.ruleset", /* not set */ null, DisplayName = "SQ 7.4 - test projects are not analyzed CS")]
+        [DataRow("8.0.0.29455", "cs", @"c:\csharp-deactivated.ruleset", /* not set */ null, DisplayName = "SonarQube 8.0 build version CS")]
+        [DataRow("8.0.0.18955", "cs", @"c:\csharp-deactivated.ruleset", "true", DisplayName = "SonarCloud build version - needs exclustion parameter CS")]
+        [DataRow("8.8", "cs", @"c:\csharp-deactivated.ruleset", /* not set */ null, DisplayName = "SQ 8.8 - test projects are not analyzed CS")]
+        [DataRow("8.9", "cs", @"c:\csharp-deactivated.ruleset", "true", DisplayName = "SQ 8.9 - needs exclustion parameter CS")]
+        [DataRow("9.0", "cs", @"c:\csharp-deactivated.ruleset", "TRUE", DisplayName = "SQ 9.0 - needs exclustion parameter CS")]
+        [DataRow("10.0", "cs", @"c:\csharp-deactivated.ruleset", "tRUE", DisplayName = "SQ 10.0 - needs exclustion parameter CS")]
+        [DataRow("7.3", "vbnet", @"c:\vbnet-deactivated.ruleset", /* not set */ null, DisplayName = "Legacy VB")]
+        [DataRow("7.4", "vbnet", @"c:\vbnet-deactivated.ruleset", /* not set */ null, DisplayName = "SQ 7.4 - test projects are not analyzed VB")]
+        [DataRow("8.0.0.18955", "vbnet", @"c:\vbnet-deactivated.ruleset", "true", DisplayName = "SonarCloud build version - needs exclustion parameter CS")]
+        [DataRow("8.8", "vbnet", @"c:\vbnet-deactivated.ruleset", /* not set */ null, DisplayName = "SQ 8.8 - test projects are not analyzed VB")]
+        [DataRow("8.9", "vbnet", @"c:\vbnet-deactivated.ruleset", "true", DisplayName = "SQ 8.9 - needs exclustion parameter VB")]
         public void ConfigExists_ForTestProject_WhenExcluded_DeactivatedSonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string expectedRuleset, string excludeTestProject)
         {
             // Arrange and Act
@@ -343,6 +356,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
             var config = new AnalysisConfig
             {
                 SonarQubeVersion = sonarQubeVersion,
+                SonarQubeHostUrl = "https://localhost:9000",
                 ServerSettings = new AnalysisProperties
                 {
                     // Server settings should be ignored

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
@@ -274,65 +274,65 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         }
 
         [DataTestMethod]
-        [DataRow("7.3", "cs", @"c:\csharp-normal.ruleset", DisplayName = "Legacy CS")]
-        [DataRow("7.4", "cs", @"c:\csharp-normal.ruleset")]
-        [DataRow("7.3", "vbnet", @"c:\vbnet-normal.ruleset", DisplayName = "Legacy VB")]
-        [DataRow("7.4", "vbnet", @"c:\vbnet-normal.ruleset")]
+        [DataRow("7.3", "cs", DisplayName = "Legacy CS")]
+        [DataRow("7.4", "cs")]
+        [DataRow("7.3", "vbnet", DisplayName = "Legacy VB")]
+        [DataRow("7.4", "vbnet")]
         public void ConfigExists_ForProductProject_SonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string expectedRuleset)
         {
             // Arrange and Act
             var executedTask = Execute_ConfigExists(sonarQubeVersion, language, false, null);
 
             // Assert
-            executedTask.RuleSetFilePath.Should().Be(expectedRuleset);
+            executedTask.RuleSetFilePath.Should().Be($@"c:\{language}-normal.ruleset");
             executedTask.AnalyzerFilePaths.Should().BeEquivalentTo(@"c:\wintellect1.dll", @"c:\Google.Protobuf.dll", $@"c:\sonar.{language}.dll", @"c:\Google.Protobuf.dll");
             executedTask.AdditionalFilePaths.Should().BeEquivalentTo($@"c:\add1.{language}.txt", @"d:\replaced1.txt", "original.should.be.preserved.for.product.txt");
         }
 
         [DataTestMethod]
-        [DataRow("8.0.0.18955", "cs", @"c:\csharp-normal.ruleset", /* not set */ null, DisplayName = "SonarCloud build version CS")]
-        [DataRow("8.9", "cs", @"c:\csharp-normal.ruleset", /* not set */ null)]
-        [DataRow("8.9", "cs", @"c:\csharp-normal.ruleset", "false")]
-        [DataRow("9.0", "cs", @"c:\csharp-normal.ruleset", "FALSE")]
-        [DataRow("10.0", "cs", @"c:\csharp-normal.ruleset", "UnexpectedParamValue")]
-        [DataRow("8.0.0.18955", "vbnet", @"c:\vbnet-normal.ruleset", /* not set */ null, DisplayName = "SonarCloud build version VB")]
-        [DataRow("8.9", "vbnet", @"c:\vbnet-normal.ruleset", /* not set */ null)]
-        [DataRow("8.9", "vbnet", @"c:\vbnet-normal.ruleset", "false")]
-        [DataRow("9.0", "vbnet", @"c:\vbnet-normal.ruleset", "FALSE")]
-        [DataRow("10.0", "vbnet", @"c:\vbnet-normal.ruleset", "UnexpectedParamValue")]
+        [DataRow("8.0.0.18955", "cs", /* not set */ null, DisplayName = "SonarCloud build version CS")]
+        [DataRow("8.9", "cs", /* not set */ null)]
+        [DataRow("8.9", "cs", "false")]
+        [DataRow("9.0", "cs", "FALSE")]
+        [DataRow("10.0", "cs", "UnexpectedParamValue")]
+        [DataRow("8.0.0.18955", "vbnet", /* not set */ null, DisplayName = "SonarCloud build version VB")]
+        [DataRow("8.9", "vbnet", /* not set */ null)]
+        [DataRow("8.9", "vbnet", "false")]
+        [DataRow("9.0", "vbnet", "FALSE")]
+        [DataRow("10.0", "vbnet", "UnexpectedParamValue")]
         public void ConfigExists_ForTestProject_WhenAnalyzed_SonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string expectedRuleset, string excludeTestProject)
         {
             // Arrange and Act
             var executedTask = Execute_ConfigExists(sonarQubeVersion, language, true, excludeTestProject);
 
             // Assert
-            executedTask.RuleSetFilePath.Should().Be(expectedRuleset);
+            executedTask.RuleSetFilePath.Should().Be($@"c:\{language}-normal.ruleset");
             executedTask.AnalyzerFilePaths.Should().BeEquivalentTo(@"c:\wintellect1.dll", @"c:\Google.Protobuf.dll", $@"c:\sonar.{language}.dll", @"c:\Google.Protobuf.dll");
             // This TestProject is not excluded => additional file "original.should.be.removed.for.excluded.test.txt" should be preserved
             executedTask.AdditionalFilePaths.Should().BeEquivalentTo($@"c:\add1.{language}.txt", @"d:\replaced1.txt", "original.should.be.removed.for.excluded.test.txt");
         }
 
         [DataTestMethod]
-        [DataRow("7.3", "cs", @"c:\csharp-deactivated.ruleset", /* not set */ null, DisplayName = "Legacy CS")]
-        [DataRow("7.4", "cs", @"c:\csharp-deactivated.ruleset", /* not set */ null, DisplayName = "SQ 7.4 - test projects are not analyzed CS")]
-        [DataRow("8.0.0.29455", "cs", @"c:\csharp-deactivated.ruleset", /* not set */ null, DisplayName = "SonarQube 8.0 build version CS")]
-        [DataRow("8.0.0.18955", "cs", @"c:\csharp-deactivated.ruleset", "true", DisplayName = "SonarCloud build version - needs exclustion parameter CS")]
-        [DataRow("8.8", "cs", @"c:\csharp-deactivated.ruleset", /* not set */ null, DisplayName = "SQ 8.8 - test projects are not analyzed CS")]
-        [DataRow("8.9", "cs", @"c:\csharp-deactivated.ruleset", "true", DisplayName = "SQ 8.9 - needs exclustion parameter CS")]
-        [DataRow("9.0", "cs", @"c:\csharp-deactivated.ruleset", "TRUE", DisplayName = "SQ 9.0 - needs exclustion parameter CS")]
-        [DataRow("10.0", "cs", @"c:\csharp-deactivated.ruleset", "tRUE", DisplayName = "SQ 10.0 - needs exclustion parameter CS")]
-        [DataRow("7.3", "vbnet", @"c:\vbnet-deactivated.ruleset", /* not set */ null, DisplayName = "Legacy VB")]
-        [DataRow("7.4", "vbnet", @"c:\vbnet-deactivated.ruleset", /* not set */ null, DisplayName = "SQ 7.4 - test projects are not analyzed VB")]
-        [DataRow("8.0.0.18955", "vbnet", @"c:\vbnet-deactivated.ruleset", "true", DisplayName = "SonarCloud build version - needs exclustion parameter CS")]
-        [DataRow("8.8", "vbnet", @"c:\vbnet-deactivated.ruleset", /* not set */ null, DisplayName = "SQ 8.8 - test projects are not analyzed VB")]
-        [DataRow("8.9", "vbnet", @"c:\vbnet-deactivated.ruleset", "true", DisplayName = "SQ 8.9 - needs exclustion parameter VB")]
+        [DataRow("7.3", "cs", /* not set */ null, DisplayName = "Legacy CS")]
+        [DataRow("7.4", "cs", /* not set */ null, DisplayName = "SQ 7.4 - test projects are not analyzed CS")]
+        [DataRow("8.0.0.29455", "cs", /* not set */ null, DisplayName = "SonarQube 8.0 build version CS")]
+        [DataRow("8.0.0.18955", "cs", "true", DisplayName = "SonarCloud build version - needs exclustion parameter CS")]
+        [DataRow("8.8", "cs", /* not set */ null, DisplayName = "SQ 8.8 - test projects are not analyzed CS")]
+        [DataRow("8.9", "cs", "true", DisplayName = "SQ 8.9 - needs exclustion parameter CS")]
+        [DataRow("9.0", "cs", "TRUE", DisplayName = "SQ 9.0 - needs exclustion parameter CS")]
+        [DataRow("10.0", "cs", "tRUE", DisplayName = "SQ 10.0 - needs exclustion parameter CS")]
+        [DataRow("7.3", "vbnet", /* not set */ null, DisplayName = "Legacy VB")]
+        [DataRow("7.4", "vbnet", /* not set */ null, DisplayName = "SQ 7.4 - test projects are not analyzed VB")]
+        [DataRow("8.0.0.18955", "vbnet", "true", DisplayName = "SonarCloud build version - needs exclustion parameter CS")]
+        [DataRow("8.8", "vbnet", /* not set */ null, DisplayName = "SQ 8.8 - test projects are not analyzed VB")]
+        [DataRow("8.9", "vbnet", "true", DisplayName = "SQ 8.9 - needs exclustion parameter VB")]
         public void ConfigExists_ForTestProject_WhenExcluded_DeactivatedSonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string expectedRuleset, string excludeTestProject)
         {
             // Arrange and Act
             var executedTask = Execute_ConfigExists(sonarQubeVersion, language, true, excludeTestProject);
 
             // Assert
-            executedTask.RuleSetFilePath.Should().Be(expectedRuleset);
+            executedTask.RuleSetFilePath.Should().Be($@"c:\{language}-deactivated.ruleset");
             executedTask.AnalyzerFilePaths.Should().BeEquivalentTo($@"c:\sonar.{language}.dll", @"c:\Google.Protobuf.dll");
             executedTask.AdditionalFilePaths.Should().BeEquivalentTo($@"c:\add1.{language}.txt", @"d:\replaced1.txt");
         }
@@ -376,8 +376,8 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
                     new AnalyzerSettings
                     {
                         Language = "cs",
-                        RulesetPath = @"c:\csharp-normal.ruleset",
-                        DeactivatedRulesetPath = @"c:\csharp-deactivated.ruleset",
+                        RulesetPath = @"c:\cs-normal.ruleset",
+                        DeactivatedRulesetPath = @"c:\cs-deactivated.ruleset",
                         AnalyzerPlugins = new List<AnalyzerPlugin>
                         {
                             new AnalyzerPlugin("roslyn.wintellect", "2.0", "dummy resource", new [] { @"c:\wintellect1.dll", @"c:\wintellect\bar.ps1", @"c:\Google.Protobuf.dll" }),

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
@@ -316,16 +316,16 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         [DataRow("7.3", "cs", /* not set */ null, DisplayName = "Legacy CS")]
         [DataRow("7.4", "cs", /* not set */ null, DisplayName = "SQ 7.4 - test projects are not analyzed CS")]
         [DataRow("8.0.0.29455", "cs", /* not set */ null, DisplayName = "SonarQube 8.0 build version CS")]
-        [DataRow("8.0.0.18955", "cs", "true", DisplayName = "SonarCloud build version - needs exclustion parameter CS")]
+        [DataRow("8.0.0.18955", "cs", "true", DisplayName = "SonarCloud build version - needs exclusion parameter CS")]
         [DataRow("8.8", "cs", /* not set */ null, DisplayName = "SQ 8.8 - test projects are not analyzed CS")]
-        [DataRow("8.9", "cs", "true", DisplayName = "SQ 8.9 - needs exclustion parameter CS")]
-        [DataRow("9.0", "cs", "TRUE", DisplayName = "SQ 9.0 - needs exclustion parameter CS")]
-        [DataRow("10.0", "cs", "tRUE", DisplayName = "SQ 10.0 - needs exclustion parameter CS")]
+        [DataRow("8.9", "cs", "true", DisplayName = "SQ 8.9 - needs exclusion parameter CS")]
+        [DataRow("9.0", "cs", "TRUE", DisplayName = "SQ 9.0 - needs exclusion parameter CS")]
+        [DataRow("10.0", "cs", "tRUE", DisplayName = "SQ 10.0 - needs exclusion parameter CS")]
         [DataRow("7.3", "vbnet", /* not set */ null, DisplayName = "Legacy VB")]
         [DataRow("7.4", "vbnet", /* not set */ null, DisplayName = "SQ 7.4 - test projects are not analyzed VB")]
-        [DataRow("8.0.0.18955", "vbnet", "true", DisplayName = "SonarCloud build version - needs exclustion parameter CS")]
+        [DataRow("8.0.0.18955", "vbnet", "true", DisplayName = "SonarCloud build version - needs exclusion parameter CS")]
         [DataRow("8.8", "vbnet", /* not set */ null, DisplayName = "SQ 8.8 - test projects are not analyzed VB")]
-        [DataRow("8.9", "vbnet", "true", DisplayName = "SQ 8.9 - needs exclustion parameter VB")]
+        [DataRow("8.9", "vbnet", "true", DisplayName = "SQ 8.9 - needs exclusion parameter VB")]
         public void ConfigExists_ForTestProject_WhenExcluded_DeactivatedSonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string excludeTestProject)
         {
             // Arrange and Act
@@ -356,7 +356,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
             var config = new AnalysisConfig
             {
                 SonarQubeVersion = sonarQubeVersion,
-                SonarQubeHostUrl = "https://localhost:9000", // This will be classified as SonarCloud with proper sonarQubeVersion
+                SonarQubeHostUrl = "https://localhost:9000", // If any SQ 8.0 version is passed (other than 8.0.0.29455), this will be classified as SonarCloud
                 ServerSettings = new AnalysisProperties
                 {
                     // Server settings should be ignored. "true" value should break existing tests.

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
@@ -278,7 +278,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         [DataRow("7.4", "cs")]
         [DataRow("7.3", "vbnet", DisplayName = "Legacy VB")]
         [DataRow("7.4", "vbnet")]
-        public void ConfigExists_ForProductProject_SonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string expectedRuleset)
+        public void ConfigExists_ForProductProject_SonarAnalyzerSettingsUsed(string sonarQubeVersion, string language)
         {
             // Arrange and Act
             var executedTask = Execute_ConfigExists(sonarQubeVersion, language, false, null);
@@ -300,7 +300,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         [DataRow("8.9", "vbnet", "false")]
         [DataRow("9.0", "vbnet", "FALSE")]
         [DataRow("10.0", "vbnet", "UnexpectedParamValue")]
-        public void ConfigExists_ForTestProject_WhenAnalyzed_SonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string expectedRuleset, string excludeTestProject)
+        public void ConfigExists_ForTestProject_WhenAnalyzed_SonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string excludeTestProject)
         {
             // Arrange and Act
             var executedTask = Execute_ConfigExists(sonarQubeVersion, language, true, excludeTestProject);
@@ -326,7 +326,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         [DataRow("8.0.0.18955", "vbnet", "true", DisplayName = "SonarCloud build version - needs exclustion parameter CS")]
         [DataRow("8.8", "vbnet", /* not set */ null, DisplayName = "SQ 8.8 - test projects are not analyzed VB")]
         [DataRow("8.9", "vbnet", "true", DisplayName = "SQ 8.9 - needs exclustion parameter VB")]
-        public void ConfigExists_ForTestProject_WhenExcluded_DeactivatedSonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string expectedRuleset, string excludeTestProject)
+        public void ConfigExists_ForTestProject_WhenExcluded_DeactivatedSonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string excludeTestProject)
         {
             // Arrange and Act
             var executedTask = Execute_ConfigExists(sonarQubeVersion, language, true, excludeTestProject);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -223,7 +223,7 @@ public class ScannerMSBuildTest {
 
   @Test
   public void testExcludedAndTest_AnalyzeTestProject() throws Exception {
-    testExcludedAndTest(false, 1);
+    testExcludedAndTest(false, 0); // ToDo: This should fail with SQ 8.9 release. Update expected to 1.
   }
 
   @Test

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -223,7 +223,8 @@ public class ScannerMSBuildTest {
 
   @Test
   public void testExcludedAndTest_AnalyzeTestProject() throws Exception {
-    testExcludedAndTest(false, 0); // ToDo: This should fail with SQ 8.9 release. Update expected to 1.
+    int expectedTestProjectIssues = ORCHESTRATOR.getServer().version().isGreaterThan(8, 8) ? 1 : 0;
+    testExcludedAndTest(false, expectedTestProjectIssues);
   }
 
   @Test

--- a/src/SonarScanner.MSBuild.Common/SonarProduct.cs
+++ b/src/SonarScanner.MSBuild.Common/SonarProduct.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * SonarScanner for MSBuild
  * Copyright (C) 2016-2021 SonarSource SA
  * mailto:info AT sonarsource DOT com
@@ -18,18 +18,23 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using System;
+
 namespace SonarScanner.MSBuild.Common
 {
     public static class SonarProduct
     {
-        public static string GetSonarProductToLog(string hostNameUrl)
-        {
-            if(hostNameUrl == null)
-            {
-                return "SonarQube";
-            }
+        private static readonly Version SonarQube80 = new Version(8, 0, 0, 29455); // Build number of SQ 8.0
 
-            return hostNameUrl.Contains("sonarcloud.io") ? "SonarCloud" : "SonarQube";
-        }
+        public static string GetSonarProductToLog(string host) =>
+            ContainsSonarCloud(host) ? "SonarCloud" : "SonarQube";
+
+        public static bool IsSonarCloud(string host, Version version) =>
+            version.Major == 8
+            && version.Minor == 0
+            && (version != SonarQube80 || ContainsSonarCloud(host));
+
+        private static bool ContainsSonarCloud(string host) =>
+            host?.IndexOf("sonarcloud.io", StringComparison.OrdinalIgnoreCase) >= 0;
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
@@ -124,16 +124,8 @@ namespace SonarScanner.MSBuild.PreProcessor
             return allRules;
         }
 
-        private async Task<bool> IsSonarCloud()
-        {
-            var version = await GetServerVersion();
-            if (version.CompareTo(new Version(8, 0)) < 0 || version.CompareTo(new Version(8, 1)) >= 0)
-                return false;
-            else
-            {
-                return this.serverUrl.Contains("sonarcloud.io") || version != new Version(8, 0, 0, 29455); //this is the build number of SQ 8.0
-            }
-        }
+        private async Task<bool> IsSonarCloud() =>
+            SonarProduct.IsSonarCloud(this.serverUrl, await GetServerVersion());
 
         public async Task WarnIfSonarQubeVersionIsDeprecated()
         {


### PR DESCRIPTION
Related to #980

Do not analyze test code for SQ<=8.8 to avoid performance regression. 

Old SQ can be used with latest Scanner.
Old SQ will ignore issues raised on a test code.

This is a draft, rebase will be needed once #986 is merged. First `Squash AnalyzeTest` commit doesn't need a review for the same reason.