### PR TITLE
BUILD-2292 Use Vault

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,13 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Setup JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v2
-        env:
-          JF_ARTIFACTORY_1: ${{ secrets.REPOX_CLI_CONFIG_BUILD_PROMOTER_LT }}
+      - name: Setup JFrog
+        uses: SonarSource/jfrog-setup-wrapper@3.0.0-1
+        with:
+          artifactoryRoleSuffix: promoter
       - name: Get the version
         id: get_version
         run: |


### PR DESCRIPTION
* Use jfrog-setup-wrapper instead, that way the credentials are retrieved automatically from Vault and no longer Github

Fixes [BUILD-2292](https://sonarsource.atlassian.net/browse/BUILD-2292)

[BUILD-2292]: https://sonarsource.atlassian.net/browse/BUILD-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ