### PR TITLE
Verify Mend jar signature with SHA256 hash instead of checking for certificate pattern.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,7 +219,7 @@ stages:
                   Package-NetScanner "net5.0" "net5.0"
                 pwsh: true
             - powershell: .\scripts\Mend\Mend-Scan.ps1
-              condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+            #  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
               env:
                 JAVA_HOME_11_X64: '$(JAVA_HOME_11_X64)'
                 WS_PRODUCTNAME: '$(MEND_PRODUCTNAME)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,7 +219,7 @@ stages:
                   Package-NetScanner "net5.0" "net5.0"
                 pwsh: true
             - powershell: .\scripts\Mend\Mend-Scan.ps1
-              #condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+              condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
               env:
                 JAVA_HOME_11_X64: '$(JAVA_HOME_11_X64)'
                 WS_PRODUCTNAME: '$(MEND_PRODUCTNAME)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,7 +219,7 @@ stages:
                   Package-NetScanner "net5.0" "net5.0"
                 pwsh: true
             - powershell: .\scripts\Mend\Mend-Scan.ps1
-              condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+              #condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
               env:
                 JAVA_HOME_11_X64: '$(JAVA_HOME_11_X64)'
                 WS_PRODUCTNAME: '$(MEND_PRODUCTNAME)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,7 +219,7 @@ stages:
                   Package-NetScanner "net5.0" "net5.0"
                 pwsh: true
             - powershell: .\scripts\Mend\Mend-Scan.ps1
-            #  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+              condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
               env:
                 JAVA_HOME_11_X64: '$(JAVA_HOME_11_X64)'
                 WS_PRODUCTNAME: '$(MEND_PRODUCTNAME)'

--- a/scripts/Mend/Mend-Scan.ps1
+++ b/scripts/Mend/Mend-Scan.ps1
@@ -44,7 +44,7 @@ if (-Not $?) # if result is "jar is unsigned" exit code is false, otherwise it's
 }
 
 Write-Host "Download wss-unified-agent.jar.sha256 file"
-$shaPath=Join-Path $toolsPath "wss-unified-agent.jar.sha256"
+$shaPath = Join-Path $toolsPath "wss-unified-agent.jar.sha256"
 Invoke-WebRequest -Uri https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar.sha256 -OutFile $shaPath
 if (-Not (Test-Path -Path $shaPath)){
   Write-Host "wss-unified-agent.jar.sha256 file does not exist - cannot complete signature verification."

--- a/scripts/Mend/Mend-Scan.ps1
+++ b/scripts/Mend/Mend-Scan.ps1
@@ -35,21 +35,22 @@ for ($num = 1 ; $num -le $NUM_RETRIES ; $num++)
   }
 }
 
-Write-Host "Validating Mend agent certificate signature..."
-Write-Host "Download wss-unified-agent.jar.sha256 file"
-$shaPath=Join-Path $MendAgentPath "wss-unified-agent.jar.sha256"
-Invoke-WebRequest -Uri https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar.sha256 -OutFile $shaPath
-if (-Not (Test-Path -Path $shaPath)){
-  Write-Host "wss-unified-agent.jar.sha256 file does not exist - cannot complete signature verification."
-  exit 1
-}
-
+Write-Host "Validating Mend agent jar signature..."
 if (-Not (& "$env:JAVA_HOME_11_X64\bin\jarsigner.exe" -verify -strict -verbose $MendAgentPath |  Select-String -Pattern "jar verified." -CaseSensitive -Quiet))
 {
   Write-Host "wss-unified-agent.jar signature verification failed."
   exit 1
 }
 
+Write-Host "Download wss-unified-agent.jar.sha256 file"
+$shaPath=Join-Path $toolsPath "wss-unified-agent.jar.sha256"
+Invoke-WebRequest -Uri https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar.sha256 -OutFile $shaPath
+if (-Not (Test-Path -Path $shaPath)){
+  Write-Host "wss-unified-agent.jar.sha256 file does not exist - cannot complete signature verification."
+  exit 1
+}
+
+Write-Host "Validating Mend agent jar hash..."
 if (-Not (Get-Content $shaPath).split(" ")[0] -eq  (Get-FileHash $MendAgentPath).Hash)
 {
     Write-Host "Failed to verify jar hash".

--- a/scripts/Mend/Mend-Scan.ps1
+++ b/scripts/Mend/Mend-Scan.ps1
@@ -36,7 +36,13 @@ for ($num = 1 ; $num -le $NUM_RETRIES ; $num++)
 }
 
 Write-Host "Validating Mend agent certificate signature..."
-$cert = 'Signed by "CN=whitesource software inc, O=whitesource software inc, STREET=79 Madison Ave, L=New York, ST=New York, OID.2.5.4.17=10016, C=US"'
+Write-Host "Download wss-unified-agent.jar.sha256 file"
+Invoke-WebRequest -Uri https://unified-agent.s3.amazonaws.com/wss-unified-agent.jar.sha256 -OutFile $MendAgentPath
+$shaPath=Join-Path $MendAgentPath "wss-unified-agent.jar.sha256"
+if (-Not (Test-Path -Path $shaPath)){
+  Write-Host "wss-unified-agent.jar.sha256 file does not exist - cannot complete signature verification."
+  exit 1
+}
 if (-Not (& "$env:JAVA_HOME_11_X64\bin\jarsigner.exe" -verify -strict -verbose $MendAgentPath |  Select-String -Pattern $cert -CaseSensitive -Quiet)){
   Write-Host "wss-unified-agent.jar signature verification failed."
   exit 1

--- a/scripts/Mend/Mend-Scan.ps1
+++ b/scripts/Mend/Mend-Scan.ps1
@@ -36,7 +36,8 @@ for ($num = 1 ; $num -le $NUM_RETRIES ; $num++)
 }
 
 Write-Host "Validating Mend agent jar signature..."
-if (-Not (& "$env:JAVA_HOME_11_X64\bin\jarsigner.exe" -verify -strict -verbose $MendAgentPath |  Select-String -Pattern "jar verified." -CaseSensitive -Quiet))
+& "$env:JAVA_HOME_11_X64\bin\jarsigner.exe" -verify -strict -verbose $MendAgentPath
+if (-Not $?) # if result is "jar is unsigned" exit code is false, otherwise it's true.
 {
   Write-Host "wss-unified-agent.jar signature verification failed."
   exit 1


### PR DESCRIPTION
The pipeline is failing due to the way the mend jar verification is happening.
For more info see https://sonarsource.atlassian.net/browse/BUILD-2478.
For this PR I followed the same pattern with SC: https://github.com/SonarSource/sonarcloud-core/pull/4775/files

To see how mend run step will look like on master: https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=61727&view=results