### PR TITLE
Do not run Net6 razor ITs for MsBuild16 setUp

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -543,6 +543,7 @@ public class ScannerMSBuildTest {
 
   @Test
   public void testRazorCompilationNet6WithoutSourceGenerators() throws IOException {
+    assumeFalse(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2019")); // We can't build without MsBuild17
     String projectName = "RazorWebApplication.net6.withoutSourceGenerators";
     assertProjectFileContains(projectName, "<UseRazorSourceGenerator>false</UseRazorSourceGenerator>");
     validateRazorProject(projectName);
@@ -550,6 +551,7 @@ public class ScannerMSBuildTest {
 
   @Test
   public void testRazorCompilationNet6WithSourceGenerators() throws IOException {
+    assumeFalse(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2019")); // We can't build without MsBuild17
     String projectName = "RazorWebApplication.net6.withSourceGenerators";
     assertProjectFileContains(projectName, "<UseRazorSourceGenerator>true</UseRazorSourceGenerator>");
     validateRazorProject(projectName);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -543,7 +543,7 @@ public class ScannerMSBuildTest {
 
   @Test
   public void testRazorCompilationNet6WithoutSourceGenerators() throws IOException {
-    assumeTrue(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2022")); // We can't build without MsBuild17
+    Assume.assumeTrue(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2022")); // We can't build without MsBuild17
     String projectName = "RazorWebApplication.net6.withoutSourceGenerators";
     assertProjectFileContains(projectName, "<UseRazorSourceGenerator>false</UseRazorSourceGenerator>");
     validateRazorProject(projectName);
@@ -551,7 +551,7 @@ public class ScannerMSBuildTest {
 
   @Test
   public void testRazorCompilationNet6WithSourceGenerators() throws IOException {
-    assumeTrue(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2022")); // We can't build without MsBuild17
+    Assume.assumeTrue(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2022")); // We can't build without MsBuild17
     String projectName = "RazorWebApplication.net6.withSourceGenerators";
     assertProjectFileContains(projectName, "<UseRazorSourceGenerator>true</UseRazorSourceGenerator>");
     validateRazorProject(projectName);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -543,7 +543,7 @@ public class ScannerMSBuildTest {
 
   @Test
   public void testRazorCompilationNet6WithoutSourceGenerators() throws IOException {
-    assumeFalse(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2019")); // We can't build without MsBuild17
+    assumeTrue(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2022")); // We can't build without MsBuild17
     String projectName = "RazorWebApplication.net6.withoutSourceGenerators";
     assertProjectFileContains(projectName, "<UseRazorSourceGenerator>false</UseRazorSourceGenerator>");
     validateRazorProject(projectName);
@@ -551,7 +551,7 @@ public class ScannerMSBuildTest {
 
   @Test
   public void testRazorCompilationNet6WithSourceGenerators() throws IOException {
-    assumeFalse(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2019")); // We can't build without MsBuild17
+    assumeTrue(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2022")); // We can't build without MsBuild17
     String projectName = "RazorWebApplication.net6.withSourceGenerators";
     assertProjectFileContains(projectName, "<UseRazorSourceGenerator>true</UseRazorSourceGenerator>");
     validateRazorProject(projectName);


### PR DESCRIPTION
Related to the following changes: https://github.com/SonarSource/re-ci-images/pull/79

See the tested behavior also on: https://github.com/SonarSource/sonar-scanner-msbuild/pull/1231

Why it worked earlier and not anymore? Explanation:

- With .NET 6, the.NET 6.0.100 SDK can be used in version 16.11 for downlevel targeting. This means that you're not forced to update your SDK and Visual Studio versions simultaneously. However, you won't be able to target .NET 6 because of limitations in 6.0 features and C# 10 features in version 16.11. This compatibility is specifically for targeting 5.0 and below.

- 6.0.300 and newer SDKs require a minimum Visual Studio version of 17.0

See at https://docs.microsoft.com/en-us/dotnet/core/porting/versioning-sdk-msbuild-vs