### PR TITLE
Use the dev version of sonar-dotnet (and fix the build)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -418,8 +418,8 @@ stages:
               vs2017_latest89:
                 SQ_VERSION: "LATEST_RELEASE[8.9]"
                 SONAR_CFAMILYPLUGIN_VERSION: "6.20.5.49286"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
-                SONAR_CSHARPPLUGIN_VERSION: "LATEST_RELEASE"
-                SONAR_VBNETPLUGIN_VERSION: "LATEST_RELEASE"
+                SONAR_CSHARPPLUGIN_VERSION: "DEV"
+                SONAR_VBNETPLUGIN_VERSION: "DEV"
                 MSBUILD_PATH: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe"
                 PLATFORMTOOLSET: "v140"
                 WINDOWSSDKTARGET: "10.0.17763.0"
@@ -427,8 +427,8 @@ stages:
               vs2019_latest79:
                 SQ_VERSION: "LATEST_RELEASE[7.9]"
                 SONAR_CFAMILYPLUGIN_VERSION: "6.3.0.11371"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
-                SONAR_CSHARPPLUGIN_VERSION: "LATEST_RELEASE"
-                SONAR_VBNETPLUGIN_VERSION: "LATEST_RELEASE"
+                SONAR_CSHARPPLUGIN_VERSION: "DEV"
+                SONAR_VBNETPLUGIN_VERSION: "DEV"
                 MSBUILD_PATH: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe"
                 PLATFORMTOOLSET: "v140"
                 WINDOWSSDKTARGET: "10.0.17763.0"
@@ -436,8 +436,8 @@ stages:
               vs2022_latest89:
                 SQ_VERSION: "LATEST_RELEASE[8.9]"
                 SONAR_CFAMILYPLUGIN_VERSION: "6.20.5.49286"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
-                SONAR_CSHARPPLUGIN_VERSION: "LATEST_RELEASE"
-                SONAR_VBNETPLUGIN_VERSION: "LATEST_RELEASE"
+                SONAR_CSHARPPLUGIN_VERSION: "DEV"
+                SONAR_VBNETPLUGIN_VERSION: "DEV"
                 MSBUILD_PATH: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe"
                 PLATFORMTOOLSET: "v140"
                 WINDOWSSDKTARGET: "10.0.17763.0"
@@ -445,8 +445,8 @@ stages:
               vs2022_latest:
                 SQ_VERSION: "LATEST_RELEASE"
                 SONAR_CFAMILYPLUGIN_VERSION: "LATEST_RELEASE"
-                SONAR_CSHARPPLUGIN_VERSION: "LATEST_RELEASE"
-                SONAR_VBNETPLUGIN_VERSION: "LATEST_RELEASE"
+                SONAR_CSHARPPLUGIN_VERSION: "DEV"
+                SONAR_VBNETPLUGIN_VERSION: "DEV"
                 MSBUILD_PATH: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe"
                 PLATFORMTOOLSET: "v140"
                 WINDOWSSDKTARGET: "10.0.17763.0"
@@ -454,8 +454,8 @@ stages:
               vs2022_dev:
                 SQ_VERSION: "DEV"
                 SONAR_CFAMILYPLUGIN_VERSION: "LATEST_RELEASE"
-                SONAR_CSHARPPLUGIN_VERSION: "LATEST_RELEASE"
-                SONAR_VBNETPLUGIN_VERSION: "LATEST_RELEASE"
+                SONAR_CSHARPPLUGIN_VERSION: "DEV"
+                SONAR_VBNETPLUGIN_VERSION: "DEV"
                 MSBUILD_PATH: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe"
                 PLATFORMTOOLSET: "v140"
                 WINDOWSSDKTARGET: "10.0.17763.0"

--- a/its/src/test/java/com/sonar/it/scanner/SonarScannerTestSuite.java
+++ b/its/src/test/java/com/sonar/it/scanner/SonarScannerTestSuite.java
@@ -42,8 +42,8 @@ public class SonarScannerTestSuite {
     .setEdition(Edition.DEVELOPER)
     .addPlugin(TestUtils.getMavenLocation("com.sonarsource.cpp", "sonar-cfamily-plugin", System.getProperty("sonar.cfamilyplugin.version", "LATEST_RELEASE")))
     .addPlugin(FileLocation.of(TestUtils.getCustomRoslynPlugin().toFile()))
-    .addPlugin(TestUtils.getMavenLocation("org.sonarsource.dotnet", "sonar-csharp-plugin", System.getProperty("sonar.csharpplugin.version", "LATEST_RELEASE")))
-    .addPlugin(TestUtils.getMavenLocation("org.sonarsource.dotnet", "sonar-vbnet-plugin", System.getProperty("sonar.vbnetplugin.version", "LATEST_RELEASE")))
+    .addPlugin(TestUtils.getMavenLocation("org.sonarsource.dotnet", "sonar-csharp-plugin", System.getProperty("sonar.csharpplugin.version", "DEV")))
+    .addPlugin(TestUtils.getMavenLocation("org.sonarsource.dotnet", "sonar-vbnet-plugin", System.getProperty("sonar.vbnetplugin.version", "DEV")))
     .activateLicense()
     .build();
 


### PR DESCRIPTION
The latest release of sonar-dotnet is failing the build on older versions of SonarQube (<9.4) because it doesn't check the caching API is available before using it.

I think it's preferable to validate against the DEV version (of sonar-dotnet) to find possible compatibility issues before releasing  sonar-dotnet analyzers.
