### PR TITLE
mTLS with ClientCert Password

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/WebClientDownloaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/WebClientDownloaderTest.cs
@@ -36,16 +36,16 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
             ILogger logger = new TestLogger();
 
             WebClientDownloader downloader;
-            downloader = new WebClientDownloader(null, null, null, null, logger);
+            downloader = new WebClientDownloader(null, null, logger);
             downloader.GetHeader(HttpRequestHeader.Authorization).Should().BeNull();
 
-            downloader = new WebClientDownloader("da39a3ee5e6b4b0d3255bfef95601890afd80709", null, null, null, logger);
+            downloader = new WebClientDownloader("da39a3ee5e6b4b0d3255bfef95601890afd80709", null, logger);
             downloader.GetHeader(HttpRequestHeader.Authorization).Should().Be("Basic ZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOTo=");
 
-            downloader = new WebClientDownloader(null, "password", null, null, logger);
+            downloader = new WebClientDownloader(null, "password", logger);
             downloader.GetHeader(HttpRequestHeader.Authorization).Should().BeNull();
 
-            downloader = new WebClientDownloader("admin", "password", null, null, logger);
+            downloader = new WebClientDownloader("admin", "password", logger);
             downloader.GetHeader(HttpRequestHeader.Authorization).Should().Be("Basic YWRtaW46cGFzc3dvcmQ=");
         }
 
@@ -53,7 +53,7 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
         public void UserAgent()
         {
             // Arrange
-            var downloader = new WebClientDownloader(null, null, null, null, new TestLogger());
+            var downloader = new WebClientDownloader(null, null, new TestLogger());
 
             // Act
             var userAgent = downloader.GetHeader(HttpRequestHeader.UserAgent);
@@ -69,7 +69,7 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
             // Arrange
             var expectedUserAgent = string.Format("ScannerMSBuild/{0}",
                 typeof(WebClientDownloaderTest).Assembly.GetName().Version.ToDisplayString());
-            var downloader = new WebClientDownloader(null, null, null, null, new TestLogger());
+            var downloader = new WebClientDownloader(null, null, new TestLogger());
 
             // Act & Assert
             var userAgent = downloader.GetHeader(HttpRequestHeader.UserAgent);
@@ -92,27 +92,27 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
         [TestMethod]
         public void SemicolonInUsername()
         {
-            Action act = () => new WebClientDownloader("user:name", "", null, null, new TestLogger());
+            Action act = () => new WebClientDownloader("user:name", "", new TestLogger());
             act.Should().ThrowExactly<ArgumentException>().WithMessage("username cannot contain the ':' character due to basic authentication limitations");
         }
 
         [TestMethod]
         public void AccentsInUsername()
         {
-            Action act = () => new WebClientDownloader("héhé", "password", null, null, new TestLogger());
+            Action act = () => new WebClientDownloader("héhé", "password", new TestLogger());
             act.Should().ThrowExactly<ArgumentException>().WithMessage("username and password should contain only ASCII characters due to basic authentication limitations");
         }
 
         [TestMethod]
         public void AccentsInPassword()
         {
-            Action act = () => new WebClientDownloader("username", "héhé", null, null, new TestLogger());
+            Action act = () => new WebClientDownloader("username", "héhé", new TestLogger());
             act.Should().ThrowExactly<ArgumentException>().WithMessage("username and password should contain only ASCII characters due to basic authentication limitations");
         }
         [TestMethod]
         public void UsingClientCert()
         {
-            Action act = () => new WebClientDownloader(null, null, "certtestsonar.pem", "dummypw", new TestLogger());
+            Action act = () => new WebClientDownloader(null, null, new TestLogger(), "certtestsonar.pem", "dummypw");
             act.Should().NotThrow();
         }
     }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/WebClientDownloaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/WebClientDownloaderTest.cs
@@ -36,16 +36,16 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
             ILogger logger = new TestLogger();
 
             WebClientDownloader downloader;
-            downloader = new WebClientDownloader(null, null, null, logger);
+            downloader = new WebClientDownloader(null, null, null, null, logger);
             downloader.GetHeader(HttpRequestHeader.Authorization).Should().BeNull();
 
-            downloader = new WebClientDownloader("da39a3ee5e6b4b0d3255bfef95601890afd80709", null, null, logger);
+            downloader = new WebClientDownloader("da39a3ee5e6b4b0d3255bfef95601890afd80709", null, null, null, logger);
             downloader.GetHeader(HttpRequestHeader.Authorization).Should().Be("Basic ZGEzOWEzZWU1ZTZiNGIwZDMyNTViZmVmOTU2MDE4OTBhZmQ4MDcwOTo=");
 
-            downloader = new WebClientDownloader(null, "password", null, logger);
+            downloader = new WebClientDownloader(null, "password", null, null, logger);
             downloader.GetHeader(HttpRequestHeader.Authorization).Should().BeNull();
 
-            downloader = new WebClientDownloader("admin", "password", null, logger);
+            downloader = new WebClientDownloader("admin", "password", null, null, logger);
             downloader.GetHeader(HttpRequestHeader.Authorization).Should().Be("Basic YWRtaW46cGFzc3dvcmQ=");
         }
 
@@ -53,7 +53,7 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
         public void UserAgent()
         {
             // Arrange
-            var downloader = new WebClientDownloader(null, null, null, new TestLogger());
+            var downloader = new WebClientDownloader(null, null, null, null, new TestLogger());
 
             // Act
             var userAgent = downloader.GetHeader(HttpRequestHeader.UserAgent);
@@ -69,7 +69,7 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
             // Arrange
             var expectedUserAgent = string.Format("ScannerMSBuild/{0}",
                 typeof(WebClientDownloaderTest).Assembly.GetName().Version.ToDisplayString());
-            var downloader = new WebClientDownloader(null, null, null, new TestLogger());
+            var downloader = new WebClientDownloader(null, null, null, null, new TestLogger());
 
             // Act & Assert
             var userAgent = downloader.GetHeader(HttpRequestHeader.UserAgent);
@@ -92,27 +92,27 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
         [TestMethod]
         public void SemicolonInUsername()
         {
-            Action act = () => new WebClientDownloader("user:name", "", null, new TestLogger());
+            Action act = () => new WebClientDownloader("user:name", "", null, null, new TestLogger());
             act.Should().ThrowExactly<ArgumentException>().WithMessage("username cannot contain the ':' character due to basic authentication limitations");
         }
 
         [TestMethod]
         public void AccentsInUsername()
         {
-            Action act = () => new WebClientDownloader("héhé", "password", null, new TestLogger());
+            Action act = () => new WebClientDownloader("héhé", "password", null, null, new TestLogger());
             act.Should().ThrowExactly<ArgumentException>().WithMessage("username and password should contain only ASCII characters due to basic authentication limitations");
         }
 
         [TestMethod]
         public void AccentsInPassword()
         {
-            Action act = () => new WebClientDownloader("username", "héhé", null, new TestLogger());
+            Action act = () => new WebClientDownloader("username", "héhé", null, null, new TestLogger());
             act.Should().ThrowExactly<ArgumentException>().WithMessage("username and password should contain only ASCII characters due to basic authentication limitations");
         }
         [TestMethod]
         public void UsingClientCert()
         {
-            Action act = () => new WebClientDownloader(null, null, "certtestsonar.pem", new TestLogger());
+            Action act = () => new WebClientDownloader(null, null, "certtestsonar.pem", "dummypw", new TestLogger());
             act.Should().NotThrow();
         }
     }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Tests/WebClientDownloaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Tests/WebClientDownloaderTest.cs
@@ -109,6 +109,7 @@ namespace SonarScanner.MSBuild.PreProcessor.UnitTests
             Action act = () => new WebClientDownloader("username", "héhé", new TestLogger());
             act.Should().ThrowExactly<ArgumentException>().WithMessage("username and password should contain only ASCII characters due to basic authentication limitations");
         }
+        
         [TestMethod]
         public void UsingClientCert()
         {

--- a/src/SonarScanner.MSBuild.Common/SonarProperties.cs
+++ b/src/SonarScanner.MSBuild.Common/SonarProperties.cs
@@ -59,5 +59,6 @@ namespace SonarScanner.MSBuild.Common
         public const string VsTestReportsPaths = "sonar.cs.vstest.reportsPaths";
 
         public const string ClientCertPath = "sonar.clientcert.path";
+        public const string ClientCertPassword = "sonar.clientcert.password";
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -59,9 +59,10 @@ namespace SonarScanner.MSBuild.PreProcessor
             var username = args.GetSetting(SonarProperties.SonarUserName, null);
             var password = args.GetSetting(SonarProperties.SonarPassword, null);
             var clientCertPath = args.GetSetting(SonarProperties.ClientCertPath, null);
+            var clientCertPassword = args.GetSetting(SonarProperties.ClientCertPassword, null);
             var hostUrl = args.SonarQubeUrl;
 
-            this.server = new SonarWebService(new WebClientDownloader(username, password, clientCertPath, this.logger), hostUrl, this.logger);
+            this.server = new SonarWebService(new WebClientDownloader(username, password, clientCertPath, clientCertPassword, this.logger), hostUrl, this.logger);
             return this.server;
         }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -62,7 +62,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             var clientCertPassword = args.GetSetting(SonarProperties.ClientCertPassword, null);
             var hostUrl = args.SonarQubeUrl;
 
-            this.server = new SonarWebService(new WebClientDownloader(username, password, clientCertPath, clientCertPassword, this.logger), hostUrl, this.logger);
+            this.server = new SonarWebService(new WebClientDownloader(username, password, this.logger, clientCertPath, clientCertPassword), hostUrl, this.logger);
             return this.server;
         }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
@@ -48,7 +48,7 @@ namespace SonarScanner.MSBuild.PreProcessor
 
             if (this.client == null)
             {
-                if (clientCertPath != null || clientCertPassword != null) // password mandatory, as to use client cert in .jar it cannot be with empty password
+                if (clientCertPath != null && clientCertPassword != null) // password mandatory, as to use client cert in .jar it cannot be with empty password
                 {
                     var clientHandler = new HttpClientHandler();
                     clientHandler.ClientCertificateOptions = ClientCertificateOption.Manual;

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
@@ -35,7 +35,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         private readonly ILogger logger;
         private readonly HttpClient client;
 
-        public WebClientDownloader(string userName, string password, string clientCertPath, string clientCertPassword, ILogger logger)
+        public WebClientDownloader(string userName, string password, ILogger logger, string clientCertPath = null, string clientCertPassword = null)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
@@ -35,7 +35,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         private readonly ILogger logger;
         private readonly HttpClient client;
 
-        public WebClientDownloader(string userName, string password, string clientCertPath, ILogger logger)
+        public WebClientDownloader(string userName, string password, string clientCertPath, string clientCertPassword, ILogger logger)
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
 
@@ -48,11 +48,11 @@ namespace SonarScanner.MSBuild.PreProcessor
 
             if (this.client == null)
             {
-                if (clientCertPath != null)
+                if (clientCertPath != null || clientCertPassword != null) // password mandatory, as to use client cert in .jar it cannot be with empty password
                 {
                     var clientHandler = new HttpClientHandler();
                     clientHandler.ClientCertificateOptions = ClientCertificateOption.Manual;
-                    clientHandler.ClientCertificates.Add(new X509Certificate2(clientCertPath));
+                    clientHandler.ClientCertificates.Add(new X509Certificate2(clientCertPath, clientCertPassword));
                     
                     this.client = new HttpClient(clientHandler);
                 }

--- a/src/SonarScanner.MSBuild/SonarScanner.MSBuild.csproj
+++ b/src/SonarScanner.MSBuild/SonarScanner.MSBuild.csproj
@@ -4,6 +4,9 @@
     <AssemblyName>SonarScanner.MSBuild</AssemblyName>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
+    <WarningLevel>5</WarningLevel>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="SonarQube.Analysis.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Today the current version is developed to allow ClientCert without password, for the "begin" operation it works good. But for the "end" operation, java required that the clientcert be with a password defined. 

This is why in the current version we have to user two client certs, one (with no pw) for "begin" and another (with pw) for "end". This PR will allow to use only one clientcert with pw, for both operations and simplify the usage of mTLS. 