### PR TITLE
Use Major instead of LatestMajor for roll-forward

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/RuntimeConfigTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/RuntimeConfigTest.java
@@ -48,7 +48,7 @@ public class RuntimeConfigTest {
       Config config = gson.fromJson(Files.newBufferedReader(runtimeConfigPath), Config.class);
       assertThat(config.runtimeOptions).isNotNull();
       assertThat(config.runtimeOptions.tfm).isEqualToIgnoringCase(suffixAndTfm.getValue());
-      assertThat(config.runtimeOptions.rollForward).isEqualToIgnoringCase("LatestMajor");
+      assertThat(config.runtimeOptions.rollForward).isEqualToIgnoringCase("Major");
     }
   }
 

--- a/src/SonarScanner.MSBuild/SonarScanner.MSBuild.csproj
+++ b/src/SonarScanner.MSBuild/SonarScanner.MSBuild.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>$(ScannerNetCoreVersion);$(ScannerNetFxVersion);$(ScannerNetVersion)</TargetFrameworks>
     <AssemblyName>SonarScanner.MSBuild</AssemblyName>
     <OutputType>Exe</OutputType>
-    <RollForward>LatestMajor</RollForward>
+    <RollForward>Major</RollForward>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">


### PR DESCRIPTION
Use `Major` so that the nearest version is rolled forward to, which for .NET 5 is .NET 6, so that .NET 7 isn't used instead, which [otherwise breaks the tool](https://community.sonarsource.com/t/dotnet-sonarscanner-fails-with-invalid-project-key-with-latest-net-6-sdk-on-linux/75845).

From [the docs](https://learn.microsoft.com/en-us/dotnet/core/versions/selection#values)

> Roll-forward to the next available higher major version, and lowest minor version, if requested major version is missing. If the requested major version is present, then the Minor policy is used.

I've tested the Regex causing the issue in a compiled-for-`net-7.0` application, and it works as expected. I think the underlying issue is an edge case of a .NET 5 application rolling forward to .NET 7.0 (which has had extensive changes to [Regular Expressions](https://devblogs.microsoft.com/dotnet/regular-expression-improvements-in-dotnet-7/)) without being recompiled.

To workaround this problem (which has taken us quite some time to get to the bottom of) which started with us rebuilding some Docker containers since .NET 7 was released, is to set the `DOTNET_ROLL_FORWARD: Major` environment variable and ensure that .NET 6 is installed.
