### PR TITLE
Incremental PR analysis: Implement the hashing

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
@@ -51,7 +51,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             const string allNewLines = "public class Sample\n{\n\r\tint field;\n\r}\r";
             const string diacritics = "ěščřžýáí";
-            using var sut = new CacheProcessor(new Mock<ISonarQubeServer>().Object, CreateProcessedArgs(), new Mock<ILogger>().Object);
+            using var sut = new CacheProcessor(Mock.Of<ISonarQubeServer>(), CreateProcessedArgs(), Mock.Of<ILogger>());
             var root = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
             var emptyWithBom = CreateFile(root, "EmptyWithBom.cs", string.Empty, Encoding.UTF8);
             var emptyNoBom = CreateFile(root, "EmptyNoBom.cs", string.Empty, Encoding.ASCII);
@@ -75,7 +75,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [TestMethod]
         public void ContentHash_IsDeterministic()
         {
-            using var sut = new CacheProcessor(new Mock<ISonarQubeServer>().Object, CreateProcessedArgs(), new Mock<ILogger>().Object);
+            using var sut = new CacheProcessor(Mock.Of<ISonarQubeServer>(), CreateProcessedArgs(), Mock.Of<ILogger>());
             var root = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
             var path = CreateFile(root, "File.txt", "Lorem ipsum", Encoding.UTF8);
             var hash1 = sut.ContentHash(path);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
@@ -63,13 +63,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             File.ReadAllBytes(emptyWithBom).Should().HaveCount(3, "UTF8 encoding should generate BOM");
             File.ReadAllBytes(emptyNoBom).Should().HaveCount(0, "ASCII encoding should not generate BOM");
 
-            sut.ContentHash(emptyWithBom).Should().Be("57218c316b6921e2cd61027a2387edc31a2d9471");
-            sut.ContentHash(emptyNoBom).Should().Be("da39a3ee5e6b4b0d3255bfef95601890afd80709");
-            sut.ContentHash(codeWithBom).Should().Be("2d6384153e0b4eea0e3d9fc50dcf5dfb5f41e5da");
-            sut.ContentHash(codeNoBom).Should().Be("870f9b1e73d47d817957a1d13d3ea71add4c8a91");
-            sut.ContentHash(utf8).Should().Be("0611f145cc23f580a749be262a3598511787dcae");
-            sut.ContentHash(utf16).Should().Be("5e27d7cde2a1aeaca931297c23ab051394457248");
-            sut.ContentHash(ansi).Should().Be("b705e5ea2fd011094db5f565a5133912aa97c1e6");
+            sut.ContentHash(emptyWithBom).Should().Be("f1945cd6c19e56b3c1c78943ef5ec18116907a4ca1efc40a57d48ab1db7adfc5");
+            sut.ContentHash(emptyNoBom).Should().Be("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+            sut.ContentHash(codeWithBom).Should().Be("b98aaf2ce5a3f9cdf8ab785563951f2309d577baa6351098f78908300fdc610a");
+            sut.ContentHash(codeNoBom).Should().Be("8c7535a8e3679bf8cc241b5749cef5fc38243401556f2b7869495c7b48ee4980");
+            sut.ContentHash(utf8).Should().Be("13aa54e315a806270810f3a91501f980a095a2ef1bcc53167d4c750a1b78684d");
+            sut.ContentHash(utf16).Should().Be("a9b3c4402770855d090ba4b49adeb5ad601cb3bbd6de18495302f45f242ef932");
+            sut.ContentHash(ansi).Should().Be("b965073262109da4f106cd90a5eeea025e2441c244af272537afa2cfb03c3ab8");
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
@@ -51,7 +51,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             const string allNewLines = "public class Sample\n{\n\r\tint field;\n\r}\r";
             const string diacritics = "ěščřžýáí";
-            var sut = new CacheProcessor(new Mock<ISonarQubeServer>().Object, CreateProcessedArgs(), new Mock<ILogger>().Object);
+            using var sut = new CacheProcessor(new Mock<ISonarQubeServer>().Object, CreateProcessedArgs(), new Mock<ILogger>().Object);
             var root = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
             var emptyWithBom = CreateFile(root, "EmptyWithBom.cs", string.Empty, Encoding.UTF8);
             var emptyNoBom = CreateFile(root, "EmptyNoBom.cs", string.Empty, Encoding.ASCII);
@@ -75,9 +75,9 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [TestMethod]
         public void ContentHash_IsDeterministic()
         {
+            using var sut = new CacheProcessor(new Mock<ISonarQubeServer>().Object, CreateProcessedArgs(), new Mock<ILogger>().Object);
             var root = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
             var path = CreateFile(root, "File.txt", "Lorem ipsum", Encoding.UTF8);
-            var sut = new CacheProcessor(new Mock<ISonarQubeServer>().Object, CreateProcessedArgs(), new Mock<ILogger>().Object);
             var hash1 = sut.ContentHash(path);
             var hash2 = sut.ContentHash(path);
             var hash3 = sut.ContentHash(path);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
@@ -19,10 +19,13 @@
  */
 
 using System;
+using System.IO;
+using System.Text;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using SonarScanner.MSBuild.Common;
+using TestUtilities;
 
 namespace SonarScanner.MSBuild.PreProcessor.Test
 {
@@ -41,6 +44,52 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             ((Func<CacheProcessor>)(() => new CacheProcessor(null, settings, logger))).Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("server");
             ((Func<CacheProcessor>)(() => new CacheProcessor(server, null, logger))).Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("settings");
             ((Func<CacheProcessor>)(() => new CacheProcessor(server, settings, null))).Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("logger");
+        }
+
+        [TestMethod]
+        public void ContentHash_ComputeUniqueHash()
+        {
+            const string allNewLines = "public class Sample\n{\n\r\tint field;\n\r}\r";
+            const string diacritics = "ěščřžýáí";
+            var sut = new CacheProcessor(new Mock<ISonarQubeServer>().Object, CreateProcessedArgs(), new Mock<ILogger>().Object);
+            var root = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
+            var emptyWithBom = CreateFile(root, "EmptyWithBom.cs", string.Empty, Encoding.UTF8);
+            var emptyNoBom = CreateFile(root, "EmptyNoBom.cs", string.Empty, Encoding.ASCII);
+            var codeWithBom = CreateFile(root, "CodeWithBom.cs", allNewLines, Encoding.UTF8);
+            var codeNoBom = CreateFile(root, "CodeNoBom.cs", allNewLines, Encoding.ASCII);
+            var utf8 = CreateFile(root, "Utf8.cs", diacritics, Encoding.UTF8);
+            var utf16 = CreateFile(root, "Utf16.cs", diacritics, Encoding.Unicode);
+            var ansi = CreateFile(root, "Ansi.cs", diacritics, Encoding.GetEncoding(1250));
+            File.ReadAllBytes(emptyWithBom).Should().HaveCount(3, "UTF8 encoding should generate BOM");
+            File.ReadAllBytes(emptyNoBom).Should().HaveCount(0, "ASCII encoding should not generate BOM");
+
+            sut.ContentHash(emptyWithBom).Should().Be("57218c316b6921e2cd61027a2387edc31a2d9471");
+            sut.ContentHash(emptyNoBom).Should().Be("da39a3ee5e6b4b0d3255bfef95601890afd80709");
+            sut.ContentHash(codeWithBom).Should().Be("2d6384153e0b4eea0e3d9fc50dcf5dfb5f41e5da");
+            sut.ContentHash(codeNoBom).Should().Be("870f9b1e73d47d817957a1d13d3ea71add4c8a91");
+            sut.ContentHash(utf8).Should().Be("0611f145cc23f580a749be262a3598511787dcae");
+            sut.ContentHash(utf16).Should().Be("5e27d7cde2a1aeaca931297c23ab051394457248");
+            sut.ContentHash(ansi).Should().Be("b705e5ea2fd011094db5f565a5133912aa97c1e6");
+        }
+
+        [TestMethod]
+        public void ContentHash_IsDeterministic()
+        {
+            var root = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
+            var path = CreateFile(root, "File.txt", "Lorem ipsum", Encoding.UTF8);
+            var sut = new CacheProcessor(new Mock<ISonarQubeServer>().Object, CreateProcessedArgs(), new Mock<ILogger>().Object);
+            var hash1 = sut.ContentHash(path);
+            var hash2 = sut.ContentHash(path);
+            var hash3 = sut.ContentHash(path);
+            hash2.Should().Be(hash1);
+            hash3.Should().Be(hash1);
+        }
+
+        private static string CreateFile(string root, string fileName, string content, Encoding encoding)
+        {
+            var path = Path.Combine(root, fileName);
+            File.WriteAllText(path, content, encoding);
+            return path;
         }
 
         private static ProcessedArgs CreateProcessedArgs()

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
@@ -97,6 +97,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             logger.AssertDebugLogged("Processing analysis cache");
 
             AssertAnalysisConfig(settings.AnalysisConfigFilePath, 2, logger);
+
+            logger.AssertDebugLogged("Processing analysis cache");
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
@@ -97,8 +97,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             logger.AssertDebugLogged("Processing analysis cache");
 
             AssertAnalysisConfig(settings.AnalysisConfigFilePath, 2, logger);
-
-            logger.AssertDebugLogged("Processing analysis cache");
         }
 
         [TestMethod]

--- a/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
@@ -32,7 +32,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         private readonly ILogger logger;
         private readonly ISonarQubeServer server;
         private readonly ProcessedArgs settings;
-        private readonly SHA1 sha = new SHA1Managed();
+        private readonly HashAlgorithm sha256 = new SHA256Managed();
 
         public CacheProcessor(ISonarQubeServer server, ProcessedArgs settings, ILogger logger)
         {
@@ -53,7 +53,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         internal /* for testing */ string ContentHash(string path)
         {
             var content = File.ReadAllBytes(path);
-            var hash = sha.ComputeHash(content);
+            var hash = sha256.ComputeHash(content);
             return string.Concat(hash.Select(x => x.ToString("x2")));
         }
 
@@ -69,6 +69,6 @@ namespace SonarScanner.MSBuild.PreProcessor
         // ToDo: Move IsPullRequest here
 
         public void Dispose() =>
-            sha.Dispose();
+            sha256.Dispose();
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
@@ -19,16 +19,20 @@
  */
 
 using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild.PreProcessor
 {
-    public class CacheProcessor
+    public sealed class CacheProcessor : IDisposable
     {
         private readonly ILogger logger;
         private readonly ISonarQubeServer server;
         private readonly ProcessedArgs settings;
+        private readonly SHA1 sha = new SHA1Managed();
 
         public CacheProcessor(ISonarQubeServer server, ProcessedArgs settings, ILogger logger)
         {
@@ -46,15 +50,25 @@ namespace SonarScanner.MSBuild.PreProcessor
             // }
         }
 
+        internal /* for testing */ string ContentHash(string path)
+        {
+            var content = File.ReadAllBytes(path);
+            var hash = sha.ComputeHash(content);
+            return string.Concat(hash.Select(x => x.ToString("x2")));
+        }
+
         //private void ProcessPullRequestCache()
         //{
-            // ToDo: Deserialize
-            // ToDo: Hash
-            // ToDo: UnchangedFiles
-            // ToDo: Save to disk -> "...\UnchangedFiles.txt"
-            // ToDo: Populate AnalysisConfig
+        // ToDo: Deserialize
+        // ToDo: Hash
+        // ToDo: UnchangedFiles
+        // ToDo: Save to disk -> "...\UnchangedFiles.txt"
+        // ToDo: Populate AnalysisConfig
         //}
 
         // ToDo: Move IsPullRequest here
+
+        public void Dispose() =>
+            sha.Dispose();
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
@@ -52,8 +52,8 @@ namespace SonarScanner.MSBuild.PreProcessor
 
         internal /* for testing */ string ContentHash(string path)
         {
-            var content = File.ReadAllBytes(path);
-            var hash = sha256.ComputeHash(content);
+            using var stream = new FileStream(path, FileMode.Open);
+            var hash = sha256.ComputeHash(stream);
             return string.Concat(hash.Select(x => x.ToString("x2")));
         }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -123,7 +123,8 @@ namespace SonarScanner.MSBuild.PreProcessor
                 logger.LogDebug(Resources.MSG_Processing_PullRequest_NoBranch);
             }
 
-            await new CacheProcessor(server, settings, logger).Execute();
+            using var cache = new CacheProcessor(server, settings, logger);
+            await cache.Execute();
 
             // analyzerSettings can be empty
             AnalysisConfigGenerator.GenerateFile(settings, teamBuildSettings, argumentsAndRuleSets.ServerSettings, argumentsAndRuleSets.AnalyzersSettings, server, logger);

--- a/src/SonarScanner.MSBuild.PreProcessor/Properties/InternalsVisibleTo.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Properties/InternalsVisibleTo.cs
@@ -1,0 +1,27 @@
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2022 SonarSource SA
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Runtime.CompilerServices;
+
+#if SignAssembly
+[assembly: InternalsVisibleTo("SonarScanner.MSBuild.PreProcessor.Test,PublicKey=002400000480000094000000060200000024000052534131000400000100010081b4345a022cc0f4b42bdc795a5a7a1623c1e58dc2246645d751ad41ba98f2749dc5c4e0da3a9e09febcb2cd5b088a0f041f8ac24b20e736d8ae523061733782f9c4cd75b44f17a63714aced0b29a59cd1ce58d8e10ccdb6012c7098c39871043b7241ac4ab9f6b34f183db716082cd57c1ff648135bece256357ba735e67dc6")]
+#else
+[assembly: InternalsVisibleTo("SonarScanner.MSBuild.PreProcessor.Test")]
+#endif


### PR DESCRIPTION
Fixes #1369 

It works with this Java counterpart:
```java
  @Test
  public void fixme() throws Throwable {
    assertThat(contentHash("EmptyWithBom.cs")).isEqualTo("f1945cd6c19e56b3c1c78943ef5ec18116907a4ca1efc40a57d48ab1db7adfc5");
    assertThat(contentHash("EmptyNoBom.cs")).isEqualTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
    assertThat(contentHash("CodeWithBom.cs")).isEqualTo("b98aaf2ce5a3f9cdf8ab785563951f2309d577baa6351098f78908300fdc610a");
    assertThat(contentHash("CodeNoBom.cs")).isEqualTo("8c7535a8e3679bf8cc241b5749cef5fc38243401556f2b7869495c7b48ee4980");
    assertThat(contentHash("Utf8.cs")).isEqualTo("13aa54e315a806270810f3a91501f980a095a2ef1bcc53167d4c750a1b78684d");
    assertThat(contentHash("Utf16.cs")).isEqualTo("a9b3c4402770855d090ba4b49adeb5ad601cb3bbd6de18495302f45f242ef932");
    assertThat(contentHash("Ansi.cs")).isEqualTo("b965073262109da4f106cd90a5eeea025e2441c244af272537afa2cfb03c3ab8");
  }

  private String contentHash(String fileName) throws Throwable {
    MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
    byte[] content = Files.readAllBytes(Path.of("d:\\_Temp\\HashFiles\\", fileName));
    byte[] hash = sha256.digest(content);
    return bytesToHex(hash);
  }

  private static final byte[] HEX_ARRAY = "0123456789abcdef".getBytes(StandardCharsets.US_ASCII);

  private static String bytesToHex(byte[] bytes) {
    byte[] hexChars = new byte[bytes.length * 2];
    for (int i = 0; i < bytes.length; i++) {
      int v = bytes[i] & 0xFF; // FIXME: WTF?
      hexChars[i * 2] = HEX_ARRAY[v >>> 4];
      hexChars[i * 2 + 1] = HEX_ARRAY[v & 0x0F];
    }
    return new String(hexChars, StandardCharsets.UTF_8);
  }
```

The biggest pain is `bytesToHex` part 🤦‍♂️ 🤦‍♂️ 🤦‍♂️ 