### PR TITLE
Fix SonarWebService disposing

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockSonarQubeServer.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockSonarQubeServer.cs
@@ -146,5 +146,10 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
         private void LogMethodCalled([CallerMemberName] string methodName = null) =>
             calledMethods.Add(methodName);
+
+        public void Dispose()
+        {
+            // Nothing needed
+        }
     }
 }

--- a/src/SonarScanner.MSBuild.Common/Utilities.cs
+++ b/src/SonarScanner.MSBuild.Common/Utilities.cs
@@ -222,18 +222,6 @@ namespace SonarScanner.MSBuild.Common
             logger.LogInfo("{0} {1}", description, ScannerVersion);
         }
 
-        /// <summary>
-        /// Disposes the supplied object if it can be disposed. Null objects are ignored.
-        /// </summary>
-        public static void SafeDispose(object instance)
-        {
-            if (instance != null)
-            {
-                var disposable = instance as IDisposable;
-                disposable?.Dispose();
-            }
-        }
-
         public static string ToDisplayString(this Version version)
         {
             var sb = new StringBuilder();

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarQubeServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarQubeServer.cs
@@ -29,7 +29,7 @@ namespace SonarScanner.MSBuild.PreProcessor
     /// <summary>
     /// Provides an abstraction for the interactions with the SonarQube server
     /// </summary>
-    public interface ISonarQubeServer
+    public interface ISonarQubeServer : IDisposable
     {
         /// <summary>
         /// Retrieves rules from the quality profile with the given ID, including their parameters and template keys.

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -82,7 +82,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                 return false;
             }
 
-            var server = factory.CreateSonarQubeServer(localSettings);
+            using var server = factory.CreateSonarQubeServer(localSettings);
             // ToDo: Fail fast after release of S4NET 6.0
             await server.WarnIfSonarQubeVersionIsDeprecated();  // Deprecation notice for SQ < 7.9
             try
@@ -193,10 +193,6 @@ namespace SonarScanner.MSBuild.PreProcessor
                 }
 
                 throw;
-            }
-            finally
-            {
-                Utilities.SafeDispose(server);
             }
 
             argumentsAndRuleSets.IsSuccess = true;

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarWebService.cs
@@ -32,7 +32,7 @@ using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
 
 namespace SonarScanner.MSBuild.PreProcessor
 {
-    public sealed class SonarWebService : ISonarQubeServer, IDisposable
+    public sealed class SonarWebService : ISonarQubeServer
     {
         private const string oldDefaultProjectTestPattern = @"[^\\]*test[^\\]*$";
         private readonly Uri serverUri;
@@ -454,7 +454,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             {
                 if (disposing)
                 {
-                    Utilities.SafeDispose(downloader);
+                    downloader.Dispose();
                 }
 
                 disposedValue = true;


### PR DESCRIPTION
Issue from ITs:
```
16:17:43.319  Processing analysis cache
16:17:43.319  Processing pull request with base branch 'base-branch'.
16:17:43.32  Downloading cache. Project key: incremental-pr-analysis, branch: base-branch.
16:17:43.321  Downloading from http://127.0.0.1:59878/api/analysis_cache/get?project=incremental-pr-analysis&branch=base-branch...

Unhandled Exception: System.AggregateException: One or more errors occurred. ---> System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Net.Http.HttpClient'.
   at System.Net.Http.HttpClient.CheckDisposed()
   at System.Net.Http.HttpClient.SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.GetAsync(Uri requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken)
   at SonarScanner.MSBuild.PreProcessor.WebClientDownloader.<DownloadStream>d__7.MoveNext()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at SonarScanner.MSBuild.PreProcessor.SonarWebService.<>c.<DownloadCache>b__16_0(Task`1 x)
   at System.Threading.Tasks.ContinuationResultTaskFromResultTask`2.InnerInvoke()
   at System.Threading.Tasks.Task.Execute()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at SonarScanner.MSBuild.PreProcessor.CacheProcessor.<Execute>d__13.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at SonarScanner.MSBuild.PreProcessor.PreProcessor.<DoExecute>d__7.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at SonarScanner.MSBuild.PreProcessor.PreProcessor.<Execute>d__6.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at SonarScanner.MSBuild.BootstrapperClass.<PreProcess>d__10.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at SonarScanner.MSBuild.BootstrapperClass.<Execute>d__8.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at SonarScanner.MSBuild.Program.<Execute>d__4.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at SonarScanner.MSBuild.Program.<Execute>d__3.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at SonarScanner.MSBuild.Program.<Main>d__2.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at SonarScanner.MSBuild.Program.<Main>(String[] args)
]

	at com.sonar.orchestrator.build.BuildRunner.run(BuildRunner.java:44)
	at com.sonar.orchestrator.Orchestrator.executeBuildInternal(Orchestrator.java:250)
	at com.sonar.orchestrator.Orchestrator.executeBuild(Orchestrator.java:230)
	at com.sonar.orchestrator.Orchestrator.executeBuild(Orchestrator.java:226)
	at com.sonar.it.scanner.msbuild.ScannerMSBuildTest.incrementalPrAnalysis_ProducesUnchangedFiles(ScannerMSBuildTest.java:927

```