### PR TITLE
Moved from SHA256Managed to SHA256CryptoServiceProvider in CacheProvider to be FIPS compliant

### DIFF
--- a/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/CacheProcessor.cs
@@ -35,7 +35,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         private readonly ISonarWebService server;
         private readonly ProcessedArgs localSettings;
         private readonly IBuildSettings buildSettings;
-        private readonly HashAlgorithm sha256 = new SHA256Managed();
+        private readonly HashAlgorithm sha256 = new SHA256CryptoServiceProvider();
 
         public string PullRequestCacheBasePath { get; }
         public string UnchangedFilesPath { get; private set; }


### PR DESCRIPTION
Moved from SHA256Managed to SHA256CryptoServiceProvider in CacheProvider to be FIPS compliant, which was previously fixed in another area in #873 but was reintroduced as of 4.32

Fixes #873
