### PR TITLE
Add retry mechanism, re-enable IT

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -690,7 +690,6 @@ public class ScannerMSBuildTest {
     runCSharpSharedFileWithOneProjectUsingProjectBaseDir(Path::toString);
   }
 
-  @Ignore("https://github.com/SonarSource/sonar-scanner-msbuild/issues/1122")
   @Test
   public void testProjectTypeDetectionWithWrongCasingReferenceName() throws IOException {
     BuildResult buildResult = runBeginBuildAndEndForStandardProject("DotnetProjectTypeDetection", "TestProjectWrongReferenceCasing");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -66,6 +66,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestUtils {
   final static Logger LOG = LoggerFactory.getLogger(ScannerMSBuildTest.class);
 
+  private static final int MSBUILD_RETRY = 3;
   private static final String NUGET_PATH = "NUGET_PATH";
   private static String token = null;
 
@@ -212,8 +213,18 @@ public class TestUtils {
   }
 
   public static void runMSBuild(Orchestrator orch, Path projectDir, String... arguments) {
-    BuildResult r = runMSBuildQuietly(orch, projectDir, arguments);
-    assertThat(r.isSuccess()).isTrue();
+    int attempts = 0;
+    boolean isSuccess = false;
+    while (!isSuccess && attempts < MSBUILD_RETRY) {
+      BuildResult r = runMSBuildQuietly(orch, projectDir, arguments);
+      isSuccess = r.isSuccess();
+      attempts++;
+      if (!isSuccess)
+      {
+        LOG.warn("Failed to build, will retry " + (MSBUILD_RETRY - 1) + " times");
+      }
+    }
+    assertThat(isSuccess).isTrue();
   }
 
   // Versions of SonarQube and plugins support aliases:


### PR DESCRIPTION
Related to #1122

Another approach would be to disable reusing `msbuild` nodes as suggested here: https://github.com/SonarSource/sonar-scanner-msbuild/issues/1122#issuecomment-981351976