### PR TITLE
Make RuntimeConfigTest part of a test suite

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/others/OthersTestSuite.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/others/OthersTestSuite.java
@@ -1,0 +1,31 @@
+/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+package com.sonar.it.scanner.msbuild.others;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+  RuntimeConfigTest.class
+})
+public class OthersTestSuite {
+}

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/others/RuntimeConfigTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/others/RuntimeConfigTest.java
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package com.sonar.it.scanner.msbuild.sonarqube;
+package com.sonar.it.scanner.msbuild.others;
 
 import com.google.gson.Gson;
 import java.io.IOException;
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,8 +34,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RuntimeConfigTest {
 
   @Test
-  public void TestRuntimConfigRollForward() throws IOException {
-    Map<String, String> releasedSuffixAndTfm  = new HashMap<String, String>() {{
+  public void TestRuntimeConfigRollForward() throws IOException {
+    Map<String, String> releasedSuffixAndTfm  = new HashMap<>() {{
       put("netcoreapp2.0", "netcoreapp2.1");
       put("netcoreapp3.0", "netcoreapp3.1");
       put("net5.0", "net5.0");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SonarQubeTestSuite.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SonarQubeTestSuite.java
@@ -29,7 +29,11 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(Suite.class)
-@SuiteClasses({CppTest.class, ScannerMSBuildTest.class, SQLServerTest.class})
+@SuiteClasses({
+  CppTest.class,
+  SQLServerTest.class,
+  ScannerMSBuildTest.class
+})
 public class SonarQubeTestSuite {
 
   @ClassRule


### PR DESCRIPTION
The test will not run yet on the CI. I've added an issue for the update: https://github.com/SonarSource/sonar-scanner-msbuild/issues/1477