### PR TITLE
Run the integration tests also on the latest release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -439,6 +439,14 @@ stages:
                 MSBUILD_PATH: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe"
                 PLATFORMTOOLSET: "v140"
                 WINDOWSSDKTARGET: "10.0.17763.0"
+              vs2022_latest:
+                SQ_VERSION: "LATEST_RELEASE"
+                SONAR_CFAMILYPLUGIN_VERSION: "LATEST_RELEASE"
+                SONAR_CSHARPPLUGIN_VERSION: "LATEST_RELEASE"
+                SONAR_VBNETPLUGIN_VERSION: "LATEST_RELEASE"
+                MSBUILD_PATH: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe"
+                PLATFORMTOOLSET: "v140"
+                WINDOWSSDKTARGET: "10.0.17763.0"
               vs2022_dev:
                 SQ_VERSION: "DEV"
                 SONAR_CFAMILYPLUGIN_VERSION: "LATEST_RELEASE"

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -956,7 +956,7 @@ public class ScannerMSBuildTest {
     Assume.assumeTrue(ORCHESTRATOR.getServer().version().isGreaterThanOrEquals(9, 4)); // Cache API was introduced in 9.4
 
     String projectKey = "incremental-pr-analysis";
-    String baseBranch = TestUtils.getMainBranchName(ORCHESTRATOR);
+    String baseBranch = TestUtils.getDefaultBranchName(ORCHESTRATOR);
     Path projectDir = TestUtils.projectDir(temp, "IncrementalPRAnalysis");
     // This is a temporary solution for uploading a valid cache.
     // The file was generated from https://github.com/SonarSource/sonar-dotnet/commit/28c1224aca62968fb52b0332d6f6b7ef3da11f2b commit.
@@ -984,8 +984,8 @@ public class ScannerMSBuildTest {
 
     assertTrue(result.isSuccess());
     assertThat(result.getLogs()).contains("Processing analysis cache");
-    assertThat(result.getLogs()).contains("Processing pull request with base branch 'main'.");
-    assertThat(result.getLogs()).contains("Downloading cache. Project key: incremental-pr-analysis, branch: main.");
+    assertThat(result.getLogs()).contains("Processing pull request with base branch '" + baseBranch + "'.");
+    assertThat(result.getLogs()).contains("Downloading cache. Project key: incremental-pr-analysis, branch: " + baseBranch + ".");
 
     Path buildDirectory = VstsUtils.isRunningUnderVsts() ? Path.of(VstsUtils.getEnvBuildDirectory()) : projectDir;
     Path expectedUnchangedFiles = buildDirectory.resolve(".sonarqube\\conf\\UnchangedFiles.txt");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/ScannerMSBuildTest.java
@@ -956,7 +956,7 @@ public class ScannerMSBuildTest {
     Assume.assumeTrue(ORCHESTRATOR.getServer().version().isGreaterThanOrEquals(9, 4)); // Cache API was introduced in 9.4
 
     String projectKey = "incremental-pr-analysis";
-    String baseBranch = "main";
+    String baseBranch = TestUtils.getMainBranchName(ORCHESTRATOR);
     Path projectDir = TestUtils.projectDir(temp, "IncrementalPRAnalysis");
     // This is a temporary solution for uploading a valid cache.
     // The file was generated from https://github.com/SonarSource/sonar-dotnet/commit/28c1224aca62968fb52b0332d6f6b7ef3da11f2b commit.

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -382,6 +382,14 @@ public class TestUtils {
       .getIssuesList();
   }
 
+  public static String getMainBranchName(Orchestrator orchestrator) {
+    if (orchestrator.getServer().version().isGreaterThanOrEquals(9, 8)) {
+      return "main";
+    } else {
+      return "master";
+    }
+  }
+
   static WsClient newWsClient(Orchestrator orchestrator) {
     return WsClientFactories.getDefault().newClient(HttpConnector.newBuilder()
       .url(orchestrator.getServer().getUrl())

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/TestUtils.java
@@ -382,12 +382,8 @@ public class TestUtils {
       .getIssuesList();
   }
 
-  public static String getMainBranchName(Orchestrator orchestrator) {
-    if (orchestrator.getServer().version().isGreaterThanOrEquals(9, 8)) {
-      return "main";
-    } else {
-      return "master";
-    }
+  public static String getDefaultBranchName(Orchestrator orchestrator) {
+    return orchestrator.getServer().version().isGreaterThanOrEquals(9, 8) ? "main" : "master";
   }
 
   static WsClient newWsClient(Orchestrator orchestrator) {


### PR DESCRIPTION
Currently the tests are run only on `7.9`, `8.9` and `DEV` but the latest release is also supported.