### PR TITLE
Fix sonar.{langauge}.roslyn.ignoreIssues default value

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/RoslynTargetsTests.cs
@@ -708,6 +708,11 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
             {
                 SonarQubeHostUrl = "http://sonarqube.com",
                 SonarQubeVersion = "8.9", // Latest behavior, test code is analyzed by default.
+                ServerSettings = new AnalysisProperties
+                {
+                    new Property { Id = "sonar.cs.roslyn.ignoreIssues", Value="true" },
+                    new Property { Id = "sonar.vbnet.roslyn.ignoreIssues", Value="true" }
+                },
                 LocalSettings = new AnalysisProperties
                 {
                     new Property { Id = "sonar.dotnet.excludeTestProjects", Value = excludeTestProject }
@@ -744,7 +749,7 @@ namespace SonarScanner.MSBuild.Tasks.IntegrationTests.TargetsTests
                     }
             };
 
-            // Create the project. 'sonar.cs.roslyn.ignoreIssues' is 'true' by default. Additional analyzers will be removed.
+            // Create the project
             var projectSnippet = $@"
 <PropertyGroup>
     <Language>{msBuildLanguage}</Language>

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/GetAnalyzerSettingsTests.cs
@@ -443,11 +443,11 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         [DataTestMethod]
         [DataRow("cs")]
         [DataRow("vbnet")]
-        public void ShouldMerge_Multiples_NewServer_NoSetting_ReturnsFalse(string language)
+        public void ShouldMerge_Multiples_NewServer_NoSetting_ReturnsTrue(string language)
         {
-            // Should default to false i.e. override, don't merge
-            var logger = CheckShouldMerge("7.4.0.0", language, ignoreExternalIssues: null /* not set */, expected: false);
-            logger.AssertDebugLogged($"sonar.{language}.roslyn.ignoreIssues=true");
+            // ignoreIssues should default to false => we want to process Roslyn issues => should merge
+            var logger = CheckShouldMerge("7.4.0.0", language, ignoreExternalIssues: null /* not set */, expected: true);
+            logger.AssertDebugLogged($"sonar.{language}.roslyn.ignoreIssues=false");
         }
 
         [DataTestMethod]

--- a/src/SonarScanner.MSBuild.Tasks/GetAnalyzerSettings.cs
+++ b/src/SonarScanner.MSBuild.Tasks/GetAnalyzerSettings.cs
@@ -177,7 +177,7 @@ namespace SonarScanner.MSBuild.Tasks
 
             // See https://github.com/SonarSource/sonar-scanner-msbuild/issues/561
             // Legacy behaviour is to overwrite.
-            // The new (SQ 7.4+) behaviour is to merge only if sonar.[LANGUAGE].roslyn.ignoreIssues is true.
+            // The new (SQ 7.4+) behaviour is to merge only if sonar.[LANGUAGE].roslyn.ignoreIssues is false.
             var serverVersion = config?.FindServerVersion();
             if (serverVersion == null || serverVersion < new Version("7.4"))
             {
@@ -186,7 +186,7 @@ namespace SonarScanner.MSBuild.Tasks
             }
 
             var settingName = $"sonar.{language}.roslyn.ignoreIssues";
-            var settingInFile = config.GetSettingOrDefault(settingName, includeServerSettings: true, defaultValue: "true");
+            var settingInFile = config.GetSettingOrDefault(settingName, includeServerSettings: true, defaultValue: "false");
 
             if (bool.TryParse(settingInFile, out var ignoreExternalRoslynIssues))
             {


### PR DESCRIPTION
Fixes issue found here https://github.com/SonarSource/sonar-scanner-msbuild/pull/989#discussion_r608510247

`ignoreIssues` should default to `false` according to [docs](https://docs.sonarqube.org/latest/analysis/external-issues/)

It was working before, because server provides the value explicitly.