### PR TITLE
Improve wording on proxy setup documentation

### DIFF
--- a/sonar-docs/analysis/scan/sonarscanner-for-msbuild.md
+++ b/sonar-docs/analysis/scan/sonarscanner-for-msbuild.md
@@ -303,7 +303,7 @@ SONAR_SCANNER_OPTS = "-Dhttp.proxyHost=yourProxyHost -Dhttp.proxyPort=yourProxyP
 ```
 Where _yourProxyHost_ and _yourProxyPort_ are the hostname and the port of your proxy server. There are additional proxy settings for HTTPS, authentication and exclusions that could be passed to the Java VM. For more information see the following article: https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html.
 
-`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` will be automatically recognized and use to make call against {instance}. The Scanner for .NET makes HTTP calls, independant from the settings above concerning the Java VM, to fetch the Quality Profile and other useful settings for the "end" step.
+You will also need to ensure that the appropriate proxy environment variables used by .NET are set. `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` are all supported, further details can be found [here](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.defaultproxy?view=net-5.0)
 
 ## Known issues
 


### PR DESCRIPTION
Fixes #1078 where the wording around proxy setup didn't make it clear which environment variables needed to be set for the .NET part to work