### PR TITLE
Add UTs for FixEncoding

### DIFF
--- a/Tests/SonarScanner.MSBuild.Shim.Test/ProjectInfoExtensionsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/ProjectInfoExtensionsTests.cs
@@ -38,7 +38,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         [DataTestMethod]
         [DataRow(null)]
         [DataRow("FOO")]
-        public void FixEncoding_WithNullEncodingNullGlobalEncodingNotSupportedProject_DoesNothing(string projectLanguage)
+        public void FixEncoding_WithNullEncoding_NullGlobalEncoding_NotSupportedProject_DoesNothing(string projectLanguage)
         {
             ProjectInfo sut = new()
             {
@@ -55,7 +55,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         [DataTestMethod]
         [DataRow(ProjectLanguages.CSharp)]
         [DataRow(ProjectLanguages.VisualBasic)]
-        public void FixEncoding_WithNullEncodingNullGlobalEncodingSupportedProject_SetsUtf8WebName(string projectLanguage)
+        public void FixEncoding_WithNullEncoding_NullGlobalEncoding_SupportedProject_SetsUtf8WebName(string projectLanguage)
         {
             ProjectInfo sut = new()
             {
@@ -70,7 +70,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FixEncoding_WithNullEncodingAndNotNullGlobalEncoding_SetsGlobalEncoding()
+        public void FixEncoding_WithNullEncoding_GlobalEncoding_SetsGlobalEncoding()
         {
             ProjectInfo sut = new()
             {
@@ -84,7 +84,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FixEncoding_WithNotNullEncodingAndNotNullGlobalEncoding_DoesNotChangeEncodingAndCallsLogAction()
+        public void FixEncoding_WithEncoding_GlobalEncoding_DoesNotChangeEncodingAndCallsLogAction()
         {
             ProjectInfo sut = new()
             {
@@ -98,7 +98,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         }
 
         [TestMethod]
-        public void FixEncoding_WithNotNullEncodingAndNullGlobalEncoding_DoesNothing()
+        public void FixEncoding_WithEncoding_NullGlobalEncoding_DoesNothing()
         {
             ProjectInfo sut = new()
             {

--- a/Tests/SonarScanner.MSBuild.Shim.Test/ProjectInfoExtensionsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/ProjectInfoExtensionsTests.cs
@@ -1,0 +1,114 @@
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2022 SonarSource SA
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.Text;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarScanner.MSBuild.Common;
+
+namespace SonarScanner.MSBuild.Shim.Test
+{
+    [TestClass]
+    public class ProjectInfoExtensionsTests
+    {
+        private static bool isLogActionInvoked;
+        private readonly Action logActionMock = () => isLogActionInvoked = true;
+
+        [TestInitialize]
+        public void InitializeTests() => isLogActionInvoked = false;
+
+        [DataTestMethod]
+        [DataRow(null)]
+        [DataRow("FOO")]
+        public void FixEncoding_WithNullEncodingNullGlobalEncodingNotSupportedProject_DoesNothing(string projectLanguage)
+        {
+            ProjectInfo sut = new()
+            {
+                ProjectLanguage = projectLanguage,
+                Encoding = null
+            };
+
+            sut.FixEncoding(null, logActionMock);
+
+            sut.Encoding.Should().BeNull();
+            isLogActionInvoked.Should().BeFalse();
+        }
+
+        [DataTestMethod]
+        [DataRow(ProjectLanguages.CSharp)]
+        [DataRow(ProjectLanguages.VisualBasic)]
+        public void FixEncoding_WithNullEncodingNullGlobalEncodingSupportedProject_SetsUtf8WebName(string projectLanguage)
+        {
+            ProjectInfo sut = new()
+            {
+                ProjectLanguage = projectLanguage,
+                Encoding = null
+            };
+
+            sut.FixEncoding(null, logActionMock);
+
+            sut.Encoding.Should().Be(Encoding.UTF8.WebName);
+            isLogActionInvoked.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void FixEncoding_WithNullEncodingAndNotNullGlobalEncoding_SetsGlobalEncoding()
+        {
+            ProjectInfo sut = new()
+            {
+                Encoding = null
+            };
+
+            sut.FixEncoding("FOO", logActionMock);
+
+            sut.Encoding.Should().Be("FOO");
+            isLogActionInvoked.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void FixEncoding_WithNotNullEncodingAndNotNullGlobalEncoding_DoesNotChangeEncodingAndCallsLogAction()
+        {
+            ProjectInfo sut = new()
+            {
+                Encoding = "FOO"
+            };
+
+            sut.FixEncoding("BAR", logActionMock);
+
+            sut.Encoding.Should().Be("FOO");
+            isLogActionInvoked.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void FixEncoding_WithNotNullEncodingAndNullGlobalEncoding_DoesNothing()
+        {
+            ProjectInfo sut = new()
+            {
+                Encoding = "FOO"
+            };
+
+            sut.FixEncoding(null, logActionMock);
+
+            sut.Encoding.Should().Be("FOO");
+            isLogActionInvoked.Should().BeFalse();
+        }
+    }
+}

--- a/src/SonarScanner.MSBuild.Shim/ProjectInfoExtensions.cs
+++ b/src/SonarScanner.MSBuild.Shim/ProjectInfoExtensions.cs
@@ -19,6 +19,7 @@
  */
 
 using System;
+using System.Text;
 using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild.Shim
@@ -40,6 +41,28 @@ namespace SonarScanner.MSBuild.Shim
             }
 
             return ProjectInfoValidity.Valid;
+        }
+
+        public static void FixEncoding(this ProjectInfo projectInfo, string globalSourceEncoding, ILogger logger)
+        {
+            if (projectInfo.Encoding is null)
+            {
+                if (globalSourceEncoding is null)
+                {
+                    if (ProjectLanguages.IsCSharpProject(projectInfo.ProjectLanguage) || ProjectLanguages.IsVbProject(projectInfo.ProjectLanguage))
+                    {
+                        projectInfo.Encoding = Encoding.UTF8.WebName;
+                    }
+                }
+                else
+                {
+                    projectInfo.Encoding = globalSourceEncoding;
+                }
+            }
+            else if (globalSourceEncoding is not null)
+            {
+                logger.LogInfo(Resources.WARN_PropertyIgnored, SonarProperties.SourceEncoding);
+            }
         }
 
         private static bool HasInvalidGuid(ProjectInfo project)

--- a/src/SonarScanner.MSBuild.Shim/ProjectInfoExtensions.cs
+++ b/src/SonarScanner.MSBuild.Shim/ProjectInfoExtensions.cs
@@ -43,7 +43,7 @@ namespace SonarScanner.MSBuild.Shim
             return ProjectInfoValidity.Valid;
         }
 
-        public static void FixEncoding(this ProjectInfo projectInfo, string globalSourceEncoding, ILogger logger)
+        public static void FixEncoding(this ProjectInfo projectInfo, string globalSourceEncoding, Action logIfIgnored)
         {
             if (projectInfo.Encoding is null)
             {
@@ -61,7 +61,7 @@ namespace SonarScanner.MSBuild.Shim
             }
             else if (globalSourceEncoding is not null)
             {
-                logger.LogInfo(Resources.WARN_PropertyIgnored, SonarProperties.SourceEncoding);
+                logIfIgnored();
             }
         }
 

--- a/src/SonarScanner.MSBuild.Shim/ProjectInfoExtensions.cs
+++ b/src/SonarScanner.MSBuild.Shim/ProjectInfoExtensions.cs
@@ -43,7 +43,7 @@ namespace SonarScanner.MSBuild.Shim
             return ProjectInfoValidity.Valid;
         }
 
-        public static void FixEncoding(this ProjectInfo projectInfo, string globalSourceEncoding, Action logIfIgnored)
+        public static void FixEncoding(this ProjectInfo projectInfo, string globalSourceEncoding, Action logIfGlobalEncodingIsIgnored)
         {
             if (projectInfo.Encoding is null)
             {
@@ -61,7 +61,7 @@ namespace SonarScanner.MSBuild.Shim
             }
             else if (globalSourceEncoding is not null)
             {
-                logIfIgnored();
+                logIfGlobalEncodingIsIgnored();
             }
         }
 

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -25,7 +25,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using SonarScanner.MSBuild.Common;
-using SonarScanner.MSBuild.Common.Interfaces;
 using SonarScanner.MSBuild.Shim.Interfaces;
 
 namespace SonarScanner.MSBuild.Shim

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -357,7 +357,7 @@ namespace SonarScanner.MSBuild.Shim
             foreach (var project in projects)
             {
                 TryFixSarifReport(project);
-                FixEncoding(project, globalSourceEncoding);
+                project.FixEncoding(globalSourceEncoding, logger);
             }
         }
 
@@ -405,28 +405,6 @@ namespace SonarScanner.MSBuild.Shim
                 // encoding doesn't exist
             }
             return null;
-        }
-
-        private void FixEncoding(ProjectInfo projectInfo, string globalSourceEncoding)
-        {
-            if (projectInfo.Encoding is null)
-            {
-                if (globalSourceEncoding is null)
-                {
-                    if (ProjectLanguages.IsCSharpProject(projectInfo.ProjectLanguage) || ProjectLanguages.IsVbProject(projectInfo.ProjectLanguage))
-                    {
-                        projectInfo.Encoding = Encoding.UTF8.WebName;
-                    }
-                }
-                else
-                {
-                    projectInfo.Encoding = globalSourceEncoding;
-                }
-            }
-            else if (globalSourceEncoding is not null)
-            {
-                logger.LogInfo(Resources.WARN_PropertyIgnored, SonarProperties.SourceEncoding);
-            }
         }
     }
 }

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -354,11 +354,11 @@ namespace SonarScanner.MSBuild.Shim
         private void FixSarifAndEncoding(IList<ProjectInfo> projects, AnalysisProperties analysisProperties)
         {
             var globalSourceEncoding = GetSourceEncoding(analysisProperties);
-            var logIfIgnored = () => logger.LogInfo(Resources.WARN_PropertyIgnored, SonarProperties.SourceEncoding);
+            var logIfGlobalEncodingIsIgnored = () => logger.LogInfo(Resources.WARN_PropertyIgnored, SonarProperties.SourceEncoding);
             foreach (var project in projects)
             {
                 TryFixSarifReport(project);
-                project.FixEncoding(globalSourceEncoding, logIfIgnored);
+                project.FixEncoding(globalSourceEncoding, logIfGlobalEncodingIsIgnored);
             }
 
             static string GetSourceEncoding(AnalysisProperties properties)


### PR DESCRIPTION
`FixEncoding` makes the New Code Period look bad.

Even if it was just slightly refactored in [this commit](https://github.com/SonarSource/sonar-scanner-msbuild/pull/1306/files#diff-f79831385eb9ec0eb0115604abf180c8e806ae8d03a220ca778d52d0aa915fbfR412), we need to **clean as we code** 🥷 .

![image](https://user-images.githubusercontent.com/38876598/184667791-a862e6a2-fdd3-4de6-bbee-42a2df073c11.png)

As usual, it's better to review commit by commit.