### PR TITLE
Fix assembly name parsing in IsTestByReference

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/SonarQubeCategoriseProjectTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTests/TargetsTests/SonarQubeCategoriseProjectTests.cs
@@ -503,7 +503,7 @@ namespace SonarScanner.Integration.Tasks.IntegrationTests.TargetsTests
         private static void AssertIsTestProject(BuildLog log)
         {
             log.GetPropertyAsBoolean(TargetProperties.SonarQubeTestProject).Should().BeTrue();
-            log.MessageLog.Should().Contain("categorized as TEST project (test code). This MSBuild project will not be analyzed.\n");
+            log.MessageLog.Should().Contain("categorized as TEST project (test code).\n");
         }
 
         private static void AssertIsNotTestProject(BuildLog log)

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTests/IsTestByReferenceTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTests/IsTestByReferenceTests.cs
@@ -32,6 +32,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         [DataRow("SimpleReference")]
         [DataRow("mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
         [DataRow("mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "StrongNameAndSimple")]
+        [DataRow("@(mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)", "@(StrongNameAndSimple)")]
         public void TestReference_ProductReference_IsNull(params string[] references) =>
             ExecuteAndAssert(references, null, "No test reference was found for the current project.");
 
@@ -44,6 +45,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTests
         [DataTestMethod]
         [DataRow("Microsoft.VisualStudio.TestPlatform.TestFramework")]
         [DataRow("Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL")]
+        [DataRow("@(Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL)")]
         [DataRow("Microsoft.VisualStudio.TestPlatform.TestFramework", "ProductionReference")]
         [DataRow("ProductionReference", "Microsoft.VisualStudio.TestPlatform.TestFramework")]
         public void TestReference_TestReference_IsTest(params string[] references) =>

--- a/src/SonarScanner.MSBuild.Tasks/IsTestByReference.cs
+++ b/src/SonarScanner.MSBuild.Tasks/IsTestByReference.cs
@@ -84,7 +84,7 @@ namespace SonarScanner.MSBuild.Tasks
         {
             try
             {
-                return new AssemblyName(fullName).Name;
+                return new AssemblyName(fullName.Trim('@', '(', ')')).Name;
             }
             catch
             {

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -239,7 +239,7 @@
     <Message Condition="$(tmpSonarIsTestFileByNameResult)=='true'" Importance="normal" Text="Sonar: ($(MSBuildProjectFile)) project is evaluated as a test project based on the project name." />
 
     <Message Importance="normal" Condition="$(SonarQubeTestProject)=='false'" Text="Sonar: ($(MSBuildProjectFile)) categorized as MAIN project (production code)." />
-    <Message Importance="normal" Condition="$(SonarQubeTestProject)=='true'"  Text="Sonar: ($(MSBuildProjectFile)) categorized as TEST project (test code). This MSBuild project will not be analyzed." />
+    <Message Importance="normal" Condition="$(SonarQubeTestProject)=='true'"  Text="Sonar: ($(MSBuildProjectFile)) categorized as TEST project (test code)." />
   </Target>
 
   <!-- **************************************************************************** -->


### PR DESCRIPTION
I saw this issue when playing with our integration tests. We need to parse `@(AssebmlyName)` format as well in the `IsTestByReference` task.

```
Using "IsTestByReference" task from assembly "C:\Projects\sonar-dotnet\analyzers\its\sources\Nancy\src\.sonarqube\bin\SonarScanner.MSBuild.Tasks.dll".
Task "IsTestByReference" (TaskId:35)
  Task Parameter:
      References=
          @(Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
          @(mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
          @(System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
          @(System.ComponentModel.DataAnnotations, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)
          @(System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
          @(System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
          @(System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)
          @(System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089) (TaskId:35)
  Unable to parse assembly name '@(Microsoft.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)' (TaskId:35)
  Unable to parse assembly name '@(mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)' (TaskId:35)
  Unable to parse assembly name '@(System.ComponentModel.Composition, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)' (TaskId:35)
  Unable to parse assembly name '@(System.ComponentModel.DataAnnotations, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35)' (TaskId:35)
  Unable to parse assembly name '@(System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)' (TaskId:35)
  Unable to parse assembly name '@(System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)' (TaskId:35)
  Unable to parse assembly name '@(System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)' (TaskId:35)
  Unable to parse assembly name '@(System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089)' (TaskId:35)
  No test reference was found for the current project. (TaskId:35)
Done executing task "IsTestByReference". (TaskId:35)
```
