### PR TITLE
Refactoring: organization field cleanup in SonarWebService

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockIDownloaderHelper.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockIDownloaderHelper.cs
@@ -1,4 +1,24 @@
-﻿using System;
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
 using Moq;
 
 namespace SonarScanner.MSBuild.PreProcessor.Test.Infrastructure

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockIDownloaderHelper.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockIDownloaderHelper.cs
@@ -5,65 +5,40 @@ namespace SonarScanner.MSBuild.PreProcessor.Test.Infrastructure
 {
     internal static class MockIDownloaderHelper
     {
-        /// <summary>
-        /// Create basic mocked instance of <see cref="IDownloader"/> with
-        /// </summary>
-        /// <returns>The mocked instance <see cref="IDownloader"/>.</returns>
         public static Mock<IDownloader> CreateMock()
         {
             var mock = new Mock<IDownloader>(MockBehavior.Strict);
             mock.Setup(x => x.Dispose());
-
             return mock;
         }
 
-        /// <summary>
-        /// Setup the <see cref="IDownloader.TryDownloadIfExists"/> method for the current mocked <see cref="IDownloader"/>.
-        /// </summary>
-        /// <param name="mock">The mocked <see cref="IDownloader"/>.</param>
-        /// <param name="requestUri"><see cref="Uri"/> of the request resource, if null, will match any url.</param>
-        /// <param name="response">Response content, if null, mocked response will be: <code>(false, null)</code></param>
-        /// <returns>The mocked <see cref="IDownloader"/>.</returns>
         public static Mock<IDownloader> SetupTryDownloadIfExists(this Mock<IDownloader> mock, Uri requestUri = null, string response = null)
         {
             if (requestUri is null)
             {
-                mock
-                    .Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>()))
+                mock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>()))
                     .ReturnsAsync(Tuple.Create(response != null, response));
             }
             else
             {
-                mock
-                    .Setup(x => x.TryDownloadIfExists(It.Is<Uri>(dlUri => dlUri == requestUri), It.IsAny<bool>()))
+                mock.Setup(x => x.TryDownloadIfExists(It.Is<Uri>(downloadUri => downloadUri == requestUri), It.IsAny<bool>()))
                     .ReturnsAsync(Tuple.Create(response != null, response));
             }
-
             return mock;
         }
 
-        /// <summary>
-        /// Setup the <see cref="IDownloader.Download"/> method for the current mocked <see cref="IDownloader"/>.
-        /// </summary>
-        /// <param name="mock">The mocked <see cref="IDownloader"/>.</param>
-        /// <param name="requestUri"><see cref="Uri"/> of the request resource, if null, will match any url.</param>
-        /// <param name="response">Response content, if null, mocked response will be: <code>(false, null)</code></param>
-        /// <returns>The mocked <see cref="IDownloader"/>.</returns>
         public static Mock<IDownloader> SetupDownload(this Mock<IDownloader> mock, Uri requestUri, string response)
         {
             if (requestUri is null)
             {
-                mock
-                    .Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>()))
+                mock.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>()))
                     .ReturnsAsync(response);
             }
             else
             {
-                mock
-                    .Setup(x => x.Download(It.Is<Uri>(dlUri => dlUri == requestUri), It.IsAny<bool>()))
+                mock.Setup(x => x.Download(It.Is<Uri>(downloadUri => downloadUri == requestUri), It.IsAny<bool>()))
                     .ReturnsAsync(response);
             }
-
             return mock;
         }
     }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockIDownloaderHelper.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockIDownloaderHelper.cs
@@ -34,31 +34,15 @@ namespace SonarScanner.MSBuild.PreProcessor.Test.Infrastructure
 
         public static Mock<IDownloader> SetupTryDownloadIfExists(this Mock<IDownloader> mock, Uri requestUri = null, string response = null)
         {
-            if (requestUri is null)
-            {
-                mock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>()))
-                    .ReturnsAsync(Tuple.Create(response != null, response));
-            }
-            else
-            {
-                mock.Setup(x => x.TryDownloadIfExists(It.Is<Uri>(downloadUri => downloadUri == requestUri), It.IsAny<bool>()))
-                    .ReturnsAsync(Tuple.Create(response != null, response));
-            }
+            mock.Setup(x => x.TryDownloadIfExists(It.Is<Uri>(downloadUri => requestUri == null || downloadUri == requestUri), It.IsAny<bool>()))
+                .ReturnsAsync(Tuple.Create(response != null, response));
             return mock;
         }
 
         public static Mock<IDownloader> SetupDownload(this Mock<IDownloader> mock, Uri requestUri, string response)
         {
-            if (requestUri is null)
-            {
-                mock.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>()))
-                    .ReturnsAsync(response);
-            }
-            else
-            {
-                mock.Setup(x => x.Download(It.Is<Uri>(downloadUri => downloadUri == requestUri), It.IsAny<bool>()))
-                    .ReturnsAsync(response);
-            }
+            mock.Setup(x => x.Download(It.Is<Uri>(downloadUri => requestUri == null || downloadUri == requestUri), It.IsAny<bool>()))
+                .ReturnsAsync(response);
             return mock;
         }
     }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockIDownloaderHelper.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockIDownloaderHelper.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Moq;
+
+namespace SonarScanner.MSBuild.PreProcessor.Test.Infrastructure
+{
+    internal static class MockIDownloaderHelper
+    {
+        /// <summary>
+        /// Create basic mocked instance of <see cref="IDownloader"/> with
+        /// </summary>
+        /// <returns>The mocked instance <see cref="IDownloader"/>.</returns>
+        public static Mock<IDownloader> CreateMock()
+        {
+            var mock = new Mock<IDownloader>(MockBehavior.Strict);
+            mock.Setup(x => x.Dispose());
+
+            return mock;
+        }
+
+        /// <summary>
+        /// Setup the <see cref="IDownloader.TryDownloadIfExists"/> method for the current mocked <see cref="IDownloader"/>.
+        /// </summary>
+        /// <param name="mock">The mocked <see cref="IDownloader"/>.</param>
+        /// <param name="requestUri"><see cref="Uri"/> of the request resource, if null, will match any url.</param>
+        /// <param name="response">Response content, if null, mocked response will be: <code>(false, null)</code></param>
+        /// <returns>The mocked <see cref="IDownloader"/>.</returns>
+        public static Mock<IDownloader> SetupTryDownloadIfExists(this Mock<IDownloader> mock, Uri requestUri = null, string response = null)
+        {
+            if (requestUri is null)
+            {
+                mock
+                    .Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>()))
+                    .ReturnsAsync(Tuple.Create(response != null, response));
+            }
+            else
+            {
+                mock
+                    .Setup(x => x.TryDownloadIfExists(It.Is<Uri>(dlUri => dlUri == requestUri), It.IsAny<bool>()))
+                    .ReturnsAsync(Tuple.Create(response != null, response));
+            }
+
+            return mock;
+        }
+
+        /// <summary>
+        /// Setup the <see cref="IDownloader.Download"/> method for the current mocked <see cref="IDownloader"/>.
+        /// </summary>
+        /// <param name="mock">The mocked <see cref="IDownloader"/>.</param>
+        /// <param name="requestUri"><see cref="Uri"/> of the request resource, if null, will match any url.</param>
+        /// <param name="response">Response content, if null, mocked response will be: <code>(false, null)</code></param>
+        /// <returns>The mocked <see cref="IDownloader"/>.</returns>
+        public static Mock<IDownloader> SetupDownload(this Mock<IDownloader> mock, Uri requestUri, string response)
+        {
+            if (requestUri is null)
+            {
+                mock
+                    .Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>()))
+                    .ReturnsAsync(response);
+            }
+            else
+            {
+                mock
+                    .Setup(x => x.Download(It.Is<Uri>(dlUri => dlUri == requestUri), It.IsAny<bool>()))
+                    .ReturnsAsync(response);
+            }
+
+            return mock;
+        }
+    }
+}

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
@@ -31,7 +31,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
     internal class MockObjectFactory : IPreprocessorObjectFactory
     {
         public TestLogger Logger { get; } = new();
-        public MockSonarWebService Server { get; } = new();
+        public MockSonarWebService Server { get; }
         public Mock<ITargetsInstaller> TargetsInstaller { get; } = new();
         public MockRoslynAnalyzerProvider AnalyzerProvider { get; } = new() { SettingsToReturn = new AnalyzerSettings { RulesetPath = "c:\\xxx.ruleset" } };
 
@@ -40,6 +40,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
         public MockObjectFactory(bool withDefaultRules = true, string organization = null)
         {
+            Server = new(organization);
+
             var data = Server.Data;
             data.ServerProperties.Add("server.key", "server value 1");
             data.Languages.Add("cs");

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockSonarWebService.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockSonarWebService.cs
@@ -32,6 +32,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 {
     internal class MockSonarWebService : ISonarWebService
     {
+        private readonly string organization;
         private readonly List<string> calledMethods = new();
         private readonly List<string> warnings = new();
 
@@ -47,6 +48,11 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                 LogMethodCalled();
                 return Data.SonarQubeVersion;
             }
+        }
+
+        public MockSonarWebService(string organization = null)
+        {
+            this.organization = organization;
         }
 
         public void AssertMethodCalled(string methodName, int callCount)
@@ -88,7 +94,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             return Task.FromResult(Data.ServerProperties);
         }
 
-        Task<Tuple<bool, string>> ISonarWebService.TryGetQualityProfile(string projectKey, string projectBranch, string organization, string language)
+        Task<Tuple<bool, string>> ISonarWebService.TryGetQualityProfile(string projectKey, string projectBranch, string language)
         {
             LogMethodCalled();
             TryGetQualityProfilePreprocessing();

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServiceTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServiceTest.cs
@@ -45,23 +45,27 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         private const string ProjectKey = "project-key";
         private const string ProjectBranch = "project-branch";
         private const string Token = "42";
+        private const string Organization = "org42";
+
+        private readonly TestDownloader downloader;
+        private readonly Uri uri;
+        private readonly Version version;
+        private readonly TestLogger logger;
 
         private SonarCloudWebService sut;
-        private TestDownloader downloader;
-        private Uri uri;
-        private string organization;
-        private Version version;
-        private TestLogger logger;
 
-        [TestInitialize]
-        public void Init()
+        public SonarCloudWebServiceTest()
         {
             downloader = new TestDownloader();
             uri = new Uri("http://myhost:222");
             version = new Version("5.6");
             logger = new TestLogger();
-            organization = "org42";
-            sut = new SonarCloudWebService(downloader, uri, version, logger, organization);
+        }
+
+        [TestInitialize]
+        public void Init()
+        {
+            sut = new SonarCloudWebService(downloader, uri, version, logger, Organization);
         }
 
         [TestCleanup]
@@ -75,7 +79,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [TestMethod]
         public void IsLicenseValid_IsSonarCloud_ShouldReturnTrue()
         {
-            sut = new SonarCloudWebService(downloader, uri, version, logger, organization);
+            sut = new SonarCloudWebService(downloader, uri, version, logger, Organization);
 
             sut.IsServerLicenseValid().Result.Should().BeTrue();
         }
@@ -83,7 +87,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [TestMethod]
         public void WarnIfDeprecated_ShouldNotWarn()
         {
-            sut = new SonarCloudWebService(downloader, uri, new Version("0.0.1"), logger, organization);
+            sut = new SonarCloudWebService(downloader, uri, new Version("0.0.1"), logger, Organization);
 
             logger.Warnings.Should().BeEmpty();
         }
@@ -145,7 +149,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [TestMethod]
         public void GetProperties_NullProjectKey_Throws()
         {
-            var testSubject = new SonarQubeWebService(new TestDownloader(), uri, version, logger, null);
+            var testSubject = new SonarCloudWebService(downloader, uri, version, logger, Organization);
             Action act = () => _ = testSubject.GetProperties(null, null).Result;
 
             act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("projectKey");
@@ -167,15 +171,14 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         [TestMethod]
-        [DataRow("", "", "", "", "Incremental PR analysis: ProjectKey parameter was not provided.")]
-        [DataRow("project", "", "", "", "Incremental PR analysis: Organization parameter was not provided.")]
-        [DataRow("project", "organization", "", "", "Incremental PR analysis: Base branch parameter was not provided.")]
-        [DataRow("project", "organization", "branch", "", "Incremental PR analysis: Token parameter was not provided.")]
-        [DataRow("project", "organization", "branch", "token", "Incremental PR analysis: CacheBaseUrl was not successfully retrieved.")]
-        public async Task DownloadCache_InvalidArguments(string projectKey, string organizationName, string branch, string token, string infoMessage)
+        [DataRow("", "", "", "Incremental PR analysis: ProjectKey parameter was not provided.")]
+        [DataRow("project", "", "", "Incremental PR analysis: Base branch parameter was not provided.")]
+        [DataRow("project", "branch", "", "Incremental PR analysis: Token parameter was not provided.")]
+        [DataRow("project", "branch", "token", "Incremental PR analysis: CacheBaseUrl was not successfully retrieved.")]
+        public async Task DownloadCache_InvalidArguments(string projectKey, string branch, string token, string infoMessage)
         {
-            sut = new SonarCloudWebService(MockIDownloader(), uri, version, logger, organizationName);
-            var localSettings = CreateLocalSettings(projectKey, branch, organizationName, token);
+            sut = new SonarCloudWebService(MockIDownloader(), uri, version, logger, Organization);
+            var localSettings = CreateLocalSettings(projectKey, branch, Organization, token);
 
             var res = await sut.DownloadCache(localSettings);
 
@@ -189,7 +192,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [DataRow("http://cacheBaseUrl:222/sonar/", "http://cacheBaseUrl:222/sonar/v1/sensor_cache/prepare_read?organization=org42&project=project-key&branch=project-branch")]
         public async Task DownloadCache_RequestUrl(string cacheBaseUrl, string cacheFullUrl)
         {
-            var organization = "org42";
+            const string organization = "org42";
             using var stream = new MemoryStream();
             var handler = MockHttpHandler(true, cacheFullUrl, "https://www.ephemeralUrl.com", Token, stream);
 
@@ -205,13 +208,12 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [TestMethod]
         public async Task DownloadCache_CacheHit()
         {
-            var organization = "org42";
             var cacheBaseUrl = "https://www.cacheBaseUrl.com";
-            var cacheFullUrl = "https://www.cacheBaseUrl.com/v1/sensor_cache/prepare_read?organization=org42&project=project-key&branch=project-branch";
+            var cacheFullUrl = $"https://www.cacheBaseUrl.com/v1/sensor_cache/prepare_read?organization={Organization}&project=project-key&branch=project-branch";
             using var stream = CreateCacheStream(new SensorCacheEntry { Key = "key", Data = ByteString.CopyFromUtf8("value") });
             var handler = MockHttpHandler(true, cacheFullUrl, "https://www.ephemeralUrl.com", Token, stream);
-            sut = new SonarCloudWebService(MockIDownloader(cacheBaseUrl), uri, version, logger, organization, handler.Object);
-            var localSettings = CreateLocalSettings(ProjectKey, ProjectBranch, organization, Token);
+            sut = new SonarCloudWebService(MockIDownloader(cacheBaseUrl), uri, version, logger, Organization, handler.Object);
+            var localSettings = CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token);
 
             var result = await sut.DownloadCache(localSettings);
 
@@ -224,14 +226,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [TestMethod]
         public async Task DownloadCache_ThrowException()
         {
-            var organization = "org42";
-            var cacheBaseUrl = "https://www.cacheBaseUrl.com";
-            var cacheFullUrl = "https://www.cacheBaseUrl.com/v1/sensor_cache/prepare_read?organization=org42&project=project-key&branch=project-branch";
+            const string cacheBaseUrl = "https://www.cacheBaseUrl.com";
+            var cacheFullUrl = $"https://www.cacheBaseUrl.com/v1/sensor_cache/prepare_read?organization={Organization}&project=project-key&branch=project-branch";
 
             using var stream = new MemoryStream(new byte[] { 42, 42 }); // this is a random byte array that fails deserialization
             var handler = MockHttpHandler(true, cacheFullUrl, "https://www.ephemeralUrl.com", Token, stream);
-            sut = new SonarCloudWebService(MockIDownloader(cacheBaseUrl), uri, version, logger, organization, handler.Object);
-            var localSettings = CreateLocalSettings(ProjectKey, ProjectBranch, organization, Token);
+            sut = new SonarCloudWebService(MockIDownloader(cacheBaseUrl), uri, version, logger, Organization, handler.Object);
+            var localSettings = CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token);
 
             var result = await sut.DownloadCache(localSettings);
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServiceTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServiceTest.cs
@@ -149,8 +149,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [TestMethod]
         public void GetProperties_NullProjectKey_Throws()
         {
-            var testSubject = new SonarCloudWebService(downloader, uri, version, logger, Organization);
-            Action act = () => _ = testSubject.GetProperties(null, null).Result;
+            sut = new SonarCloudWebService(downloader, uri, version, logger, Organization);
+            Action act = () => _ = sut.GetProperties(null, null).Result;
 
             act.Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("projectKey");
         }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServiceTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServiceTest.cs
@@ -135,7 +135,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             sut.IsServerLicenseValid().Result.Should().BeTrue();
         }
 
-
         [TestMethod]
         [DataRow("foo bar", "my org")]
         public async Task TryGetQualityProfile_OrganizationProfile_QualityProfileUrlContainsOrganization(string projectKey, string organization)
@@ -157,7 +156,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             result.Item1.Should().BeTrue();
             result.Item2.Should().Be(profileKey);
         }
-
 
         [TestMethod]
         [DataRow("foo bar", "my org")]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServiceTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServiceTest.cs
@@ -60,7 +60,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             downloader = new TestDownloader();
             version = new Version("9.9");
             logger = new TestLogger();
-            sut = new SonarWebServiceStub(downloader, uri, version, null, logger);
+            sut = new SonarWebServiceStub(downloader, uri, version, logger, null);
         }
 
         [TestCleanup]
@@ -70,15 +70,15 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [TestMethod]
         public void Ctor_Null_Throws()
         {
-            ((Func<SonarWebServiceStub>)(() => new SonarWebServiceStub(null, uri, version, null, logger))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("downloader");
-            ((Func<SonarWebServiceStub>)(() => new SonarWebServiceStub(downloader, null, version, null, logger))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("serverUri");
-            ((Func<SonarWebServiceStub>)(() => new SonarWebServiceStub(downloader, uri, null, null, logger))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("serverVersion");
+            ((Func<SonarWebServiceStub>)(() => new SonarWebServiceStub(null, uri, version, logger, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("downloader");
+            ((Func<SonarWebServiceStub>)(() => new SonarWebServiceStub(downloader, null, version, logger, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("serverUri");
+            ((Func<SonarWebServiceStub>)(() => new SonarWebServiceStub(downloader, uri, null, logger, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("serverVersion");
             ((Func<SonarWebServiceStub>)(() => new SonarWebServiceStub(downloader, uri, version, null, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("logger");
         }
 
         [TestMethod]
         public void Ctor_ServerUri_Should_EndWithSlash() =>
-            ((Func<SonarWebServiceStub>)(() => new SonarWebServiceStub(downloader, new Uri("https://www.sonarsource.com/sonarlint"), version, null, logger)))
+            ((Func<SonarWebServiceStub>)(() => new SonarWebServiceStub(downloader, new Uri("https://www.sonarsource.com/sonarlint"), version, logger, null)))
                 .Should()
                 .Throw<ArgumentException>()
                 .And.ParamName.Should().Be("serverUri");
@@ -107,7 +107,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             mockDownloader.Setup(x => x.Download(new Uri(serverUrl, "api/qualityprofiles/search?defaults=true&organization=ThisIsInvalidValue"), false)).Returns(Task.FromResult<string>(null));
             mockDownloader.Setup(x => x.Dispose());
 
-            sut = new SonarWebServiceStub(mockDownloader.Object, serverUrl, new Version("6.4"), "ThisIsInvalidValue", logger);
+            sut = new SonarWebServiceStub(mockDownloader.Object, serverUrl, new Version("6.4"), logger, "ThisIsInvalidValue");
             Action a = () => _ = sut.TryGetQualityProfile(ProjectKey, null, "cs").Result;
 
             a.Should().Throw<AggregateException>().WithMessage("One or more errors occurred.");
@@ -129,7 +129,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             mockDownloader
                 .Setup(x => x.TryDownloadIfExists(It.Is<Uri>(dlUri => dlUri == qualityProfileUri), It.IsAny<bool>()))
                 .ReturnsAsync(Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}"));
-            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), null, logger);
+            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), logger, null);
 
             var result = await sut.TryGetQualityProfile(projectKey, null, language);
 
@@ -151,7 +151,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             mockDownloader
                 .Setup(x => x.TryDownloadIfExists(It.Is<Uri>(dlUri => dlUri == qualityProfileUri), It.IsAny<bool>()))
                 .ReturnsAsync(Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}"));
-            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), null, logger);
+            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), logger, null);
 
             var result = await sut.TryGetQualityProfile(projectKey, branchName, language);
 
@@ -173,7 +173,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             mockDownloader
                 .Setup(x => x.TryDownloadIfExists(It.Is<Uri>(dlUri => dlUri == qualityProfileUri), It.IsAny<bool>()))
                 .ReturnsAsync(Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}"));
-            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), organization, logger);
+            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), logger, organization);
 
             var result = await sut.TryGetQualityProfile(projectKey, null, language);
 
@@ -198,7 +198,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             mockDownloader
                 .Setup(x => x.Download(It.Is<Uri>(dlUri => dlUri == defaultProfileUri), It.IsAny<bool>()))
                 .ReturnsAsync($"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}");
-            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), null, logger);
+            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), logger, null);
 
             var result = await sut.TryGetQualityProfile(projectKey, null, language);
 
@@ -220,7 +220,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             mockDownloader
                 .Setup(x => x.TryDownloadIfExists(It.Is<Uri>(dlUri => dlUri == qualityProfileUri), It.IsAny<bool>()))
                 .ReturnsAsync(Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}"));
-            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), null, logger);
+            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), logger, null);
 
             var result = await sut.TryGetQualityProfile(projectKey, null, missingLanguage);
 
@@ -241,7 +241,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             mockDownloader
                 .Setup(x => x.TryDownloadIfExists(It.Is<Uri>(dlUri => dlUri == qualityProfileUri), It.IsAny<bool>()))
                 .ReturnsAsync(Tuple.Create(true, $"{{ profiles: []}}"));
-            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), null, logger);
+            sut = new SonarWebServiceStub(mockDownloader.Object, hostUrl, new Version("9.9"), logger, null);
 
             var result = await sut.TryGetQualityProfile(projectKey, null, language);
 
@@ -278,7 +278,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             var testDownloader = new TestDownloader();
             testDownloader.Pages[new Uri(profileUrl)] = @"{ profiles: [ { ""key"":""p1"", ""name"":""p1"", ""language"":""cs"", ""isDefault"": false } ] }";
-            sut = new SonarWebServiceStub(testDownloader, new Uri(hostUrl), version, null, logger);
+            sut = new SonarWebServiceStub(testDownloader, new Uri(hostUrl), version, logger, null);
 
             var (result, profile) = await sut.TryGetQualityProfile("foo", null, "cs");
 
@@ -685,7 +685,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             var testDownloader = new TestDownloader();
             testDownloader.Pages[new Uri(qualityProfileUrl)] = "{ total: 1, p: 1, ps: 1, rules: [] }";
-            sut = new SonarWebServiceStub(testDownloader, new Uri(hostUrl), version, null, logger);
+            sut = new SonarWebServiceStub(testDownloader, new Uri(hostUrl), version, logger, null);
 
             var rules = await sut.GetRules("profile");
 
@@ -759,7 +759,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void GetServerVersion_ReturnsVersion()
         {
             const string expected = "4.2";
-            sut = new SonarWebServiceStub(downloader, uri, new Version(expected), null, logger);
+            sut = new SonarWebServiceStub(downloader, uri, new Version(expected), logger, null);
 
             sut.ServerVersion.ToString().Should().Be(expected);
         }
@@ -771,7 +771,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             var testDownloader = new TestDownloader();
             testDownloader.Pages[new Uri(languagesUrl)] = "{ languages: [ ] }";
-            sut = new SonarWebServiceStub(testDownloader, new Uri(hostUrl), version, null, logger);
+            sut = new SonarWebServiceStub(testDownloader, new Uri(hostUrl), version, logger, null);
 
             var languages = await sut.GetAllLanguages();
 
@@ -786,7 +786,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
             var testDownloader = new TestDownloader();
             testDownloader.Pages[new Uri(downloadUrl)] = "file content";
-            sut = new SonarWebServiceStub(testDownloader, new Uri(hostUrl), version, null, logger);
+            sut = new SonarWebServiceStub(testDownloader, new Uri(hostUrl), version, logger, null);
 
             var result = await sut.TryDownloadEmbeddedFile("csharp", "file.txt", testDir);
 
@@ -795,7 +795,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
         private class SonarWebServiceStub : SonarWebService
         {
-            public SonarWebServiceStub(IDownloader downloader, Uri serverUri, Version serverVersion, string organization, ILogger logger)
+            public SonarWebServiceStub(IDownloader downloader, Uri serverUri, Version serverVersion, ILogger logger, string organization)
                 : base(downloader, serverUri, serverVersion, logger, organization)
             { }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarWebService.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarWebService.cs
@@ -56,7 +56,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// <summary>
         /// Get the name of the quality profile (of the given language) to be used by the given project key.
         /// </summary>
-        Task<Tuple<bool, string>> TryGetQualityProfile(string projectKey, string projectBranch, string organization, string language);
+        Task<Tuple<bool, string>> TryGetQualityProfile(string projectKey, string projectBranch, string language);
 
         /// <summary>
         /// Attempts to download a file embedded in the "static" folder in a plugin jar.

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -138,7 +138,7 @@ namespace SonarScanner.MSBuild.PreProcessor
 
                 foreach (var language in Languages.Where(availableLanguages.Contains))
                 {
-                    var qualityProfile = await server.TryGetQualityProfile(args.ProjectKey, projectBranch, args.Organization, language);
+                    var qualityProfile = await server.TryGetQualityProfile(args.ProjectKey, projectBranch, language);
 
                     // Fetch project quality profile
                     if (!qualityProfile.Item1)

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -62,8 +62,8 @@ namespace SonarScanner.MSBuild.PreProcessor
             var serverVersion = await QueryServerVersion(serverUri, downloader);
 
             return SonarProduct.IsSonarCloud(serverUri.Host, serverVersion)
-                       ? new SonarCloudWebService(downloader, serverUri, serverVersion, logger)
-                       : new SonarQubeWebService(downloader, serverUri, serverVersion, logger);
+                       ? new SonarCloudWebService(downloader, serverUri, serverVersion, logger, args.Organization)
+                       : new SonarQubeWebService(downloader, serverUri, serverVersion, logger, args.Organization);
         }
 
         public ITargetsInstaller CreateTargetInstaller() =>

--- a/src/SonarScanner.MSBuild.PreProcessor/WebService/SonarCloudWebService.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebService/SonarCloudWebService.cs
@@ -39,7 +39,8 @@ namespace SonarScanner.MSBuild.PreProcessor.WebService
         public SonarCloudWebService(IDownloader downloader, Uri serverUri, Version serverVersion, ILogger logger, string organization, HttpMessageHandler handler = null)
             : base(downloader, serverUri, serverVersion, logger, organization)
         {
-            _ = organization ?? throw new ArgumentNullException(nameof(organization));
+            Contract.ThrowIfNullOrWhitespace(organization, nameof(organization));
+
             cacheClient = handler is null ? new HttpClient() : new HttpClient(handler, true);
         }
 
@@ -66,11 +67,6 @@ namespace SonarScanner.MSBuild.PreProcessor.WebService
             if (string.IsNullOrWhiteSpace(localSettings.ProjectKey))
             {
                 logger.LogInfo(Resources.MSG_Processing_PullRequest_NoProjectKey);
-                return empty;
-            }
-            if (string.IsNullOrWhiteSpace(organization))
-            {
-                logger.LogInfo(Resources.MSG_Processing_PullRequest_NoOrganization);
                 return empty;
             }
             if (!localSettings.TryGetSetting(SonarProperties.PullRequestBase, out var branch))

--- a/src/SonarScanner.MSBuild.PreProcessor/WebService/SonarCloudWebService.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebService/SonarCloudWebService.cs
@@ -36,9 +36,10 @@ namespace SonarScanner.MSBuild.PreProcessor.WebService
 
         private readonly HttpClient cacheClient;
 
-        public SonarCloudWebService(IDownloader downloader, Uri serverUri, Version serverVersion, ILogger logger, HttpMessageHandler handler = null)
-            : base(downloader, serverUri, serverVersion, logger)
+        public SonarCloudWebService(IDownloader downloader, Uri serverUri, Version serverVersion, ILogger logger, string organization, HttpMessageHandler handler = null)
+            : base(downloader, serverUri, serverVersion, logger, organization)
         {
+            _ = organization ?? throw new ArgumentNullException(nameof(organization));
             cacheClient = handler is null ? new HttpClient() : new HttpClient(handler, true);
         }
 
@@ -67,7 +68,7 @@ namespace SonarScanner.MSBuild.PreProcessor.WebService
                 logger.LogInfo(Resources.MSG_Processing_PullRequest_NoProjectKey);
                 return empty;
             }
-            if (string.IsNullOrWhiteSpace(localSettings.Organization))
+            if (string.IsNullOrWhiteSpace(organization))
             {
                 logger.LogInfo(Resources.MSG_Processing_PullRequest_NoOrganization);
                 return empty;

--- a/src/SonarScanner.MSBuild.PreProcessor/WebService/SonarQubeWebService.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebService/SonarQubeWebService.cs
@@ -31,8 +31,8 @@ namespace SonarScanner.MSBuild.PreProcessor.WebService
 {
     internal class SonarQubeWebService : SonarWebService
     {
-        public SonarQubeWebService(IDownloader downloader, Uri serverUri, Version serverVersion, ILogger logger)
-            : base(downloader, serverUri, serverVersion, logger)
+        public SonarQubeWebService(IDownloader downloader, Uri serverUri, Version serverVersion, ILogger logger, string organization)
+            : base(downloader, serverUri, serverVersion, logger, organization)
         {
             // ToDo: Fail fast after release of S4NET 6.0
             if (serverVersion.CompareTo(new Version(7, 9)) < 0)
@@ -106,8 +106,8 @@ namespace SonarScanner.MSBuild.PreProcessor.WebService
                 ? await base.DownloadComponentProperties(component)
                 : await DownloadComponentPropertiesLegacy(component);
 
-        protected override Uri AddOrganization(Uri uri, string organization) =>
-            serverVersion.CompareTo(new Version(6, 3)) < 0 ? uri : base.AddOrganization(uri, organization);
+        protected override Uri AddOrganization(Uri uri) =>
+            serverVersion.CompareTo(new Version(6, 3)) < 0 ? uri : base.AddOrganization(uri);
 
         private async Task<IDictionary<string, string>> DownloadComponentPropertiesLegacy(string projectId)
         {


### PR DESCRIPTION
Fixes #1476 

- Add `organization` field to the class `SonarWebService`
- Update unit test accordingly
  - Removed duplicates
  - Refactor existing ones