### PR TITLE
Add Google.Protobuf to packaging

### DIFF
--- a/scripts/package-artifacts.ps1
+++ b/scripts/package-artifacts.ps1
@@ -29,6 +29,8 @@ function Package-NetScanner([string]$sourcetfm, [string]$targettfm)
     Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild\bin\Release\$sourcetfm\SonarScanner.MSBuild.PreProcessor.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm"
     Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild\bin\Release\$sourcetfm\SonarScanner.MSBuild.runtimeconfig.json" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm"
     Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild\bin\Release\$sourcetfm\SonarScanner.MSBuild.Shim.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm"
+    # Take files from netcoreapp3.1 because they are not present in netcoreapp2.1 bin directory
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild\bin\Release\netcoreapp3.1\Google.Protobuf.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm"
     Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild\bin\Release\netcoreapp3.1\Newtonsoft.Json.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm"
     Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\bin\Release\netstandard2.0\SonarScanner.MSBuild.Tasks.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm"
     [System.IO.Compression.ZipFile]::ExtractToDirectory("$scannerCliDownloadDir\$scannerCliArtifact", "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm")


### PR DESCRIPTION
Follow up of #1384
Prerequisite for #1398

CI run without these changes failed: https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=57479&view=results
CI run with these changes worked: https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=57501&view=results
