### PR TITLE
Incremental PR analysis: Produce deterministic base path

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/SonarPropertiesTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/SonarPropertiesTests.cs
@@ -31,7 +31,7 @@ namespace SonarScanner.MSBuild.Common.Test
         /// <summary>
         /// Strings that are used to indicate arguments that contain non sensitive data.
         /// </summary>
-        private static readonly IEnumerable<string> NonSensitivePropertyKeys = new []
+        private static readonly IEnumerable<string> NonSensitivePropertyKeys = new[]
         {
             SonarProperties.ClientCertPath,
             SonarProperties.HostUrl,
@@ -43,6 +43,7 @@ namespace SonarScanner.MSBuild.Common.Test
             SonarProperties.ProjectName,
             SonarProperties.ProjectVersion,
             SonarProperties.PullRequestBase,
+            SonarProperties.PullRequestCacheBasePath,
             SonarProperties.SourceEncoding,
             SonarProperties.Verbose,
             SonarProperties.VsCoverageXmlReportsPaths,

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Test/Infrastructure/MockBuildSettings.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Test/Infrastructure/MockBuildSettings.cs
@@ -44,5 +44,7 @@ namespace SonarScanner.MSBuild.PostProcessor.Test
         public string SonarBinDirectory { get; set; }
 
         public string AnalysisConfigFilePath { get; set; }
+
+        public string SonarScannerWorkingDirectory { get; set; }
     }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
@@ -132,6 +132,19 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             sut.PullRequestCacheBasePath.Should().Be(null);
         }
 
+        [DataTestMethod]
+        [DataRow("", null)]
+        [DataRow(null, "")]
+        public void PullRequestCacheBasePath_EmptyDirectories_IsNull(string sourcesDirectory, string sonarScannerWorkingDirectory)
+        {
+            var buildSettings = new Mock<IBuildSettings>();
+            buildSettings.SetupGet(x => x.SourcesDirectory).Returns(sourcesDirectory);
+            buildSettings.SetupGet(x => x.SonarScannerWorkingDirectory).Returns(sonarScannerWorkingDirectory);
+            using var sut = new CacheProcessor(Mock.Of<ISonarQubeServer>(), CreateProcessedArgs(), buildSettings.Object, Mock.Of<ILogger>());
+
+            sut.PullRequestCacheBasePath.Should().Be(null);
+        }
+
         private static string CreateFile(string root, string fileName, string content, Encoding encoding)
         {
             var path = Path.Combine(root, fileName);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
@@ -78,6 +78,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             var config = AssertAnalysisConfig(settings.AnalysisConfigFilePath, 2, factory.Logger);
             config.SonarQubeVersion.Should().Be("1.2.3.4");
+            config.GetConfigValue(SonarProperties.PullRequestCacheBasePath, null).Should().Be(Path.GetDirectoryName(scope.WorkingDir));
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesWriterTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesWriterTest.cs
@@ -289,7 +289,6 @@ sonar.modules=
 @"sonar.projectKey=
 sonar.working.directory=C:\\OutputDir\\CannotBeEmpty\\.sonar
 sonar.projectBaseDir=C:\\ProjectBaseDir
-sonar.pullrequest.cache.basepath=
 sonar.modules=
 
 ".Replace("\n", "\r\n"));

--- a/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesWriterTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesWriterTest.cs
@@ -275,7 +275,7 @@ sonar.projectBaseDir=C:\\ProjectBaseDir
 sonar.pullrequest.cache.basepath=C:\\PullRequest\\Cache\\BasePath
 sonar.modules=
 
-".Replace("\n", "\r\n"));
+");
         }
 
         [TestMethod]
@@ -289,9 +289,10 @@ sonar.modules=
 @"sonar.projectKey=
 sonar.working.directory=C:\\OutputDir\\CannotBeEmpty\\.sonar
 sonar.projectBaseDir=C:\\ProjectBaseDir
+sonar.pullrequest.cache.basepath=
 sonar.modules=
 
-".Replace("\n", "\r\n"));
+");
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.TFS.Test/Infrastructure/MockBuildSettings.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/Infrastructure/MockBuildSettings.cs
@@ -46,6 +46,7 @@ namespace SonarScanner.MSBuild.TFS.Tests.Infrastructure
         public string SonarBinDirectory { get; set; }
 
         public string AnalysisConfigFilePath { get; set; }
+
+        public string SonarScannerWorkingDirectory { get; set; }
     }
 }
-

--- a/src/SonarScanner.MSBuild.Common/Interfaces/IBuildSettings.cs
+++ b/src/SonarScanner.MSBuild.Common/Interfaces/IBuildSettings.cs
@@ -34,5 +34,6 @@ namespace SonarScanner.MSBuild.Common.Interfaces
         string SonarOutputDirectory { get; }
         string SonarBinDirectory { get; }
         string AnalysisConfigFilePath { get; }
+        string SonarScannerWorkingDirectory { get; }
     }
 }

--- a/src/SonarScanner.MSBuild.Common/SonarProperties.cs
+++ b/src/SonarScanner.MSBuild.Common/SonarProperties.cs
@@ -46,6 +46,7 @@ namespace SonarScanner.MSBuild.Common
 
         public const string ProjectBaseDir = "sonar.projectBaseDir";
         public const string PullRequestBase = "sonar.pullrequest.base";
+        public const string PullRequestCacheBasePath = "sonar.pullrequest.cache.basepath";
         public const string WorkingDirectory = "sonar.working.directory";
         public const string Verbose = "sonar.verbose";
         public const string LogLevel = "sonar.log.level";

--- a/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
@@ -35,6 +35,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         private readonly IBuildSettings buildSettings;
         private readonly HashAlgorithm sha256 = new SHA256Managed();
 
+        public string PullRequestCacheBasePath { get; }
         public string UnchangedFilesPath { get; private set; }
 
         public CacheProcessor(ISonarQubeServer server, ProcessedArgs localSettings, IBuildSettings buildSettings, ILogger logger)
@@ -43,6 +44,10 @@ namespace SonarScanner.MSBuild.PreProcessor
             this.localSettings = localSettings ?? throw new ArgumentNullException(nameof(localSettings));
             this.buildSettings = buildSettings ?? throw new ArgumentNullException(nameof(buildSettings));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            if (localSettings.GetSetting(SonarProperties.ProjectBaseDir, buildSettings.SourcesDirectory ?? buildSettings.SonarScannerWorkingDirectory) is { } path)
+            {
+                PullRequestCacheBasePath = Path.GetFullPath(path);
+            }
         }
 
         public async Task Execute()

--- a/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
@@ -23,6 +23,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using SonarScanner.MSBuild.Common;
+using SonarScanner.MSBuild.Common.Interfaces;
 
 namespace SonarScanner.MSBuild.PreProcessor
 {
@@ -30,15 +31,17 @@ namespace SonarScanner.MSBuild.PreProcessor
     {
         private readonly ILogger logger;
         private readonly ISonarQubeServer server;
-        private readonly ProcessedArgs settings;
+        private readonly ProcessedArgs localSettings;
+        private readonly IBuildSettings buildSettings;
         private readonly HashAlgorithm sha256 = new SHA256Managed();
 
-        public string UnchangedFilesPath { get; }
+        public string UnchangedFilesPath { get; private set; }
 
-        public CacheProcessor(ISonarQubeServer server, ProcessedArgs settings, ILogger logger)
+        public CacheProcessor(ISonarQubeServer server, ProcessedArgs localSettings, IBuildSettings buildSettings, ILogger logger)
         {
             this.server = server ?? throw new ArgumentNullException(nameof(server));
-            this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            this.localSettings = localSettings ?? throw new ArgumentNullException(nameof(localSettings));
+            this.buildSettings = buildSettings ?? throw new ArgumentNullException(nameof(buildSettings));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
@@ -44,10 +44,13 @@ namespace SonarScanner.MSBuild.PreProcessor
             this.localSettings = localSettings ?? throw new ArgumentNullException(nameof(localSettings));
             this.buildSettings = buildSettings ?? throw new ArgumentNullException(nameof(buildSettings));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            if (localSettings.GetSetting(SonarProperties.ProjectBaseDir, buildSettings.SourcesDirectory ?? buildSettings.SonarScannerWorkingDirectory) is { } path)
+            if (localSettings.GetSetting(SonarProperties.ProjectBaseDir, NullWhenEmpty(buildSettings.SourcesDirectory) ?? NullWhenEmpty(buildSettings.SonarScannerWorkingDirectory)) is { } path)
             {
                 PullRequestCacheBasePath = Path.GetFullPath(path);
             }
+
+            static string NullWhenEmpty(string value) =>
+                value == string.Empty ? null : value;
         }
 
         public async Task Execute()

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -127,7 +127,10 @@ namespace SonarScanner.MSBuild.PreProcessor
             await cache.Execute();
 
             var version = await server.GetServerVersion();
-            var additionalSettings = new Dictionary<string, string> { { nameof(cache.UnchangedFilesPath), cache.UnchangedFilesPath } };
+            var additionalSettings = new Dictionary<string, string> {
+                { nameof(cache.UnchangedFilesPath), cache.UnchangedFilesPath },
+                { SonarProperties.PullRequestCacheBasePath, cache.PullRequestCacheBasePath }
+            };
             AnalysisConfigGenerator.GenerateFile(localSettings, buildSettings, additionalSettings, argumentsAndRuleSets.ServerSettings, argumentsAndRuleSets.AnalyzersSettings, version.ToString());
 
             return true;

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -62,14 +62,14 @@ namespace SonarScanner.MSBuild.PreProcessor
             }
         }
 
-        private async Task<bool> DoExecute(ProcessedArgs settings)
+        private async Task<bool> DoExecute(ProcessedArgs localSettings)
         {
-            Debug.Assert(settings != null, "Not expecting the process arguments to be null");
+            Debug.Assert(localSettings != null, "Not expecting the process arguments to be null");
 
-            this.logger.Verbosity = VerbosityCalculator.ComputeVerbosity(settings.AggregateProperties, this.logger);
+            this.logger.Verbosity = VerbosityCalculator.ComputeVerbosity(localSettings.AggregateProperties, this.logger);
             logger.ResumeOutput();
 
-            InstallLoaderTargets(settings);
+            InstallLoaderTargets(localSettings);
 
             var buildSettings = BuildSettings.GetSettingsFromEnvironment(logger);
 
@@ -87,7 +87,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                 return false;
             }
 
-            var server = factory.CreateSonarQubeServer(settings);
+            var server = factory.CreateSonarQubeServer(localSettings);
 
             // TODO: fail fast after release of S4NET 6.0
             // Deprecation notice for SQ < 7.9
@@ -97,7 +97,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             {
                 if (!await server.IsServerLicenseValid())
                 {
-                    logger.LogError(Resources.ERR_UnlicensedServer, settings.SonarQubeUrl);
+                    logger.LogError(Resources.ERR_UnlicensedServer, localSettings.SonarQubeUrl);
                     return false;
                 }
             }
@@ -107,14 +107,14 @@ namespace SonarScanner.MSBuild.PreProcessor
                 return false;
             }
 
-            var argumentsAndRuleSets = await FetchArgumentsAndRuleSets(server, settings, buildSettings);
+            var argumentsAndRuleSets = await FetchArgumentsAndRuleSets(server, localSettings, buildSettings);
             if (!argumentsAndRuleSets.IsSuccess)
             {
                 return false;
             }
             Debug.Assert(argumentsAndRuleSets.AnalyzersSettings != null, "Not expecting the analyzers settings to be null");
 
-            if (PullRequestBaseBranch(settings) is { } baseBranch)
+            if (PullRequestBaseBranch(localSettings) is { } baseBranch)
             {
                 logger.LogInfo(Resources.MSG_Processing_PullRequest_Branch, baseBranch);
             }
@@ -123,12 +123,12 @@ namespace SonarScanner.MSBuild.PreProcessor
                 logger.LogDebug(Resources.MSG_Processing_PullRequest_NoBranch);
             }
 
-            using var cache = new CacheProcessor(server, settings, logger);
+            using var cache = new CacheProcessor(server, localSettings, buildSettings, logger);
             await cache.Execute();
 
             var version = await server.GetServerVersion();
             var additionalSettings = new Dictionary<string, string> { { nameof(cache.UnchangedFilesPath), cache.UnchangedFilesPath } };
-            AnalysisConfigGenerator.GenerateFile(settings, buildSettings, additionalSettings, argumentsAndRuleSets.ServerSettings, argumentsAndRuleSets.AnalyzersSettings, version.ToString());
+            AnalysisConfigGenerator.GenerateFile(localSettings, buildSettings, additionalSettings, argumentsAndRuleSets.ServerSettings, argumentsAndRuleSets.AnalyzersSettings, version.ToString());
 
             return true;
         }

--- a/src/SonarScanner.MSBuild.Shim/PropertiesWriter.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesWriter.cs
@@ -234,6 +234,7 @@ namespace SonarScanner.MSBuild.Shim
             AppendKeyValueIfNotEmpty(SonarProperties.ProjectVersion, config.SonarProjectVersion);
             AppendKeyValue(SonarProperties.WorkingDirectory, Path.Combine(config.SonarOutputDir, ".sonar"));
             AppendKeyValue(SonarProperties.ProjectBaseDir, projectBaseDir.FullName);
+            AppendKeyValue(SonarProperties.PullRequestCacheBasePath, config.GetConfigValue(SonarProperties.PullRequestCacheBasePath, null));
         }
 
         public void WriteSharedFiles(IEnumerable<FileInfo> sharedFiles)


### PR DESCRIPTION
Prerequisite for #1387 

The key inside the cache needs to be a relative path. 
We need to compute a common base path for S4NET and Java plugin. This value must be computed during `begin` step and passed along to the Scanner CLI.

In the best case scenario, we would use result of [ComputeProjectBaseDir](https://github.com/SonarSource/sonar-scanner-msbuild/blob/92ff75959987f61890032eda123fd4f689bf6561/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs#L224), but that one is computed during `end` step from data collected during the build - too late. We need path that is available during `begin` step. 