### PR TITLE
Fail CI if unit tests fail

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,6 +180,7 @@ stages:
           arguments: '/m /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /p:configuration=$(BuildConfiguration) /p:platform="$(BuildPlatform)"'
 
       - powershell: |
+          . .\scripts\utils.ps1
           mkdir $(Build.SourcesDirectory)\coverage\
 
           # Currently coverlet is not able to both merge the test results and convert them to OpenCover format.
@@ -190,6 +191,7 @@ stages:
               $projectPath
             )
             dotnet test $projectPath --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:Include=[SonarScanner.*]* -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "$(Build.SourcesDirectory)\TestResults" --no-build --no-restore -l trx
+            Test-ExitCode "ERROR: Unit tests for '$projectPath' FAILED."
           }
           Run-Tests-With-Coverage Tests\SonarScanner.MSBuild.Common.Test\SonarScanner.MSBuild.Common.Test.csproj
           Run-Tests-With-Coverage Tests\SonarScanner.MSBuild.PostProcessor.Test\SonarScanner.MSBuild.PostProcessor.Test.csproj
@@ -201,6 +203,7 @@ stages:
 
           # This run is special since it will do the conversion too.
           dotnet test Tests\SonarScanner.MSBuild.Tasks.UnitTest\SonarScanner.MSBuild.Tasks.UnitTest.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:Include=[SonarScanner.*]* -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "$(Build.SourcesDirectory)\TestResults" -p:CoverletOutputFormat=opencover --no-build --no-restore -l trx
+          Test-ExitCode "ERROR: Unit tests for 'Tests\SonarScanner.MSBuild.Tasks.UnitTest\SonarScanner.MSBuild.Tasks.UnitTest.csproj' merging the code coverage FAILED."
         displayName: 'Run tests and compute coverage'
 
       - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,7 +203,7 @@ stages:
 
           # This run is special since it will do the conversion too.
           dotnet test Tests\SonarScanner.MSBuild.Tasks.UnitTest\SonarScanner.MSBuild.Tasks.UnitTest.csproj --configuration $(BuildConfiguration) -p:CollectCoverage=true -p:CoverletOutput="$(Build.SourcesDirectory)\coverage\" -p:Include=[SonarScanner.*]* -p:MergeWith="$(Build.SourcesDirectory)\coverage\coverage.net48.json" -r "$(Build.SourcesDirectory)\TestResults" -p:CoverletOutputFormat=opencover --no-build --no-restore -l trx
-          Test-ExitCode "ERROR: Unit tests for 'Tests\SonarScanner.MSBuild.Tasks.UnitTest\SonarScanner.MSBuild.Tasks.UnitTest.csproj' merging the code coverage FAILED."
+          Test-ExitCode "ERROR: Unit tests for 'Tests\SonarScanner.MSBuild.Tasks.UnitTest\SonarScanner.MSBuild.Tasks.UnitTest.csproj' and merging the code coverage FAILED."
         displayName: 'Run tests and compute coverage'
 
       - task: PublishBuildArtifacts@1


### PR DESCRIPTION
Fixes #1324

Tested in https://github.com/SonarSource/sonar-scanner-msbuild/pull/1322

> Failed!  - Failed:     1, Passed:   212, Skipped:     0, Total:   213, Duration: 4 s - SonarScanner.MSBuild.Common.Test.dll (net48)
ERROR: Unit tests for 'Tests\SonarScanner.MSBuild.Common.Test\SonarScanner.MSBuild.Common.Test.csproj' FAILED.
