### PR TITLE
Align PreProcessor and PostProcessor names

### DIFF
--- a/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
@@ -34,7 +34,7 @@ using System.Linq;
 namespace SonarScanner.MSBuild.PostProcessor.Test
 {
     [TestClass]
-    public class MSBuildPostProcessorTests
+    public class PostProcessorTests
     {
         private const string CredentialsErrorMessage = "Credentials must be passed in both begin and end steps or not at all";
 
@@ -299,7 +299,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Test
             sonarProjectPropertiesValidator
                 .Setup(propValidator => propValidator.AreExistingSonarPropertiesFilesPresent(It.IsAny<string>(), It.IsAny<ICollection<ProjectData>>(), out expectedValue)).Returns(false);
 
-            var proc = new MSBuildPostProcessor(context.Scanner, context.Logger, context.TargetsUninstaller.Object, context.TfsProcessor, sonarProjectPropertiesValidator.Object);
+            var proc = new PostProcessor(context.Scanner, context.Logger, context.TargetsUninstaller.Object, context.TfsProcessor, sonarProjectPropertiesValidator.Object);
 
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
 
@@ -333,7 +333,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Test
             sonarProjectPropertiesValidator
                 .Setup(propValidator => propValidator.AreExistingSonarPropertiesFilesPresent(It.IsAny<string>(), It.IsAny<ICollection<ProjectData>>(), out expectedValue)).Returns(false);
 
-            var proc = new MSBuildPostProcessor(context.Scanner, context.Logger, context.TargetsUninstaller.Object, context.TfsProcessor, sonarProjectPropertiesValidator.Object);
+            var proc = new PostProcessor(context.Scanner, context.Logger, context.TargetsUninstaller.Object, context.TfsProcessor, sonarProjectPropertiesValidator.Object);
 
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, Guid.NewGuid().ToString());
 
@@ -363,7 +363,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Test
             var context = new PostProcTestContext(TestContext);
             var sonarProjectPropertiesValidator = new Mock<ISonarProjectPropertiesValidator>();
 
-            var proc = new MSBuildPostProcessor(context.Scanner, context.Logger, context.TargetsUninstaller.Object, context.TfsProcessor, sonarProjectPropertiesValidator.Object);
+            var proc = new PostProcessor(context.Scanner, context.Logger, context.TargetsUninstaller.Object, context.TfsProcessor, sonarProjectPropertiesValidator.Object);
             proc.Execute(args, config, settings);
         }
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
@@ -44,7 +44,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             // Arrange
             var mockServer = new MockSonarQubeServer();
-            var preprocessor = new TeamBuildPreProcessor(new MockObjectFactory(mockServer, Mock.Of<ITargetsInstaller>(), new MockRoslynAnalyzerProvider()), new TestLogger());
+            var preprocessor = new PreProcessor(new MockObjectFactory(mockServer, Mock.Of<ITargetsInstaller>(), new MockRoslynAnalyzerProvider()), new TestLogger());
 
             // Act and assert
             Func<Task> act = async () => await preprocessor.Execute(null);
@@ -77,7 +77,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                 settings.Should().NotBeNull("Test setup error: TFS environment variables have not been set correctly");
                 settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild, "Test setup error: build environment was not set correctly");
 
-                var preProcessor = new TeamBuildPreProcessor(mockFactory, logger);
+                var preProcessor = new PreProcessor(mockFactory, logger);
 
                 // Act
                 var success = await preProcessor.Execute(CreateArgs());
@@ -110,7 +110,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             using var teamBuildScope = PreprocessTestUtils.CreateValidNonTeamBuildScope();
             using var directoryScope = new WorkingDirectoryScope(workingDir);
-            var preProcessor = new TeamBuildPreProcessor(mockFactory, logger);
+            var preProcessor = new PreProcessor(mockFactory, logger);
 
             // Act
             var args = CreateArgs(properties: new Dictionary<string, string> { { SonarProperties.PullRequestBase, "BASE_BRANCH" } });
@@ -148,7 +148,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                 settings.Should().NotBeNull("Test setup error: TFS environment variables have not been set correctly");
                 settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild, "Test setup error: build environment was not set correctly");
 
-                var preProcessor = new TeamBuildPreProcessor(mockFactory, logger);
+                var preProcessor = new PreProcessor(mockFactory, logger);
 
                 // Act
                 var success = await preProcessor.Execute(CreateArgs());
@@ -193,7 +193,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                 settings.Should().NotBeNull("Test setup error: TFS environment variables have not been set correctly");
                 settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild, "Test setup error: build environment was not set correctly");
 
-                var preProcessor = new TeamBuildPreProcessor(mockFactory, logger);
+                var preProcessor = new PreProcessor(mockFactory, logger);
 
                 // Act
                 var success = await preProcessor.Execute(CreateArgs("organization"));
@@ -234,7 +234,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                 settings.Should().NotBeNull("Test setup error: TFS environment variables have not been set correctly");
                 settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild, "Test setup error: build environment was not set correctly");
 
-                var preProcessor = new TeamBuildPreProcessor(mockFactory, logger);
+                var preProcessor = new PreProcessor(mockFactory, logger);
 
                 // Act
                 var success = await preProcessor.Execute(CreateArgs());
@@ -274,7 +274,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                 settings.Should().NotBeNull("Test setup error: TFS environment variables have not been set correctly");
                 settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild, "Test setup error: build environment was not set correctly");
 
-                var preProcessor = new TeamBuildPreProcessor(mockFactory, logger);
+                var preProcessor = new PreProcessor(mockFactory, logger);
 
                 // Act
                 var success = await preProcessor.Execute(CreateArgs());
@@ -327,7 +327,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                 settings.Should().NotBeNull("Test setup error: TFS environment variables have not been set correctly");
                 settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild, "Test setup error: build environment was not set correctly");
 
-                var preProcessor = new TeamBuildPreProcessor(mockFactory, logger);
+                var preProcessor = new PreProcessor(mockFactory, logger);
 
                 // Act
                 var success = await preProcessor.Execute(CreateArgs());
@@ -359,7 +359,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var mockFactory = new MockObjectFactory(mockServer, new Mock<ITargetsInstaller>().Object, null);
             using (new WorkingDirectoryScope(workingDir))
             {
-                var preProcessor = new TeamBuildPreProcessor(mockFactory, logger);
+                var preProcessor = new PreProcessor(mockFactory, logger);
                 var success = await preProcessor.Execute(CreateArgs("InvalidOrganization"));    // Should not throw
                 success.Should().BeFalse("Expecting the pre-processing to fail");
                 mockServer.AnalysisExceptionThrown.Should().BeTrue();
@@ -407,7 +407,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                 settings.Should().NotBeNull("Test setup error: TFS environment variables have not been set correctly");
                 settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild, "Test setup error: build environment was not set correctly");
 
-                var preProcessor = new TeamBuildPreProcessor(mockFactory, logger);
+                var preProcessor = new PreProcessor(mockFactory, logger);
 
                 // Act
                 var success = await preProcessor.Execute(args);
@@ -547,7 +547,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             public bool AnalysisExceptionThrown { get; private set; }
 
             public Task<IEnumerable<string>> GetAllLanguages() =>
-                Task.FromResult(new[] { TeamBuildPreProcessor.CSharpLanguage, TeamBuildPreProcessor.VBNetLanguage }.AsEnumerable());
+                Task.FromResult(new[] { PreProcessor.CSharpLanguage, PreProcessor.VBNetLanguage }.AsEnumerable());
 
             public Task<IDictionary<string, string>> GetProperties(string projectKey, string projectBranch) =>
                 Task.FromResult<IDictionary<string, string>>(new Dictionary<string, string>());

--- a/Tests/SonarScanner.MSBuild.Test/AnalysisWarning/NetFrameworkBootstrapperClassTests.cs
+++ b/Tests/SonarScanner.MSBuild.Test/AnalysisWarning/NetFrameworkBootstrapperClassTests.cs
@@ -39,8 +39,8 @@ namespace SonarScanner.MSBuild.Test.AnalysisWarning
         private string rootDir;
         private string tempDir;
         private Mock<IProcessorFactory> mockProcessorFactory;
-        private Mock<ITeamBuildPreProcessor> mockPreProcessor;
-        private Mock<IMSBuildPostProcessor> mockPostProcessor;
+        private Mock<IPreProcessor> mockPreProcessor;
+        private Mock<IPostProcessor> mockPostProcessor;
         private Mock<IFrameworkVersionProvider> mockFrameworkVersionProvider;
 
         public TestContext TestContext { get; set; }
@@ -165,8 +165,8 @@ namespace SonarScanner.MSBuild.Test.AnalysisWarning
 
         private void MockProcessors(bool preProcessorOutcome, bool postProcessorOutcome)
         {
-            mockPreProcessor = new Mock<ITeamBuildPreProcessor>();
-            mockPostProcessor = new Mock<IMSBuildPostProcessor>();
+            mockPreProcessor = new Mock<IPreProcessor>();
+            mockPostProcessor = new Mock<IPostProcessor>();
             mockPreProcessor.Setup(x => x.Execute(It.IsAny<string[]>())).Returns(Task.FromResult(preProcessorOutcome));
             mockPostProcessor.Setup(x => x.Execute(It.IsAny<string[]>(), It.IsAny<AnalysisConfig>(), It.IsAny<ITeamBuildSettings>())).Returns(postProcessorOutcome);
             mockProcessorFactory = new Mock<IProcessorFactory>();

--- a/Tests/SonarScanner.MSBuild.Test/BootstrapperClassTests.cs
+++ b/Tests/SonarScanner.MSBuild.Test/BootstrapperClassTests.cs
@@ -40,8 +40,8 @@ namespace SonarScanner.MSBuild.Test
         private string rootDir;
         private string tempDir;
         private Mock<IProcessorFactory> mockProcessorFactory;
-        private Mock<ITeamBuildPreProcessor> mockPreProcessor;
-        private Mock<IMSBuildPostProcessor> mockPostProcessor;
+        private Mock<IPreProcessor> mockPreProcessor;
+        private Mock<IPostProcessor> mockPostProcessor;
 
         public TestContext TestContext { get; set; }
 
@@ -66,8 +66,8 @@ namespace SonarScanner.MSBuild.Test
 
         private void MockProcessors(bool preProcessorOutcome, bool postProcessorOutcome)
         {
-            mockPreProcessor = new Mock<ITeamBuildPreProcessor>();
-            mockPostProcessor = new Mock<IMSBuildPostProcessor>();
+            mockPreProcessor = new Mock<IPreProcessor>();
+            mockPostProcessor = new Mock<IPostProcessor>();
             mockPreProcessor.Setup(x => x.Execute(It.IsAny<string[]>())).Returns(Task.FromResult(preProcessorOutcome));
             mockPostProcessor.Setup(x => x.Execute(It.IsAny<string[]>(), It.IsAny<AnalysisConfig>(), It.IsAny<ITeamBuildSettings>())).Returns(postProcessorOutcome);
             mockProcessorFactory = new Mock<IProcessorFactory>();

--- a/Tests/SonarScanner.MSBuild.Test/DefaultProcessorFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.Test/DefaultProcessorFactoryTests.cs
@@ -18,26 +18,21 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarScanner.MSBuild;
-using SonarScanner.MSBuild.PostProcessor;
-using SonarScanner.MSBuild.PreProcessor;
 using TestUtilities;
 
 namespace SonarScanner.MSBuild.Test
 {
     [TestClass]
     public class DefaultProcessorFactoryTests
-    { 
+    {
         [TestMethod]
         public void CreatePreProcessor_Returns_New_Instance()
         {
             var factory = new DefaultProcessorFactory(
                 new TestLogger());
-
-            factory.CreatePreProcessor().Should().BeOfType<TeamBuildPreProcessor>();
+            factory.CreatePreProcessor().Should().BeOfType<PreProcessor.PreProcessor>();
         }
 
         [TestMethod]
@@ -46,7 +41,7 @@ namespace SonarScanner.MSBuild.Test
             var factory = new DefaultProcessorFactory(
                 new TestLogger());
 
-            factory.CreatePostProcessor().Should().BeOfType<MSBuildPostProcessor>();
+            factory.CreatePostProcessor().Should().BeOfType<PostProcessor.PostProcessor>();
         }
     }
 }

--- a/src/SonarScanner.MSBuild.PostProcessor/Interfaces/IPostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/Interfaces/IPostProcessor.cs
@@ -23,7 +23,7 @@ using SonarScanner.MSBuild.Common.Interfaces;
 
 namespace SonarScanner.MSBuild.PostProcessor.Interfaces
 {
-    public interface IMSBuildPostProcessor
+    public interface IPostProcessor
     {
         bool Execute(string[] args, AnalysisConfig config, ITeamBuildSettings settings);
     }

--- a/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
@@ -30,7 +30,7 @@ using SonarScanner.MSBuild.Shim.Interfaces;
 
 namespace SonarScanner.MSBuild.PostProcessor
 {
-    public class MSBuildPostProcessor : IMSBuildPostProcessor
+    public class PostProcessor : IPostProcessor
     {
         private const string scanAllFiles = "-Dsonar.scanAllFiles=true";
 
@@ -42,7 +42,7 @@ namespace SonarScanner.MSBuild.PostProcessor
 
         private IPropertiesFileGenerator propertiesFileGenerator;
 
-        public MSBuildPostProcessor(ISonarScanner sonarScanner, ILogger logger, ITargetsUninstaller targetUninstaller, ITfsProcessor tfsProcessor,
+        public PostProcessor(ISonarScanner sonarScanner, ILogger logger, ITargetsUninstaller targetUninstaller, ITfsProcessor tfsProcessor,
             ISonarProjectPropertiesValidator sonarProjectPropertiesValidator)
         {
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IPreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IPreProcessor.cs
@@ -23,7 +23,7 @@ using System.Threading.Tasks;
 
 namespace SonarScanner.MSBuild.PreProcessor
 {
-    public interface ITeamBuildPreProcessor
+    public interface IPreProcessor
     {
         Task<bool> Execute(IEnumerable<string> args);
     }

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -29,7 +29,7 @@ using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild.PreProcessor
 {
-    public sealed class TeamBuildPreProcessor : ITeamBuildPreProcessor
+    public sealed class PreProcessor : IPreProcessor
     {
         public const string CSharpLanguage = "cs";
         public const string VBNetLanguage = "vbnet";
@@ -39,7 +39,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         private readonly IPreprocessorObjectFactory factory;
         private readonly ILogger logger;
 
-        public TeamBuildPreProcessor(IPreprocessorObjectFactory factory, ILogger logger)
+        public PreProcessor(IPreprocessorObjectFactory factory, ILogger logger)
         {
             this.factory = factory ?? throw new ArgumentNullException(nameof(factory));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));

--- a/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
+++ b/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
@@ -35,9 +35,9 @@ namespace SonarScanner.MSBuild
             this.logger = logger;
         }
 
-        public IMSBuildPostProcessor CreatePostProcessor()
+        public IPostProcessor CreatePostProcessor()
         {
-            return new MSBuildPostProcessor(
+            return new PostProcessor.PostProcessor(
                 new SonarScannerWrapper(logger),
                 logger,
                 new TargetsUninstaller(logger),
@@ -45,9 +45,9 @@ namespace SonarScanner.MSBuild
                 new SonarProjectPropertiesValidator());
         }
 
-        public ITeamBuildPreProcessor CreatePreProcessor()
+        public IPreProcessor CreatePreProcessor()
         {
-            return new TeamBuildPreProcessor(new PreprocessorObjectFactory(logger), logger);
+            return new PreProcessor.PreProcessor(new PreprocessorObjectFactory(logger), logger);
         }
     }
 }

--- a/src/SonarScanner.MSBuild/Interfaces/IProcessorFactory.cs
+++ b/src/SonarScanner.MSBuild/Interfaces/IProcessorFactory.cs
@@ -25,8 +25,8 @@ namespace SonarScanner.MSBuild
 {
     public interface IProcessorFactory
     {
-        IMSBuildPostProcessor CreatePostProcessor();
+        IPostProcessor CreatePostProcessor();
 
-        ITeamBuildPreProcessor CreatePreProcessor();
+        IPreProcessor CreatePreProcessor();
     }
 }


### PR DESCRIPTION
Names were messy and hard to navigate.

`TeamBuildPreProcessor` was tested in `PreProcessorTests` and had a counterpart of `MSBuildPostProcessor`

I'm intentionally not fixing the codesmells or coverage. We'll need few PRs for the new code period before release on that