### PR TITLE
Use MSB argument nodeReuse:false in ITs

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -270,6 +270,7 @@ public class TestUtils {
     boolean mustRetry = true;
     while (mustRetry && attempts < MSBUILD_RETRY) {
       status = CommandExecutor.create().execute(Command.create(msBuildPath.toString())
+        .addArguments("-nodeReuse:false")
         .addArguments(arguments)
         .setDirectory(projectDir.toFile()), writer, 60 * 1000);
 


### PR DESCRIPTION
Fixes #1122

Should monitor builds and revert #1183 is `nodeReuse:false` fixes the timeouts.