### PR TITLE
Use coverlet instead of Visual Studio coverage

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/SonarScanner.MSBuild.Common.Test.csproj
+++ b/Tests/SonarScanner.MSBuild.Common.Test/SonarScanner.MSBuild.Common.Test.csproj
@@ -3,6 +3,14 @@
     <TargetFrameworks>net48</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.0.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Test/SonarScanner.MSBuild.PostProcessor.Test.csproj
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Test/SonarScanner.MSBuild.PostProcessor.Test.csproj
@@ -3,6 +3,14 @@
     <TargetFrameworks>net48</TargetFrameworks>
 </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.0.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarScanner.MSBuild.PreProcessor.Test.csproj
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarScanner.MSBuild.PreProcessor.Test.csproj
@@ -3,6 +3,14 @@
     <TargetFrameworks>net48</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.0.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarScanner.MSBuild.Shim.Test.csproj
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarScanner.MSBuild.Shim.Test.csproj
@@ -3,6 +3,14 @@
     <TargetFrameworks>net48</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.0.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/SonarScanner.MSBuild.Tasks.IntegrationTest.csproj
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/SonarScanner.MSBuild.Tasks.IntegrationTest.csproj
@@ -3,6 +3,14 @@
     <TargetFrameworks>net48</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.0.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTest/SonarScanner.MSBuild.Tasks.UnitTest.csproj
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTest/SonarScanner.MSBuild.Tasks.UnitTest.csproj
@@ -3,6 +3,14 @@
     <TargetFrameworks>net48</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.0.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.10.0" />

--- a/Tests/SonarScanner.MSBuild.Test/SonarScanner.MSBuild.Test.csproj
+++ b/Tests/SonarScanner.MSBuild.Test/SonarScanner.MSBuild.Test.csproj
@@ -4,6 +4,14 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.0.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,15 +166,8 @@ stages:
           command: 'build'
           projects: '$(solution)'
           arguments: '/m /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /p:configuration=$(BuildConfiguration) /p:platform="$(BuildPlatform)"'
-      - task: VSTest@2
-        displayName: 'Run Unit Tests'
-        inputs:
-          testSelector: 'testAssemblies'
-          testAssemblyVer2: |
-            **\$(BuildConfiguration)\*\SonarScanner.MsBuild.*Test.dll
-            !**\obj\**
-          searchFolder: '$(System.DefaultWorkingDirectory)'
-          codeCoverageEnabled: true
+      
+      # Add test run + coverage here
 
       - task: PowerShell@2
         displayName: 'Delete files created by unit tests'
@@ -182,7 +175,6 @@ stages:
           targetType: 'inline'
           script: |
             Get-ChildItem $(Agent.TempDirectory) -Filter 'dummy.*' -Recurse -Attributes !Directory | Remove-Item
-            Get-ChildItem $(Agent.TempDirectory) -Filter 'VSCodeCoverageReport.*' -Recurse -Attributes !Directory | Remove-Item
       - task: SonarCloudAnalyze@1
         displayName: 'Run SonarCloud analysis'
       - task: PowerShell@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,6 +102,9 @@ stages:
           projectName: '$(sonarCloudMsBuildProjectName)'
           projectVersion: '$(SONAR_PROJECT_VERSION)'
           scannerMode: MSBuild
+          extraProperties: |
+            sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/coverage/**.xml"
+            sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/TestResults/*.trx"
       - task: DotNetCoreCLI@2
         displayName: Dotnet restore $(tfsProcessorSolution)
         inputs:
@@ -166,8 +169,20 @@ stages:
           command: 'build'
           projects: '$(solution)'
           arguments: '/m /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /p:configuration=$(BuildConfiguration) /p:platform="$(BuildPlatform)"'
-      
-      # Add test run + coverage here
+
+      - powershell: |
+          mkdir $(Build.SourcesDirectory)\coverage\
+
+          # Currently coverlet is not able to both merge the test results and convert them to OpenCover format.
+          # Due to this, we have to run tests per test project and merge the results.
+          # The last test run will do the conversion by using `-p:CoverletOutputFormat=opencover` parameter.
+          dotnet test Tests\SonarScanner.MSBuild.Common.Test\SonarScanner.MSBuild.Common.Test.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" --no-build --no-restore -l trx
+          dotnet test Tests\SonarScanner.MSBuild.PostProcessor.Test\SonarScanner.MSBuild.PostProcessor.Test.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" --no-build --no-restore -l trx
+          dotnet test Tests\SonarScanner.MSBuild.PreProcessor.Test\SonarScanner.MSBuild.PreProcessor.Test.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" --no-build --no-restore -l trx
+          dotnet test Tests\SonarScanner.MSBuild.Shim.Test\SonarScanner.MSBuild.Shim.Test.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" --no-build --no-restore -l trx
+          dotnet test Tests\SonarScanner.MSBuild.Tasks.UnitTest\SonarScanner.MSBuild.Tasks.UnitTest.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" --no-build --no-restore -l trx
+          dotnet test Tests\SonarScanner.MSBuild.Test\SonarScanner.MSBuild.Test.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" -p:CoverletOutputFormat=opencover --no-build --no-restore -l trx
+        displayName: 'Run tests and compute coverage'
 
       - task: PowerShell@2
         displayName: 'Delete files created by unit tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,12 +176,20 @@ stages:
           # Currently coverlet is not able to both merge the test results and convert them to OpenCover format.
           # Due to this, we have to run tests per test project and merge the results.
           # The last test run will do the conversion by using `-p:CoverletOutputFormat=opencover` parameter.
-          dotnet test Tests\SonarScanner.MSBuild.Common.Test\SonarScanner.MSBuild.Common.Test.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" --no-build --no-restore -l trx
-          dotnet test Tests\SonarScanner.MSBuild.PostProcessor.Test\SonarScanner.MSBuild.PostProcessor.Test.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" --no-build --no-restore -l trx
-          dotnet test Tests\SonarScanner.MSBuild.PreProcessor.Test\SonarScanner.MSBuild.PreProcessor.Test.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" --no-build --no-restore -l trx
-          dotnet test Tests\SonarScanner.MSBuild.Shim.Test\SonarScanner.MSBuild.Shim.Test.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" --no-build --no-restore -l trx
-          dotnet test Tests\SonarScanner.MSBuild.Tasks.UnitTest\SonarScanner.MSBuild.Tasks.UnitTest.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" --no-build --no-restore -l trx
-          dotnet test Tests\SonarScanner.MSBuild.Test\SonarScanner.MSBuild.Test.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "./TestResults" -p:CoverletOutputFormat=opencover --no-build --no-restore -l trx
+          function Run-Tests-With-Coverage {
+            param (
+              $projectPath
+            )
+            dotnet test $projectPath --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "$(Build.SourcesDirectory)\TestResults" --no-build --no-restore -l trx
+          }
+          Run-Tests-With-Coverage Tests\SonarScanner.MSBuild.Common.Test\SonarScanner.MSBuild.Common.Test.csproj
+          Run-Tests-With-Coverage Tests\SonarScanner.MSBuild.PostProcessor.Test\SonarScanner.MSBuild.PostProcessor.Test.csproj
+          Run-Tests-With-Coverage Tests\SonarScanner.MSBuild.PreProcessor.Test\SonarScanner.MSBuild.PreProcessor.Test.csproj
+          Run-Tests-With-Coverage Tests\SonarScanner.MSBuild.Shim.Test\SonarScanner.MSBuild.Shim.Test.csproj
+          Run-Tests-With-Coverage Tests\SonarScanner.MSBuild.Tasks.UnitTest\SonarScanner.MSBuild.Tasks.UnitTest.csproj
+          
+          # This run is special since it will do the conversion too.
+          dotnet test Tests\SonarScanner.MSBuild.Test\SonarScanner.MSBuild.Test.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "$(Build.SourcesDirectory)\TestResults" -p:CoverletOutputFormat=opencover --no-build --no-restore -l trx
         displayName: 'Run tests and compute coverage'
 
       - task: PowerShell@2


### PR DESCRIPTION
Coverlet will add better branch support but this will result in a lower overall coverage since more paths are now considered.

Coverage after the merge will drop to 84.5% from 92.3%.