### PR TITLE
Do not log warnings about files placed outside the project root directory that are binary or placed in the standard NuGet cache.

### DIFF
--- a/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
@@ -1000,8 +1000,8 @@ namespace SonarScanner.MSBuild.Shim.Test
                 new ProjectData(new ProjectInfo { FullPath = "C:\\foo.csproj" }),
                 new ProjectData(new ProjectInfo { FullPath = "C:\\foo\\bar.csproj" }),
                 new ProjectData(new ProjectInfo { FullPath = "C:\\foo\\bar\\foo.csproj" }),
-                 new ProjectData(new ProjectInfo { FullPath = "C:\\foo\\xxx.csproj" }),
-                 new ProjectData(new ProjectInfo { FullPath = "C:\\foo\\bar\\foobar\\foo.csproj" }),
+                new ProjectData(new ProjectInfo { FullPath = "C:\\foo\\xxx.csproj" }),
+                new ProjectData(new ProjectInfo { FullPath = "C:\\foo\\bar\\foobar\\foo.csproj" }),
             };
 
             // Act

--- a/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
@@ -72,7 +72,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_NoProjectInfoFiles()
+        public void GenerateFile_NoProjectInfoFiles()
         {
             // Properties file should not be generated if there are no project info files.
 
@@ -96,7 +96,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_ValidFiles()
+        public void GenerateFile_ValidFiles()
         {
             // Only non-excluded projects with files to analyze should be marked as valid
 
@@ -124,7 +124,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_Duplicate_SameGuid_DifferentCase_ShouldNotIgnoreCase()
+        public void GenerateFile_Duplicate_SameGuid_DifferentCase_ShouldNotIgnoreCase()
         {
             var projectName1 = "withFiles1";
             var projectName2 = "withFiles2";
@@ -168,7 +168,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_Duplicate_SameGuid_DifferentCase_ShouldIgnoreCase()
+        public void GenerateFile_Duplicate_SameGuid_DifferentCase_ShouldIgnoreCase()
         {
             // Arrange
             var projectName1 = "withFiles1";
@@ -205,7 +205,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_ValidFiles_SourceEncoding_Provided()
+        public void GenerateFile_ValidFiles_SourceEncoding_Provided()
         {
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -230,7 +230,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_TFS_Coverage_TrxAreWritten()
+        public void GenerateFile_TFS_Coverage_TrxAreWritten()
         {
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -257,7 +257,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_SensitiveParamsNotLogged()
+        public void GenerateFile_SensitiveParamsNotLogged()
         {
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -282,7 +282,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_ValidFiles_WithAlreadyValidSarif()
+        public void GenerateFile_ValidFiles_WithAlreadyValidSarif()
         {
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -319,7 +319,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         [DataTestMethod]
         [DataRow(ProjectLanguages.CSharp, PropertiesFileGenerator.ReportFilePathsCSharpPropertyKey, RoslynV1SarifFixer.CSharpLanguage)]
         [DataRow(ProjectLanguages.VisualBasic, PropertiesFileGenerator.ReportFilePathsVbNetPropertyKey, RoslynV1SarifFixer.VBNetLanguage)]
-        public void FileGen_ValidFiles_WithFixableSarif(string projectLanguage, string propertyKey, string expectedSarifLanguage)
+        public void GenerateFile_ValidFiles_WithFixableSarif(string projectLanguage, string propertyKey, string expectedSarifLanguage)
         {
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -356,7 +356,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_WithMultipleAnalyzerAndRoslynOutputPaths_ShouldBeSupported()
+        public void GenerateFile_WithMultipleAnalyzerAndRoslynOutputPaths_ShouldBeSupported()
         {
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -386,12 +386,12 @@ namespace SonarScanner.MSBuild.Shim.Test
             var result = new PropertiesFileGenerator(config, logger, mockSarifFixer, new RuntimeInformationWrapper()).GenerateFile();
             var provider = new SQPropertiesFileReader(result.FullPropertiesFilePath);
             provider.AssertSettingExists(
-                projectGuid.ToString().ToUpper() + "." + PropertiesFileGenerator.ReportFilePathsVbNetPropertyKey,
-                string.Join(",", testSarifPath1 + ".fixed.mock.json", testSarifPath2 + ".fixed.mock.json", testSarifPath3 + ".fixed.mock.json"));
+                $"{projectGuid.ToString().ToUpper()}.{PropertiesFileGenerator.ReportFilePathsVbNetPropertyKey}",
+                $"{testSarifPath1}.fixed.mock.json,{testSarifPath2}.fixed.mock.json,{testSarifPath3}.fixed.mock.json");
         }
 
         [TestMethod]
-        public void FileGen_ValidFiles_WithUnfixableSarif()
+        public void GenerateFile_ValidFiles_WithUnfixableSarif()
         {
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -428,7 +428,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_FileOutsideProjectPath_IsNotAnalyzedAndWarningIsLogged()
+        public void GenerateFile_FileOutsideProjectPath_IsNotAnalyzedAndWarningIsLogged()
         {
             // Files outside the project root should be ignored
 
@@ -464,7 +464,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_FilesOutOfProjectPath_PrintsCorrectWarnings()
+        public void GenerateFile_FilesOutOfProjectPath_PrintsCorrectWarnings()
         {
             // Files outside the project root should be ignored
 
@@ -503,7 +503,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_SharedFiles()
+        public void GenerateFile_SharedFiles()
         {
             // Shared files should be attached to the root project
 
@@ -542,7 +542,7 @@ namespace SonarScanner.MSBuild.Shim.Test
 
         // SONARMSBRU-335
         [TestMethod]
-        public void FileGen_SharedFiles_CaseInsensitive()
+        public void GenerateFile_SharedFiles_CaseInsensitive()
         {
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -584,7 +584,7 @@ namespace SonarScanner.MSBuild.Shim.Test
 
         // SONARMSBRU-336
         [TestMethod]
-        public void FileGen_SharedFiles_BelongToAnotherProject()
+        public void GenerateFile_SharedFiles_BelongToAnotherProject()
         {
             // Shared files that belong to another project should NOT be attached to the root project
 
@@ -623,8 +623,8 @@ namespace SonarScanner.MSBuild.Shim.Test
             provider.AssertSettingExists(project1Guid.ToString().ToUpper() + ".sonar.sources", fileInProject1);
         }
 
-        [TestMethod] //https://jira.codehaus.org/browse/SONARMSBRU-13: Analysis fails if a content file referenced in the MSBuild project does not exist
-        public void FileGen_MissingFilesAreSkipped()
+        [TestMethod] // https://jira.codehaus.org/browse/SONARMSBRU-13: Analysis fails if a content file referenced in the MSBuild project does not exist
+        public void GenerateFile_MissingFilesAreSkipped()
         {
             // Create project info with a managed file list and a content file list.
             // Each list refers to a file that does not exist on disk.
@@ -687,7 +687,7 @@ namespace SonarScanner.MSBuild.Shim.Test
 
         [TestMethod]
         [Description("Checks that the generated properties file contains additional properties")]
-        public void FileGen_AdditionalProperties()
+        public void GenerateFile_AdditionalProperties()
         {
             // 0. Arrange
             var analysisRootDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -741,7 +741,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_WhenNoGuid_LogWarnings()
+        public void GenerateFile_WhenNoGuid_LogWarnings()
         {
             // Arrange
             var analysisRootDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -763,7 +763,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod] // Old VS Bootstrapper should be forceably disabled: https://jira.sonarsource.com/browse/SONARMSBRU-122
-        public void FileGen_VSBootstrapperIsDisabled()
+        public void GenerateFile_VSBootstrapperIsDisabled()
         {
             // 0. Arrange
             var logger = new TestLogger();
@@ -778,7 +778,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_VSBootstrapperIsDisabled_OverrideUserSettings_DifferentValue()
+        public void GenerateFile_VSBootstrapperIsDisabled_OverrideUserSettings_DifferentValue()
         {
             // 0. Arrange
             var logger = new TestLogger();
@@ -796,7 +796,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_VSBootstrapperIsDisabled_OverrideUserSettings_SameValue()
+        public void GenerateFile_VSBootstrapperIsDisabled_OverrideUserSettings_SameValue()
         {
             // Arrange
             var logger = new TestLogger();
@@ -813,7 +813,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FileGen_ComputeProjectBaseDir()
+        public void GenerateFile_ComputeProjectBaseDir()
         {
             VerifyProjectBaseDir(
                 expectedValue: @"d:\work\mysources", // if there is a user value, use it

--- a/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
@@ -466,11 +466,11 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [DataTestMethod]
-        [DataRow(new string[] { ".nuget", "packages" }, 0)]
-        [DataRow(new string[] { "packages" }, 1)]
-        [DataRow(new string[] { ".nugetpackages" }, 1)]
-        [DataRow(new string[] { ".nuget", "foo", "packages" }, 1)]
-        public void GenerateFile_FileOutOfProjectRootDir_WarningsAreNotLoggedForFilesInStandardNugetCache(string[] subDirNames, int numOfWarnings)
+        [DataRow(new string[] { ".nuget", "packages" }, false)]
+        [DataRow(new string[] { "packages" }, true)]
+        [DataRow(new string[] { ".nugetpackages" }, true)]
+        [DataRow(new string[] { ".nuget", "foo", "packages" }, true)]
+        public void GenerateFile_FileOutOfProjectRootDir_WarningsAreNotLoggedForFilesInStandardNugetCache(string[] subDirNames, bool IsRaisingAWarning)
         {
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -498,10 +498,14 @@ namespace SonarScanner.MSBuild.Shim.Test
             AssertExpectedProjectCount(1, result);
             // The project has no files in its root dir and the rest of the files are outside of the root, thus ignored and not analyzed.
             AssertExpectedStatus("project", ProjectInfoValidity.NoFilesToAnalyze, result);
-            logger.AssertWarningsLogged(numOfWarnings);
-            if (numOfWarnings > 0)
+            if (IsRaisingAWarning)
             {
+                logger.AssertWarningsLogged(1);
                 logger.AssertSingleWarningExists($"File '{Path.Combine(dirOutOfProjectRoot, "foo.cs")}' is not located under the root directory");
+            }
+            else
+            {
+                logger.AssertWarningsLogged(0);
             }
         }
 

--- a/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
@@ -39,6 +39,39 @@ namespace SonarScanner.MSBuild.Shim.Test
         #region Tests
 
         [TestMethod]
+        public void PropertiesFileGenerator_WhenConfigIsNull_Throws()
+        {
+            Action action = () => new PropertiesFileGenerator(null, new TestLogger());
+
+            action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("analysisConfig");
+        }
+
+        [TestMethod]
+        public void PropertiesFileGenerator_WhenLoggerIsNull_Throws()
+        {
+            Action action = () => new PropertiesFileGenerator(new AnalysisConfig(), null);
+
+            action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("logger");
+        }
+
+        [TestMethod]
+        public void PropertiesFileGenerator_WhenFixerIsNull_Throws()
+        {
+            Action action = () => new PropertiesFileGenerator(new AnalysisConfig(), new TestLogger(), null, new RuntimeInformationWrapper());
+
+            action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("fixer");
+        }
+
+        [TestMethod]
+        public void PropertiesFileGenerator_WhenRuntimeInformationWrapperIsNull_Throws()
+        {
+            var logger = new TestLogger();
+            Action action = () => new PropertiesFileGenerator(new AnalysisConfig(), logger, new RoslynV1SarifFixer(logger), null);
+
+            action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("runtimeInformationWrapper");
+        }
+
+        [TestMethod]
         public void FileGen_NoProjectInfoFiles()
         {
             // Properties file should not be generated if there are no project info files.

--- a/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
@@ -39,36 +39,26 @@ namespace SonarScanner.MSBuild.Shim.Test
         #region Tests
 
         [TestMethod]
-        public void PropertiesFileGenerator_WhenConfigIsNull_Throws()
-        {
-            Action action = () => new PropertiesFileGenerator(null, new TestLogger());
-
-            action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("analysisConfig");
-        }
+        public void PropertiesFileGenerator_WhenConfigIsNull_Throws() =>
+            ((Action)(() => new PropertiesFileGenerator(null, new TestLogger()))).Should()
+                .ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("analysisConfig");
 
         [TestMethod]
-        public void PropertiesFileGenerator_WhenLoggerIsNull_Throws()
-        {
-            Action action = () => new PropertiesFileGenerator(new AnalysisConfig(), null);
-
-            action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("logger");
-        }
+        public void PropertiesFileGenerator_WhenLoggerIsNull_Throws() =>
+            ((Action)(() => new PropertiesFileGenerator(new AnalysisConfig(), null))).Should()
+            .ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("logger");
 
         [TestMethod]
-        public void PropertiesFileGenerator_WhenFixerIsNull_Throws()
-        {
-            Action action = () => new PropertiesFileGenerator(new AnalysisConfig(), new TestLogger(), null, new RuntimeInformationWrapper());
-
-            action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("fixer");
-        }
+        public void PropertiesFileGenerator_WhenFixerIsNull_Throws() =>
+            ((Action)(() => new PropertiesFileGenerator(new AnalysisConfig(), new TestLogger(), null, new RuntimeInformationWrapper()))).Should()
+                .ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("fixer");
 
         [TestMethod]
         public void PropertiesFileGenerator_WhenRuntimeInformationWrapperIsNull_Throws()
         {
             var logger = new TestLogger();
-            Action action = () => new PropertiesFileGenerator(new AnalysisConfig(), logger, new RoslynV1SarifFixer(logger), null);
-
-            action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("runtimeInformationWrapper");
+            ((Action)(() => new PropertiesFileGenerator(new AnalysisConfig(), logger, new RoslynV1SarifFixer(logger), null))).Should()
+                .ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("runtimeInformationWrapper");
         }
 
         [TestMethod]
@@ -470,7 +460,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         [DataRow(new string[] { "packages" }, true)]
         [DataRow(new string[] { ".nugetpackages" }, true)]
         [DataRow(new string[] { ".nuget", "foo", "packages" }, true)]
-        public void GenerateFile_FileOutOfProjectRootDir_WarningsAreNotLoggedForFilesInStandardNugetCache(string[] subDirNames, bool IsRaisingAWarning)
+        public void GenerateFile_FileOutOfProjectRootDir_WarningsAreNotLoggedForFilesInStandardNugetCache(string[] subDirNames, bool isRaisingAWarning)
         {
             // Arrange
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
@@ -498,7 +488,7 @@ namespace SonarScanner.MSBuild.Shim.Test
             AssertExpectedProjectCount(1, result);
             // The project has no files in its root dir and the rest of the files are outside of the root, thus ignored and not analyzed.
             AssertExpectedStatus("project", ProjectInfoValidity.NoFilesToAnalyze, result);
-            if (IsRaisingAWarning)
+            if (isRaisingAWarning)
             {
                 logger.AssertWarningsLogged(1);
                 logger.AssertSingleWarningExists($"File '{Path.Combine(dirOutOfProjectRoot, "foo.cs")}' is not located under the root directory");

--- a/Tests/TestUtilities/TestUtils.cs
+++ b/Tests/TestUtilities/TestUtils.cs
@@ -227,8 +227,15 @@ namespace TestUtilities
         /// <summary>
         /// Creates a new project info file in a new subdirectory with the given additional properties.
         /// </summary>
-        public static string CreateProjectInfoInSubDir(string parentDir,
-            string projectName, string projectLanguage, Guid projectGuid, ProjectType projectType, bool isExcluded, string fullProjectPath, string encoding,
+        public static string CreateProjectInfoInSubDir(
+            string parentDir,
+            string projectName,
+            string projectLanguage,
+            Guid projectGuid,
+            ProjectType projectType,
+            bool isExcluded,
+            string fullProjectPath,
+            string encoding,
             AnalysisProperties additionalProperties = null)
         {
             var newDir = Path.Combine(parentDir, projectName);

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -488,7 +488,7 @@ namespace SonarScanner.MSBuild.Shim
 
         private static bool IsInNuGetCache(string filePath)
         {
-            // List of nuget cache paths in Windows and Unix:
+            // NuGet global cache paths in Windows and Unix:
             // https://docs.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders
             var nugetCachePath =  PlatformHelper.IsWindows() ?
                 Environment.ExpandEnvironmentVariables(@"%userprofile%\.nuget\packages") :

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -167,10 +167,6 @@ namespace SonarScanner.MSBuild.Shim
         /// <returns>The list of files to attach to the root module.</returns>
         private ICollection<FileInfo> PutFilesToRightModuleOrRoot(IEnumerable<ProjectData> projects, DirectoryInfo baseDirectory)
         {
-            bool IsBinaryFile(FileInfo file) =>
-                file.Extension.Equals(".exe", StringComparison.InvariantCultureIgnoreCase)
-                || file.Extension.Equals(".dll", StringComparison.InvariantCultureIgnoreCase);
-
             var fileWithProjects = projects
                 .SelectMany(p => p.ReferencedFiles.Where(f => !IsBinaryFile(f))
                                                   .Select(f => new { Project = p, File = f }))
@@ -215,6 +211,10 @@ namespace SonarScanner.MSBuild.Shim
                     }
                 }
             }
+
+            bool IsBinaryFile(FileInfo file) =>
+                file.Extension.Equals(".exe", StringComparison.InvariantCultureIgnoreCase)
+                || file.Extension.Equals(".dll", StringComparison.InvariantCultureIgnoreCase);
 
             return rootModuleFiles;
         }

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -168,7 +168,7 @@ namespace SonarScanner.MSBuild.Shim
         private ICollection<FileInfo> PutFilesToRightModuleOrRoot(IEnumerable<ProjectData> projects, DirectoryInfo baseDirectory)
         {
             var fileWithProjects = projects
-                .SelectMany(p => p.ReferencedFiles.Where(f => f.Extension.Equals(".exe") || f.Extension.Equals(".dll"))
+                .SelectMany(p => p.ReferencedFiles.Where(f => !f.Extension.Equals(".exe") && !f.Extension.Equals(".dll"))
                                                   .Select(f => new { Project = p, File = f }))
                 .GroupBy(group => group.File, new FileInfoEqualityComparer())
                 .ToDictionary(group => group.Key, group => group.Select(x => x.Project)

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -168,20 +168,17 @@ namespace SonarScanner.MSBuild.Shim
         private ICollection<FileInfo> PutFilesToRightModuleOrRoot(IEnumerable<ProjectData> projects, DirectoryInfo baseDirectory)
         {
             var fileWithProjects = projects
-                .SelectMany(p => p.ReferencedFiles.Select(f => new { Project = p, File = f }))
+                .SelectMany(p => p.ReferencedFiles.Where(f => f.Extension.Equals(".exe") || f.Extension.Equals(".dll"))
+                                                  .Select(f => new { Project = p, File = f }))
                 .GroupBy(group => group.File, new FileInfoEqualityComparer())
-                .ToDictionary(group => group.Key, group => group.Select(x => x.Project).ToList());
+                .ToDictionary(group => group.Key, group => group.Select(x => x.Project)
+                .ToList());
 
             var rootModuleFiles = new HashSet<FileInfo>(new FileInfoEqualityComparer());
 
             foreach (var group in fileWithProjects)
             {
                 var file = group.Key;
-
-                if (file.Extension.Equals(".exe") || file.Extension.Equals(".dll"))
-                {
-                    continue;
-                }
 
                 if (!file.Exists)
                 {

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -211,13 +211,13 @@ namespace SonarScanner.MSBuild.Shim
                     }
                 }
             }
+            return rootModuleFiles;
 
             bool IsBinaryFile(FileInfo file) =>
                 file.Extension.Equals(".exe", StringComparison.InvariantCultureIgnoreCase)
                 || file.Extension.Equals(".dll", StringComparison.InvariantCultureIgnoreCase);
-
-            return rootModuleFiles;
         }
+
         private void PostProcessProjectStatus(IEnumerable<ProjectData> projects)
         {
             foreach (var project in projects)

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -178,6 +178,11 @@ namespace SonarScanner.MSBuild.Shim
             {
                 var file = group.Key;
 
+                if (file.Extension.Equals(".exe") || file.Extension.Equals(".dll"))
+                {
+                    continue;
+                }
+
                 if (!file.Exists)
                 {
                     logger.LogWarning(Resources.WARN_FileDoesNotExist, file);
@@ -189,7 +194,7 @@ namespace SonarScanner.MSBuild.Shim
 
                 if (!PathHelper.IsInDirectory(file, baseDirectory)) // File is outside of the SonarQube root module
                 {
-                    if (!IsInNuGetCache(file.FullName))
+                    if (!file.FullName.Contains(Path.Combine(".nuget", "packages")))
                     {
                         logger.LogWarning(Resources.WARN_FileIsOutsideProjectDirectory, file, baseDirectory.FullName);
                     }
@@ -216,7 +221,6 @@ namespace SonarScanner.MSBuild.Shim
 
             return rootModuleFiles;
         }
-
         private void PostProcessProjectStatus(IEnumerable<ProjectData> projects)
         {
             foreach (var project in projects)
@@ -484,17 +488,6 @@ namespace SonarScanner.MSBuild.Shim
                     projectInfo.Encoding = globalSourceEncoding;
                 }
             }
-        }
-
-        private static bool IsInNuGetCache(string filePath)
-        {
-            // NuGet global cache paths in Windows and Unix:
-            // https://docs.microsoft.com/en-us/nuget/consume-packages/managing-the-global-packages-and-cache-folders
-            var nugetCachePath =  PlatformHelper.IsWindows() ?
-                Environment.ExpandEnvironmentVariables(@"%userprofile%\.nuget\packages") :
-                Environment.ExpandEnvironmentVariables(@"%HOME%/.nuget/packages");
-
-            return filePath.Contains(nugetCachePath);
         }
     }
 }


### PR DESCRIPTION
Fixes #1032 