### PR TITLE
Improve uninstall of targets if multiple builds in the same pipeline

### DIFF
--- a/Tests/SonarScanner.MSBuild.PostProcessor.Tests/SonarScanner.MSBuild.PostProcessor.Tests.csproj
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Tests/SonarScanner.MSBuild.PostProcessor.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Infrastructure\MockTeamBuildSettings.cs" />
     <Compile Include="MSBuildPostProcessorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TargetsUninstallerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SonarScanner.MSBuild.Common\SonarScanner.MSBuild.Common.csproj">

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Tests/TargetsUninstallerTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Tests/TargetsUninstallerTests.cs
@@ -1,0 +1,114 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.IO;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarScanner.MSBuild.PostProcessor;
+using TestUtilities;
+
+namespace MSBuild.SonarQube.Internal.PostProcess.Tests
+{
+    [TestClass]
+    public class TargetsUninstallerTests
+    {
+        public TestContext TestContext { get; set; }
+
+        [TestMethod]
+        public void Ctor_Argument_Check()
+        {
+            Action action = () => new TargetsUninstaller(null);
+            action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("logger");
+        }
+
+        [TestMethod]
+        public void DeleteFileWhenPresent()
+        {
+            var context = new UninstallContext(TestContext, true);
+            context.UninstallTargets();
+            File.Exists(context.TargetsFilePath).Should().BeFalse();
+            context.Logger.AssertDebugLogged("Uninstalling target: " + context.TargetsFilePath);
+        }
+
+        [TestMethod]
+        public void Log_MissingFile()
+        {
+            var context = new UninstallContext(TestContext, false);
+            context.UninstallTargets();
+            context.Logger.AssertDebugLogged(context.BinDir + @"\targets\SonarQube.Integration.targets does not exist");
+        }
+
+        [TestMethod]
+        public void Log_OnIOException()
+        {
+            var context = new UninstallContext(TestContext, true);
+            using (var fs = new FileStream(context.TargetsFilePath, FileMode.Open, FileAccess.Read, FileShare.None))    // Lock file
+            {
+                context.UninstallTargets();
+            }
+            File.Exists(context.TargetsFilePath).Should().BeTrue(); // Failed to delete
+            context.Logger.AssertDebugLogged("Could not delete " + context.TargetsFilePath);
+        }
+
+        [TestMethod]
+        public void Log_OnUnauthorizedAccessException()
+        {
+            var context = new UninstallContext(TestContext, true);
+            File.SetAttributes(context.TargetsFilePath, FileAttributes.ReadOnly);   // Make readonly to cause UnauthorizedAccessException
+            try
+            {
+                context.UninstallTargets();
+            }
+            finally
+            {
+                // Restore to prevent UT output from blocking
+                File.SetAttributes(context.TargetsFilePath, FileAttributes.Normal);
+            }
+            File.Exists(context.TargetsFilePath).Should().BeTrue(); // Failed to delete
+            context.Logger.AssertDebugLogged("Could not delete " + context.TargetsFilePath);
+        }
+
+        private class UninstallContext
+        {
+            public readonly TestLogger Logger;
+            public readonly TargetsUninstaller Uninstaller;
+            public readonly string BinDir;
+            public readonly string TargetsFilePath;
+
+            public UninstallContext(TestContext testContext, bool createFile)
+            {
+                BinDir = TestUtils.CreateTestSpecificFolderWithSubPaths(testContext, "bin");
+                Logger = new TestLogger();
+                Uninstaller = new TargetsUninstaller(Logger);
+                if (createFile)
+                {
+                    var targetsDir = Path.Combine(BinDir, "targets");
+                    Directory.CreateDirectory(targetsDir);
+                    TargetsFilePath = TestUtils.CreateEmptyFile(targetsDir, "SonarQube.Integration.targets");
+                }
+            }
+
+            public void UninstallTargets() =>
+                Uninstaller.UninstallTargets(BinDir);
+        }
+
+    }
+}

--- a/src/SonarScanner.MSBuild.PostProcessor/Interfaces/ITargetsUninstaller.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/Interfaces/ITargetsUninstaller.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarScanner.MSBuild.Common;
-
 namespace SonarScanner.MSBuild.PostProcessor
 {
     /// <summary>

--- a/src/SonarScanner.MSBuild.PostProcessor/Interfaces/ITargetsUninstaller.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/Interfaces/ITargetsUninstaller.cs
@@ -23,7 +23,7 @@ using SonarScanner.MSBuild.Common;
 namespace SonarScanner.MSBuild.PostProcessor
 {
     /// <summary>
-    /// Deletes the SonarQube.Integration.targets from .sonarqube directory to prevent consecutive analysis.
+    /// Deletes the SonarQube.Integration.targets from .sonarqube directory to prevent subsequent analysis.
     /// </summary>
     public interface ITargetsUninstaller
     {

--- a/src/SonarScanner.MSBuild.PostProcessor/Interfaces/ITargetsUninstaller.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/Interfaces/ITargetsUninstaller.cs
@@ -1,0 +1,32 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using SonarScanner.MSBuild.Common;
+
+namespace SonarScanner.MSBuild.PostProcessor
+{
+    /// <summary>
+    /// Deletes the SonarQube.Integration.targets from .sonarqube directory to prevent consecutive analysis.
+    /// </summary>
+    public interface ITargetsUninstaller
+    {
+        void UninstallTargets(string binDirectory);
+    }
+}

--- a/src/SonarScanner.MSBuild.PostProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/Resources.Designer.cs
@@ -129,7 +129,7 @@ namespace SonarScanner.MSBuild.PostProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Could not delete {0} from {1}.
+        ///   Looks up a localized string similar to Could not delete {0}.
         /// </summary>
         internal static string MSG_UninstallTargets_CouldNotDelete {
             get {
@@ -138,7 +138,7 @@ namespace SonarScanner.MSBuild.PostProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} does not exist at {1}.
+        ///   Looks up a localized string similar to {0} does not exist.
         /// </summary>
         internal static string MSG_UninstallTargets_NotExists {
             get {
@@ -147,7 +147,7 @@ namespace SonarScanner.MSBuild.PostProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Uninstalling target: {0}\{1}.
+        ///   Looks up a localized string similar to Uninstalling target: {0}.
         /// </summary>
         internal static string MSG_UninstallTargets_Uninstalling {
             get {

--- a/src/SonarScanner.MSBuild.PostProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PostProcessor/Resources.resx
@@ -144,13 +144,13 @@ Expected location: {0}</value>
     <value>Loading the {1} analysis config from {0}</value>
   </data>
   <data name="MSG_UninstallTargets_CouldNotDelete" xml:space="preserve">
-    <value>Could not delete {0} from {1}</value>
+    <value>Could not delete {0}</value>
   </data>
   <data name="MSG_UninstallTargets_NotExists" xml:space="preserve">
-    <value>{0} does not exist at {1}</value>
+    <value>{0} does not exist</value>
   </data>
   <data name="MSG_UninstallTargets_Uninstalling" xml:space="preserve">
-    <value>Uninstalling target: {0}\{1}</value>
+    <value>Uninstalling target: {0}</value>
   </data>
   <data name="Report_CreatingSummaryMarkdown" xml:space="preserve">
     <value>Creating a summary markdown file...</value>

--- a/src/SonarScanner.MSBuild.PostProcessor/TargetsUninstaller.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/TargetsUninstaller.cs
@@ -1,0 +1,62 @@
+﻿/*
+ * SonarScanner for MSBuild
+ * Copyright (C) 2016-2021 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.IO;
+using SonarScanner.MSBuild.Common;
+
+namespace SonarScanner.MSBuild.PostProcessor
+{
+    /// <summary>
+    /// Handles removing targets from well known locations
+    /// </summary>
+    public class TargetsUninstaller : ITargetsUninstaller
+    {
+        private readonly ILogger logger;
+
+        public TargetsUninstaller(ILogger logger) =>
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        public void UninstallTargets(string binDirectory)
+        {
+            var path = Path.Combine(binDirectory, "targets", FileConstants.IntegrationTargetsName);
+            if (File.Exists(path))
+            {
+                try
+                {
+                    logger.LogDebug(Resources.MSG_UninstallTargets_Uninstalling, path);
+                    File.Delete(path);
+                }
+                catch (IOException)
+                {
+                    logger.LogDebug(Resources.MSG_UninstallTargets_CouldNotDelete, path);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    logger.LogDebug(Resources.MSG_UninstallTargets_CouldNotDelete, path);
+                }
+            }
+            else
+            {
+                logger.LogDebug(Resources.MSG_UninstallTargets_NotExists, path);
+            }
+        }
+    }
+}

--- a/src/SonarScanner.MSBuild.PostProcessor/TargetsUninstaller.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/TargetsUninstaller.cs
@@ -25,7 +25,7 @@ using SonarScanner.MSBuild.Common;
 namespace SonarScanner.MSBuild.PostProcessor
 {
     /// <summary>
-    /// Handles removing targets from well known locations
+    /// Handles removing targets from .sonarqube/bin directory
     /// </summary>
     public class TargetsUninstaller : ITargetsUninstaller
     {

--- a/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
+++ b/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
@@ -40,6 +40,7 @@ namespace SonarScanner.MSBuild
             return new MSBuildPostProcessor(
                 new SonarScannerWrapper(logger),
                 logger,
+                new TargetsUninstaller(logger),
                 new TfsProcessorWrapper(logger),
                 new SonarProjectPropertiesValidator());
         }


### PR DESCRIPTION
Fixes #964

Most of the code is a revert of #945 that removed the uninstallation. 
Main changes:
- `TargetsUninstaller` receives `binDirectory` argument
- `TargetsUninstaller` doesn't delete from `MsBuild` folders
- Added tests for `TargetsUninstallerTests`
- Refactored `MSBuildPostProcessorTests.PostProcTestContext.VerifyTargetsUninstaller` because it was validating `invoked not more than once` but didn't validated `invoked at least once`.