### PR TITLE
Remove unused package references from UTs

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTest/SonarScanner.MSBuild.Tasks.UnitTest.csproj
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTest/SonarScanner.MSBuild.Tasks.UnitTest.csproj
@@ -13,8 +13,6 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.0.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />


### PR DESCRIPTION
All in-memory project loading UTs were already redesigned in #1077 