### PR TITLE
Refactoring: Use of HttpClient.BaseAddress property

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/TestDownloader.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/TestDownloader.cs
@@ -52,8 +52,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test.Infrastructure
             // Nothing to do here
         }
 
-        public Uri GetBaseUri() => baseUri;
-
         Task<Stream> IDownloader.DownloadStream(Uri url) => throw new NotImplementedException();
 
         Task<bool> IDownloader.TryDownloadFileIfExists(Uri url, string targetFilePath, bool logPermissionDenied) => throw new NotImplementedException();

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/TestDownloader.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/TestDownloader.cs
@@ -28,21 +28,14 @@ namespace SonarScanner.MSBuild.PreProcessor.Test.Infrastructure
 {
     public sealed class TestDownloader : IDownloader
     {
-        public readonly IDictionary<Uri, string> Pages = new Dictionary<Uri, string>();
+        public readonly IDictionary<string, string> Pages = new Dictionary<string, string>();
 
-        private readonly Uri baseUri;
-
-        public TestDownloader(string baseUri)
-        {
-            this.baseUri = new Uri(baseUri);
-        }
-
-        public Task<Tuple<bool, string>> TryDownloadIfExists(Uri url, bool logPermissionDenied = false) =>
+        public Task<Tuple<bool, string>> TryDownloadIfExists(string url, bool logPermissionDenied = false) =>
             Pages.ContainsKey(url)
                 ? Task.FromResult(new Tuple<bool, string>(true, Pages[url]))
                 : Task.FromResult(new Tuple<bool, string>(false, null));
 
-        public Task<string> Download(Uri url, bool logPermissionDenied = false) =>
+        public Task<string> Download(string url, bool logPermissionDenied = false) =>
             Pages.ContainsKey(url)
                 ? Task.FromResult(Pages[url])
                 : throw new ArgumentException("Cannot find URL " + url);
@@ -52,10 +45,10 @@ namespace SonarScanner.MSBuild.PreProcessor.Test.Infrastructure
             // Nothing to do here
         }
 
-        Task<Stream> IDownloader.DownloadStream(Uri url) => throw new NotImplementedException();
+        Task<Stream> IDownloader.DownloadStream(string url) => throw new NotImplementedException();
 
-        Task<bool> IDownloader.TryDownloadFileIfExists(Uri url, string targetFilePath, bool logPermissionDenied) => throw new NotImplementedException();
+        Task<bool> IDownloader.TryDownloadFileIfExists(string url, string targetFilePath, bool logPermissionDenied) => throw new NotImplementedException();
 
-        Task<HttpResponseMessage> IDownloader.DownloadResource(Uri url) => throw new NotImplementedException();
+        Task<HttpResponseMessage> IDownloader.DownloadResource(string url) => throw new NotImplementedException();
     }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -55,7 +55,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var sut = new PreprocessorObjectFactory(logger);
             var downloader =  new Mock<IDownloader>(MockBehavior.Strict);
             downloader.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).Throws<InvalidOperationException>();
-            downloader.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
 
             var result = await sut.CreateSonarWebServer(CreateValidArguments(), downloader.Object);
 
@@ -71,7 +70,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var exception = new HttpRequestException(string.Empty, new WebException(string.Empty, WebExceptionStatus.ConnectFailure));
             var downloader =  new Mock<IDownloader>(MockBehavior.Strict);
             downloader.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).Throws(exception);
-            downloader.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
 
             var result = await sut.CreateSonarWebServer(CreateValidArguments(), downloader.Object);
 
@@ -87,7 +85,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             var sut = new PreprocessorObjectFactory(logger);
             var downloader = new Mock<IDownloader>(MockBehavior.Strict);
-            downloader.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloader.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync(version);
 
             var service = await sut.CreateSonarWebServer(CreateValidArguments(), downloader.Object);
@@ -100,7 +97,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             var downloader = new Mock<IDownloader>(MockBehavior.Strict);
             downloader.Setup(x => x.Download(new Uri("http://myhost:222/api/server/version"), It.IsAny<bool>())).ReturnsAsync("8.9");
-            downloader.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             var validArgs = CreateValidArguments();
             var sut = new PreprocessorObjectFactory(logger);
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -50,7 +50,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         [TestMethod]
-        public async Task CreateSonarWebService_RequestServerVersionFailedDueToGenericException_ShouldReturnNullAndLogAnError()
+        public async Task CreateSonarWebService_RequestServerVersionFailedDueToGenericException_ShouldReturnNull()
         {
             var sut = new PreprocessorObjectFactory(logger);
             var downloader =  new Mock<IDownloader>(MockBehavior.Strict);
@@ -60,10 +60,11 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             result.Should().BeNull();
             logger.AssertNoWarningsLogged();
+            logger.AssertNoErrorsLogged();
         }
 
         [TestMethod]
-        public async Task CreateSonarWebService_RequestServerVersionFailedDueToHttpRequestException_ShouldReturnNullAndLogAnError()
+        public async Task CreateSonarWebService_RequestServerVersionFailedDueToHttpRequestException_ShouldReturnNull()
         {
             var sut = new PreprocessorObjectFactory(logger);
             var exception = new HttpRequestException(string.Empty, new WebException(string.Empty, WebExceptionStatus.ConnectFailure));
@@ -74,6 +75,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             result.Should().BeNull();
             logger.AssertNoWarningsLogged();
+            logger.AssertNoErrorsLogged();
         }
 
         [DataTestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -60,7 +60,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             result.Should().BeNull();
             logger.AssertNoWarningsLogged();
-            logger.AssertSingleErrorExists("An error occured when calling: Operation is not valid due to the current state of the object.");
         }
 
         [TestMethod]
@@ -75,7 +74,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             result.Should().BeNull();
             logger.AssertNoWarningsLogged();
-            logger.AssertSingleErrorExists("Unable to connect to server. Please check if the server is running and if the address is correct.");
         }
 
         [DataTestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -84,23 +84,22 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task CreateSonarWebServer_CorrectServiceType(string version, Type serviceType)
         {
             var sut = new PreprocessorObjectFactory(logger);
-            var downloader = new Mock<IDownloader>(MockBehavior.Strict);
-            downloader.Setup(x => x.Download(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(version);
+            var downloader = Mock.Of<IDownloader>(x => x.Download(It.IsAny<string>(), It.IsAny<bool>()) == Task.FromResult(version));
 
-            var service = await sut.CreateSonarWebServer(CreateValidArguments(), downloader.Object);
+            var service = await sut.CreateSonarWebServer(CreateValidArguments(), downloader);
 
             service.Should().BeOfType(serviceType);
         }
 
         [TestMethod]
-        public async Task ValidCallSequence_ValidObjectReturned()
+        public async Task CreateSonarWebServer_ValidCallSequence_ValidObjectReturned()
         {
-            var downloader = new Mock<IDownloader>(MockBehavior.Strict);
-            downloader.Setup(x => x.Download("api/server/version", It.IsAny<bool>())).ReturnsAsync("8.9");
+            var downloader = Mock.Of<IDownloader>(x => x.Download("api/server/version", It.IsAny<bool>()) == Task.FromResult("8.9"));
             var validArgs = CreateValidArguments();
             var sut = new PreprocessorObjectFactory(logger);
 
-            var server = await sut.CreateSonarWebServer(validArgs, downloader.Object);
+            var server = await sut.CreateSonarWebServer(validArgs, downloader);
+
             server.Should().NotBeNull();
             sut.CreateTargetInstaller().Should().NotBeNull();
             sut.CreateRoslynAnalyzerProvider(server).Should().NotBeNull();
@@ -112,6 +111,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var sut = new PreprocessorObjectFactory(logger);
 
             Action act = () => sut.CreateRoslynAnalyzerProvider(null);
+
             act.Should().ThrowExactly<ArgumentNullException>();
         }
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -54,7 +54,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             var sut = new PreprocessorObjectFactory(logger);
             var downloader =  new Mock<IDownloader>(MockBehavior.Strict);
-            downloader.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).Throws<InvalidOperationException>();
+            downloader.Setup(x => x.Download(It.IsAny<string>(), It.IsAny<bool>())).Throws<InvalidOperationException>();
 
             var result = await sut.CreateSonarWebServer(CreateValidArguments(), downloader.Object);
 
@@ -69,7 +69,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var sut = new PreprocessorObjectFactory(logger);
             var exception = new HttpRequestException(string.Empty, new WebException(string.Empty, WebExceptionStatus.ConnectFailure));
             var downloader =  new Mock<IDownloader>(MockBehavior.Strict);
-            downloader.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).Throws(exception);
+            downloader.Setup(x => x.Download(It.IsAny<string>(), It.IsAny<bool>())).Throws(exception);
 
             var result = await sut.CreateSonarWebServer(CreateValidArguments(), downloader.Object);
 
@@ -85,7 +85,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             var sut = new PreprocessorObjectFactory(logger);
             var downloader = new Mock<IDownloader>(MockBehavior.Strict);
-            downloader.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync(version);
+            downloader.Setup(x => x.Download(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(version);
 
             var service = await sut.CreateSonarWebServer(CreateValidArguments(), downloader.Object);
 
@@ -96,7 +96,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task ValidCallSequence_ValidObjectReturned()
         {
             var downloader = new Mock<IDownloader>(MockBehavior.Strict);
-            downloader.Setup(x => x.Download(new Uri("http://myhost:222/api/server/version"), It.IsAny<bool>())).ReturnsAsync("8.9");
+            downloader.Setup(x => x.Download("api/server/version", It.IsAny<bool>())).ReturnsAsync("8.9");
             var validArgs = CreateValidArguments();
             var sut = new PreprocessorObjectFactory(logger);
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -60,7 +60,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             result.Should().BeNull();
             logger.AssertNoWarningsLogged();
-            logger.AssertSingleErrorExists("An error occured when calling 'http://myhost:222/api/server/version': Operation is not valid due to the current state of the object.");
+            logger.AssertSingleErrorExists("An error occured when calling: Operation is not valid due to the current state of the object.");
         }
 
         [TestMethod]
@@ -75,7 +75,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             result.Should().BeNull();
             logger.AssertNoWarningsLogged();
-            logger.AssertSingleErrorExists("Unable to connect to server. Please check if the server is running and if the address is correct. Url: 'http://myhost:222/api/server/version'.");
+            logger.AssertSingleErrorExists("Unable to connect to server. Please check if the server is running and if the address is correct.");
         }
 
         [DataTestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServerTest.cs
@@ -99,7 +99,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void GetProperties_Success()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(true, @"{ settings: [
                   {
                     key: ""sonar.core.id"",
@@ -260,7 +259,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                                          : "{\"settings\":[]}";
 
             var mock = new Mock<IDownloader>();
-            mock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             mock.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).Returns(Task.FromResult(serverSettingsJson));
             mock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>())).Returns(Task.FromResult(new Tuple<bool, string>(false, string.Empty)));
             return mock.Object;

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServerTest.cs
@@ -55,7 +55,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
         public SonarCloudWebServerTest()
         {
-            downloader = new TestDownloader("http://myhost:222");
+            downloader = new TestDownloader();
             version = new Version("5.6");
             logger = new TestLogger();
         }
@@ -82,7 +82,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [TestMethod]
         public void IsLicenseValid_AlwaysValid()
         {
-            downloader.Pages[new Uri("http://myhost:222/api/editions/is_valid_license")] = @"{ ""isValidLicense"": false }";
+            downloader.Pages["api/editions/is_valid_license"] = @"{ ""isValidLicense"": false }";
 
             sut.IsServerLicenseValid().Result.Should().BeTrue();
         }
@@ -99,7 +99,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void GetProperties_Success()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(true, @"{ settings: [
+            downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(true, @"{ settings: [
                   {
                     key: ""sonar.core.id"",
                     value: ""AVrrKaIfChAsLlov22f0"",
@@ -259,8 +259,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                                          : "{\"settings\":[]}";
 
             var mock = new Mock<IDownloader>();
-            mock.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).Returns(Task.FromResult(serverSettingsJson));
-            mock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>())).Returns(Task.FromResult(new Tuple<bool, string>(false, string.Empty)));
+            mock.Setup(x => x.Download(It.IsAny<string>(), It.IsAny<bool>())).Returns(Task.FromResult(serverSettingsJson));
+            mock.Setup(x => x.TryDownloadIfExists(It.IsAny<string>(), It.IsAny<bool>())).Returns(Task.FromResult(new Tuple<bool, string>(false, string.Empty)));
             return mock.Object;
         }
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
@@ -177,8 +177,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             const string profileKey = "orgProfile";
             const string language = "cs";
-            var dowloadResult = Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}");
-            var downloaderMock = Mock.Of<IDownloader>(x => x.TryDownloadIfExists(It.IsAny<string>(), It.IsAny<bool>()) == Task.FromResult(dowloadResult));
+            var downloadResult = Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}");
+            var downloaderMock = Mock.Of<IDownloader>(x => x.TryDownloadIfExists(It.IsAny<string>(), It.IsAny<bool>()) == Task.FromResult(downloadResult));
             sut = new SonarQubeWebServer(downloaderMock, new Version("9.9"), logger, organization);
 
             var result = await sut.TryGetQualityProfile(projectKey, null, language);
@@ -194,8 +194,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             const string profileKey = "orgProfile";
             const string language = "cs";
             var qualityProfileUrl = $"api/qualityprofiles/search?project={WebUtility.UrlEncode($"{projectKey}")}";
-            var dowloadResult = Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}");
-            var downloaderMock = Mock.Of<IDownloader>(x => x.TryDownloadIfExists(qualityProfileUrl, It.IsAny<bool>()) == Task.FromResult(dowloadResult));
+            var downloadResult = Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}");
+            var downloaderMock = Mock.Of<IDownloader>(x => x.TryDownloadIfExists(qualityProfileUrl, It.IsAny<bool>()) == Task.FromResult(downloadResult));
             sut = new SonarQubeWebServer(downloaderMock, new Version("6.2"), logger, organization);
 
             var result = await sut.TryGetQualityProfile(projectKey, null, language);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
@@ -51,7 +51,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
         public SonarQubeWebServerTest()
         {
-            downloader = new TestDownloader("http://myhost:222");
+            downloader = new TestDownloader();
             version = new Version("9.9");
             logger = new TestLogger();
         }
@@ -92,7 +92,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_Commercial_AuthNotForced_LicenseIsInvalid()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.DownloadResource(It.IsAny<Uri>()))
+            downloaderMock.Setup(x => x.DownloadResource(It.IsAny<string>()))
                           .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(@"{ ""isValidLicense"": false }") });
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
 
@@ -107,7 +107,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_Commercial_AuthNotForced_LicenseIsValid()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.DownloadResource(new Uri("http://myhost:222/api/editions/is_valid_license")))
+            downloaderMock.Setup(x => x.DownloadResource("api/editions/is_valid_license"))
                           .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(@"{ ""isValidLicense"": true }") });
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
 
@@ -122,7 +122,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_Commercial_AuthForced_WithoutCredentials_ShouldReturnFalseAndLogError()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.DownloadResource(new Uri("https://host:222/api/editions/is_valid_license"))).ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.Unauthorized });
+            downloaderMock.Setup(x => x.DownloadResource("https://host:222/api/editions/is_valid_license")).ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.Unauthorized });
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
 
             var result = await sut.IsServerLicenseValid();
@@ -136,7 +136,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_ServerNotLicensed()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.DownloadResource(new Uri("http://myhost:222/api/editions/is_valid_license")))
+            downloaderMock.Setup(x => x.DownloadResource("api/editions/is_valid_license"))
                           .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound, Content = new StringContent(@"{""errors"":[{""msg"":""License not found""}]}") });
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
 
@@ -151,7 +151,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_CE_SkipLicenseCheck()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.DownloadResource(new Uri("http://myhost:222/api/editions/is_valid_license")))
+            downloaderMock.Setup(x => x.DownloadResource("api/editions/is_valid_license"))
                           .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound, Content = new StringContent(@"{""errors"":[{""msg"":""Unknown url: /api/editions/is_valid_license""}]}") });
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
 
@@ -168,7 +168,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_RequestUrl(string hostUrl, string licenseUrl)
         {
             var mockDownloader = new Mock<IDownloader>();
-            mockDownloader.Setup(x => x.DownloadResource(new Uri(licenseUrl)))
+            mockDownloader.Setup(x => x.DownloadResource(licenseUrl))
                           .ReturnsAsync(new HttpResponseMessage { Content = new StringContent(@"{ ""isValidLicense"": true }"), StatusCode = HttpStatusCode.OK}).Verifiable();
             sut = new SonarQubeWebServer(mockDownloader.Object, version, logger, null);
 
@@ -185,7 +185,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             const string profileKey = "orgProfile";
             const string language = "cs";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>()))
+            downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<string>(), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}"));
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("9.9"), logger, organization);
 
@@ -202,7 +202,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             const string profileKey = "orgProfile";
             const string language = "cs";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/qualityprofiles/search?project={WebUtility.UrlEncode($"{projectKey}")}"), It.IsAny<bool>()))
+            downloaderMock.Setup(x => x.TryDownloadIfExists($"api/qualityprofiles/search?project={WebUtility.UrlEncode($"{projectKey}")}", It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}"));
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.2"), logger, organization);
 
@@ -216,7 +216,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void TryGetQualityProfile_MultipleQPForSameLanguage_ShouldThrow()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri("http://myhost:222/api/qualityprofiles/search?project=foo+bar"), It.IsAny<bool>()))
+            downloaderMock.Setup(x => x.TryDownloadIfExists("api/qualityprofiles/search?project=foo+bar", It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, "{ profiles: [{\"key\":\"profile1k\",\"name\":\"profile1\",\"language\":\"cs\", \"isDefault\": false}, {\"key\":\"profile4k\",\"name\":\"profile4\",\"language\":\"cs\", \"isDefault\": true}]}"));
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("9.9"), logger, null);
 
@@ -232,7 +232,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void GetProperties_Sq63()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri("http://myhost:222/api/settings/values?component=comp"), It.IsAny<bool>()))
+            downloaderMock.Setup(x => x.TryDownloadIfExists("api/settings/values?component=comp", It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, @"{ settings: [
                   {
                     key: ""sonar.core.id"",
@@ -282,8 +282,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             const string componentName = "nonexistent-component";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/settings/values?component={componentName}"), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(false, (string)null));
-            downloaderMock.Setup(x => x.Download(new Uri("http://myhost:222/api/settings/values"), It.IsAny<bool>())).ReturnsAsync(@"{ settings: [ { key: ""key"", value: ""42"" } ]}");
+            downloaderMock.Setup(x => x.TryDownloadIfExists($"api/settings/values?component={componentName}", It.IsAny<bool>())).ReturnsAsync(Tuple.Create(false, (string)null));
+            downloaderMock.Setup(x => x.Download("api/settings/values", It.IsAny<bool>())).ReturnsAsync(@"{ settings: [ { key: ""key"", value: ""42"" } ]}");
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.3"), logger, null);
 
             var result = await sut.GetProperties(componentName, null);
@@ -297,8 +297,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             const string componentName = "nonexistent-component";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/settings/values?component={componentName}"), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(false, (string)null));
-            downloaderMock.Setup(x => x.Download(new Uri("http://myhost:222/api/settings/values"), It.IsAny<bool>())).ReturnsAsync(@"{ settings: [ { key: ""key"" } ]}");
+            downloaderMock.Setup(x => x.TryDownloadIfExists($"api/settings/values?component={componentName}", It.IsAny<bool>())).ReturnsAsync(Tuple.Create(false, (string)null));
+            downloaderMock.Setup(x => x.Download("api/settings/values", It.IsAny<bool>())).ReturnsAsync(@"{ settings: [ { key: ""key"" } ]}");
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.3"), logger, null);
 
             await sut.Invoking(async x => await x.GetProperties(componentName, null)).Should().ThrowAsync<ArgumentException>().WithMessage("Invalid property");
@@ -317,13 +317,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void GetProperties()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.Download(new Uri("http://myhost:222/api/properties?resource=foo+bar"), It.IsAny<bool>()))
+            downloaderMock.Setup(x => x.Download("api/properties?resource=foo+bar", It.IsAny<bool>()))
                           .ReturnsAsync("[{\"key\": \"sonar.property1\",\"value\": \"value1\"},{\"key\": \"sonar.property2\",\"value\": \"value2\"},{\"key\": \"sonar.cs.msbuild.testProjectPattern\",\"value\": \"pattern\"}]");
             // This test includes a regression scenario for SONARMSBRU-187:
             // Requesting properties for project:branch should return branch-specific data
 
             // Check that properties are correctly defaulted as well as branch-specific
-            downloaderMock.Setup(x => x.Download(new Uri("http://myhost:222/api/properties?resource=foo+bar%3AaBranch"), It.IsAny<bool>()))
+            downloaderMock.Setup(x => x.Download("api/properties?resource=foo+bar%3AaBranch", It.IsAny<bool>()))
                           .ReturnsAsync("[{\"key\": \"sonar.property1\",\"value\": \"anotherValue1\"},{\"key\": \"sonar.property2\",\"value\": \"anotherValue2\"}]");
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("5.6"), logger, null);
 
@@ -355,7 +355,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task GetProperties_Old_Forbidden()
         {
             var downloaderMock = new Mock<IDownloader>(MockBehavior.Strict);
-            downloaderMock.Setup(x => x.Download(new Uri($"http://myhost:222/api/properties?resource={ProjectKey}"), It.IsAny<bool>())).Throws(new HttpRequestException("Forbidden"));
+            downloaderMock.Setup(x => x.Download($"api/properties?resource={ProjectKey}", It.IsAny<bool>())).Throws(new HttpRequestException("Forbidden"));
 
             var service = new SonarQubeWebServer(downloaderMock.Object, new Version("1.2.3.4"), logger, null);
 
@@ -369,7 +369,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void GetProperties_Sq63plus_Forbidden()
         {
             var downloaderMock = new Mock<IDownloader>(MockBehavior.Strict);
-            downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>())).Throws(new HttpRequestException("Forbidden"));
+            downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<string>(), It.IsAny<bool>())).Throws(new HttpRequestException("Forbidden"));
 
             var service = new SonarQubeWebServer(downloaderMock.Object, new Version("6.3.0.0"), logger, null);
 
@@ -383,7 +383,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task GetProperties_SQ63AndHigherWithProject_ShouldBeEmpty()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(true, "{ settings: [ ] }")).Verifiable();
+            downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(true, "{ settings: [ ] }")).Verifiable();
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.3"), logger, null);
 
             var properties = await sut.GetProperties("key", null);
@@ -396,7 +396,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task GetProperties_OlderThanSQ63_ShouldBeEmpty()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync("[]").Verifiable();
+            downloaderMock.Setup(x => x.Download(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync("[]").Verifiable();
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.2.9"), logger, null);
 
             var properties = await sut.GetProperties("key", null);
@@ -409,8 +409,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task GetProperties_SQ63AndHigherWithoutProject_ShouldBeEmpty()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(false, (string)null)).Verifiable();
-            downloaderMock.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync("{ settings: [ ] }").Verifiable();
+            downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(false, (string)null)).Verifiable();
+            downloaderMock.Setup(x => x.Download(It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync("{ settings: [ ] }").Verifiable();
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.3"), logger, null);
 
             var properties = await sut.GetProperties("key", null);
@@ -441,14 +441,11 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         [TestMethod]
-        [DataRow("http://myhost:222", "http://myhost:222/api/analysis_cache/get?project=project-key&branch=project-branch")]
-        [DataRow("http://myhost:222/", "http://myhost:222/api/analysis_cache/get?project=project-key&branch=project-branch")]
-        [DataRow("http://myhost:222/sonar/", "http://myhost:222/sonar/api/analysis_cache/get?project=project-key&branch=project-branch")]
-        public async Task DownloadCache_RequestUrl(string hostUrl, string downloadUrl)
+        public async Task DownloadCache_RequestUrl()
         {
             using Stream stream = new MemoryStream();
             var mockDownloader = new Mock<IDownloader>();
-            mockDownloader.Setup(x => x.DownloadStream(new Uri(downloadUrl))).ReturnsAsync(stream).Verifiable();
+            mockDownloader.Setup(x => x.DownloadStream("api/analysis_cache/get?project=project-key&branch=project-branch")).ReturnsAsync(stream).Verifiable();
             sut = new SonarQubeWebServer(mockDownloader.Object, version, logger, null);
             var localSettings = CreateLocalSettings(ProjectKey, ProjectBranch);
 
@@ -500,7 +497,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task DownloadCache_WhenDownloadStreamThrows_ReturnsEmptyAndLogsException()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.DownloadStream(It.IsAny<Uri>())).ThrowsAsync(new HttpRequestException());
+            downloaderMock.Setup(x => x.DownloadStream(It.IsAny<string>())).ThrowsAsync(new HttpRequestException());
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
 
             var localSettings = CreateLocalSettings(ProjectKey, ProjectBranch);
@@ -546,7 +543,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         private static IDownloader MockIDownloader(Stream stream) =>
-            Mock.Of<IDownloader>(x => x.DownloadStream(It.IsAny<Uri>()) == Task.FromResult(stream));
+            Mock.Of<IDownloader>(x => x.DownloadStream(It.IsAny<string>()) == Task.FromResult(stream));
 
         private static ProcessedArgs CreateLocalSettings(string projectKey, string branch, string organization = "placeholder", string token = "placeholder")
         {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
@@ -122,7 +122,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_Commercial_AuthForced_WithoutCredentials_ShouldReturnFalseAndLogError()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.DownloadResource("https://host:222/api/editions/is_valid_license")).ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.Unauthorized });
+            downloaderMock.Setup(x => x.DownloadResource("api/editions/is_valid_license")).ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.Unauthorized });
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
 
             var result = await sut.IsServerLicenseValid();
@@ -163,12 +163,10 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         [TestMethod]
-        [DataRow("http://myhost:222/", "http://myhost:222/api/editions/is_valid_license")]
-        [DataRow("http://myhost:222/sonar/", "http://myhost:222/sonar/api/editions/is_valid_license")]
-        public async Task IsServerLicenseValid_RequestUrl(string hostUrl, string licenseUrl)
+        public async Task IsServerLicenseValid_RequestUrl()
         {
             var mockDownloader = new Mock<IDownloader>();
-            mockDownloader.Setup(x => x.DownloadResource(licenseUrl))
+            mockDownloader.Setup(x => x.DownloadResource("api/editions/is_valid_license"))
                           .ReturnsAsync(new HttpResponseMessage { Content = new StringContent(@"{ ""isValidLicense"": true }"), StatusCode = HttpStatusCode.OK}).Verifiable();
             sut = new SonarQubeWebServer(mockDownloader.Object, version, logger, null);
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
@@ -92,7 +92,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_Commercial_AuthNotForced_LicenseIsInvalid()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.DownloadResource(It.IsAny<Uri>()))
                           .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(@"{ ""isValidLicense"": false }") });
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
@@ -108,7 +107,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_Commercial_AuthNotForced_LicenseIsValid()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.DownloadResource(new Uri("http://myhost:222/api/editions/is_valid_license")))
                           .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(@"{ ""isValidLicense"": true }") });
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
@@ -124,7 +122,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_Commercial_AuthForced_WithoutCredentials_ShouldReturnFalseAndLogError()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("https://host:222"));
             downloaderMock.Setup(x => x.DownloadResource(new Uri("https://host:222/api/editions/is_valid_license"))).ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.Unauthorized });
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
 
@@ -139,7 +136,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_ServerNotLicensed()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.DownloadResource(new Uri("http://myhost:222/api/editions/is_valid_license")))
                           .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound, Content = new StringContent(@"{""errors"":[{""msg"":""License not found""}]}") });
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
@@ -155,7 +151,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_CE_SkipLicenseCheck()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.DownloadResource(new Uri("http://myhost:222/api/editions/is_valid_license")))
                           .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound, Content = new StringContent(@"{""errors"":[{""msg"":""Unknown url: /api/editions/is_valid_license""}]}") });
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
@@ -173,7 +168,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task IsServerLicenseValid_RequestUrl(string hostUrl, string licenseUrl)
         {
             var mockDownloader = new Mock<IDownloader>();
-            mockDownloader.Setup(x => x.GetBaseUri()).Returns(new Uri(hostUrl));
             mockDownloader.Setup(x => x.DownloadResource(new Uri(licenseUrl)))
                           .ReturnsAsync(new HttpResponseMessage { Content = new StringContent(@"{ ""isValidLicense"": true }"), StatusCode = HttpStatusCode.OK}).Verifiable();
             sut = new SonarQubeWebServer(mockDownloader.Object, version, logger, null);
@@ -191,7 +185,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             const string profileKey = "orgProfile";
             const string language = "cs";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}"));
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("9.9"), logger, organization);
@@ -209,7 +202,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             const string profileKey = "orgProfile";
             const string language = "cs";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/qualityprofiles/search?project={WebUtility.UrlEncode($"{projectKey}")}"), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}"));
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.2"), logger, organization);
@@ -224,7 +216,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void TryGetQualityProfile_MultipleQPForSameLanguage_ShouldThrow()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri("http://myhost:222/api/qualityprofiles/search?project=foo+bar"), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, "{ profiles: [{\"key\":\"profile1k\",\"name\":\"profile1\",\"language\":\"cs\", \"isDefault\": false}, {\"key\":\"profile4k\",\"name\":\"profile4\",\"language\":\"cs\", \"isDefault\": true}]}"));
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("9.9"), logger, null);
@@ -241,7 +232,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void GetProperties_Sq63()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri("http://myhost:222/api/settings/values?component=comp"), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, @"{ settings: [
                   {
@@ -292,7 +282,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             const string componentName = "nonexistent-component";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/settings/values?component={componentName}"), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(false, (string)null));
             downloaderMock.Setup(x => x.Download(new Uri("http://myhost:222/api/settings/values"), It.IsAny<bool>())).ReturnsAsync(@"{ settings: [ { key: ""key"", value: ""42"" } ]}");
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.3"), logger, null);
@@ -308,7 +297,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             const string componentName = "nonexistent-component";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/settings/values?component={componentName}"), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(false, (string)null));
             downloaderMock.Setup(x => x.Download(new Uri("http://myhost:222/api/settings/values"), It.IsAny<bool>())).ReturnsAsync(@"{ settings: [ { key: ""key"" } ]}");
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.3"), logger, null);
@@ -329,7 +317,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void GetProperties()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.Download(new Uri("http://myhost:222/api/properties?resource=foo+bar"), It.IsAny<bool>()))
                           .ReturnsAsync("[{\"key\": \"sonar.property1\",\"value\": \"value1\"},{\"key\": \"sonar.property2\",\"value\": \"value2\"},{\"key\": \"sonar.cs.msbuild.testProjectPattern\",\"value\": \"pattern\"}]");
             // This test includes a regression scenario for SONARMSBRU-187:
@@ -368,7 +355,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task GetProperties_Old_Forbidden()
         {
             var downloaderMock = new Mock<IDownloader>(MockBehavior.Strict);
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.Download(new Uri($"http://myhost:222/api/properties?resource={ProjectKey}"), It.IsAny<bool>())).Throws(new HttpRequestException("Forbidden"));
 
             var service = new SonarQubeWebServer(downloaderMock.Object, new Version("1.2.3.4"), logger, null);
@@ -383,7 +369,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void GetProperties_Sq63plus_Forbidden()
         {
             var downloaderMock = new Mock<IDownloader>(MockBehavior.Strict);
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>())).Throws(new HttpRequestException("Forbidden"));
 
             var service = new SonarQubeWebServer(downloaderMock.Object, new Version("6.3.0.0"), logger, null);
@@ -398,7 +383,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task GetProperties_SQ63AndHigherWithProject_ShouldBeEmpty()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222/"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(true, "{ settings: [ ] }")).Verifiable();
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.3"), logger, null);
 
@@ -412,7 +396,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task GetProperties_OlderThanSQ63_ShouldBeEmpty()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222/"));
             downloaderMock.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync("[]").Verifiable();
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.2.9"), logger, null);
 
@@ -426,7 +409,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task GetProperties_SQ63AndHigherWithoutProject_ShouldBeEmpty()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222/"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(false, (string)null)).Verifiable();
             downloaderMock.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync("{ settings: [ ] }").Verifiable();
             sut = new SonarQubeWebServer(downloaderMock.Object, new Version("6.3"), logger, null);
@@ -466,7 +448,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             using Stream stream = new MemoryStream();
             var mockDownloader = new Mock<IDownloader>();
-            mockDownloader.Setup(x => x.GetBaseUri()).Returns(new Uri(hostUrl));
             mockDownloader.Setup(x => x.DownloadStream(new Uri(downloadUrl))).ReturnsAsync(stream).Verifiable();
             sut = new SonarQubeWebServer(mockDownloader.Object, version, logger, null);
             var localSettings = CreateLocalSettings(ProjectKey, ProjectBranch);
@@ -519,7 +500,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task DownloadCache_WhenDownloadStreamThrows_ReturnsEmptyAndLogsException()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.DownloadStream(It.IsAny<Uri>())).ThrowsAsync(new HttpRequestException());
             sut = new SonarQubeWebServer(downloaderMock.Object, version, logger, null);
 
@@ -566,7 +546,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         private static IDownloader MockIDownloader(Stream stream) =>
-            Mock.Of<IDownloader>(x => x.DownloadStream(It.IsAny<Uri>()) == Task.FromResult(stream) && x.GetBaseUri() == new Uri("http://myhost:222"));
+            Mock.Of<IDownloader>(x => x.DownloadStream(It.IsAny<Uri>()) == Task.FromResult(stream));
 
         private static ProcessedArgs CreateLocalSettings(string projectKey, string branch, string organization = "placeholder", string token = "placeholder")
         {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
@@ -75,7 +75,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task TryGetQualityProfile_LogHttpError()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/qualityprofiles/search?project={ProjectKey}"), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(true, "trash"));
             sut = new SonarWebServerStub(downloaderMock.Object, version, logger, null);
 
@@ -88,7 +87,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void TryGetQualityProfile_InvalidOrganizationKey_After_Version63()
         {
             var mockDownloader = new Mock<IDownloader>(MockBehavior.Strict);
-            mockDownloader.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             mockDownloader.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/qualityprofiles/search?project={ProjectKey}&organization=ThisIsInvalidValue"), false)).Returns(Task.FromResult(Tuple.Create(false, (string)null)));
             // SonarCloud returns 404, WebClientDownloader returns null
             mockDownloader.Setup(x => x.Download(new Uri("http://myhost:222/api/qualityprofiles/search?defaults=true&organization=ThisIsInvalidValue"), false)).Returns(Task.FromResult<string>(null));
@@ -111,7 +109,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var qualityProfileUri = new Uri($"http://myhost:222/api/qualityprofiles/search?project={WebUtility.UrlEncode(projectKey)}");
             var profileResponse = $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}";
             var mockDownloader = new Mock<IDownloader>();
-            mockDownloader.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             mockDownloader.Setup(x => x.TryDownloadIfExists(qualityProfileUri, It.IsAny<bool>())).ReturnsAsync(Tuple.Create(true, profileResponse));
             sut = new SonarWebServerStub(mockDownloader.Object, new Version("9.9"), logger, null);
 
@@ -128,7 +125,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             const string profileKey = "profile1k";
             const string language = "cs";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/qualityprofiles/search?project={WebUtility.UrlEncode($"{projectKey}:{branchName}")}"), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}"));
             sut = new SonarWebServerStub(downloaderMock.Object, new Version("9.9"), logger, null);
@@ -147,7 +143,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             const string language = "cs";
             var qualityProfileUri = new Uri($"http://myhost:222/api/qualityprofiles/search?project={WebUtility.UrlEncode($"{projectKey}")}&organization={WebUtility.UrlEncode($"{organization}")}");
             var mockDownloader = new Mock<IDownloader>();
-            mockDownloader.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             mockDownloader.Setup(x => x.TryDownloadIfExists(qualityProfileUri, It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}"));
             sut = new SonarWebServerStub(mockDownloader.Object, version, logger, organization);
@@ -165,7 +160,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             const string profileKey = "defaultProfile";
             const string language = "cs";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/qualityprofiles/search?project={WebUtility.UrlEncode(projectKey)}"), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(false, (string)null));
             downloaderMock.Setup(x => x.Download(new Uri("http://myhost:222/api/qualityprofiles/search?defaults=true"), It.IsAny<bool>()))
@@ -185,7 +179,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             const string profileKey = "defaultProfile";
             const string language = "cs";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/qualityprofiles/search?project={WebUtility.UrlEncode(projectKey)}"), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, $"{{ profiles: [{{\"key\":\"{profileKey}\",\"name\":\"profile1\",\"language\":\"{language}\"}}]}}"));
             sut = new SonarWebServerStub(downloaderMock.Object, new Version("9.9"), logger, null);
@@ -202,7 +195,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             const string language = "cs";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/qualityprofiles/search?project={WebUtility.UrlEncode(projectKey)}"), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, "{ profiles: []}"));
             sut = new SonarWebServerStub(downloaderMock.Object, new Version("9.9"), logger, null);
@@ -217,7 +209,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task TryGetQualityProfile_MissingProfiles()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/qualityprofiles/search?project={ProjectKey}"), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, @"{""unexpected"": ""valid json""}"));
             sut = new SonarWebServerStub(downloaderMock.Object, new Version("9.9"), logger, null);
@@ -232,7 +223,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task TryGetQualityProfile_MissingKey()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadIfExists(new Uri($"http://myhost:222/api/qualityprofiles/search?project={ProjectKey}"), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, @"{""language"":""cs""}"));
             sut = new SonarWebServerStub(downloaderMock.Object, new Version("9.9"), logger, null);
@@ -249,7 +239,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task TryGetQualityProfile_SpecificProfileRequestUrl(string hostUrl)
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri(hostUrl));
             downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>()))
                           .ReturnsAsync(Tuple.Create(true, @"{ profiles: [ { ""key"":""p1"", ""name"":""p1"", ""language"":""cs"", ""isDefault"": false } ] }"));
             sut = new SonarWebServerStub(downloaderMock.Object, version, logger, null);
@@ -266,7 +255,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task TryGetQualityProfile_DefaultProfileRequestUrl(string hostUrl)
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri(hostUrl));
             downloaderMock.Setup(x => x.TryDownloadIfExists(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync(Tuple.Create(false, (string)null));
             downloaderMock.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>())).ReturnsAsync(@"{ profiles: [ { ""key"":""p1"", ""name"":""p1"", ""language"":""cs"", ""isDefault"": false } ] }");
             sut = new SonarWebServerStub(downloaderMock.Object, version, logger, null);
@@ -281,7 +269,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public void GetRules_UseParamAsKey()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.Download(It.IsAny<Uri>(), It.IsAny<bool>()))
                          .ReturnsAsync(@"{ total: 1, p: 1, ps: 1,
             rules: [{
@@ -690,7 +677,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task GetInstalledPlugins()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.Download(new Uri("http://myhost:222/api/languages/list"), It.IsAny<bool>()))
                           .ReturnsAsync("{ languages: [{ key: \"cs\", name: \"C#\" }, { key: \"flex\", name: \"Flex\" } ]}");
             sut = new SonarWebServerStub(downloaderMock.Object, version, logger, null);
@@ -729,7 +715,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task TryDownloadEmbeddedFile_RequestedFileExists()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadFileIfExists(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(true);
             sut = new SonarWebServerStub(downloaderMock.Object, version, logger, null);
 
@@ -742,7 +727,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task TryDownloadEmbeddedFile_RequestedFileDoesNotExist()
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri("http://myhost:222"));
             downloaderMock.Setup(x => x.TryDownloadFileIfExists(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(false);
             sut = new SonarWebServerStub(downloaderMock.Object, version, logger, null);
 
@@ -766,7 +750,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task GetAllLanguages_RequestUrl(string hostUrl, string languagesUrl)
         {
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri(hostUrl));
             downloaderMock.Setup(x => x.Download(new Uri(languagesUrl), It.IsAny<bool>())).ReturnsAsync("{ languages: [ ] }");
             sut = new SonarWebServerStub(downloaderMock.Object, version, logger, null);
 
@@ -783,7 +766,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             const string pluginKey = "csharp";
             const string fileName = "file.txt";
             var downloaderMock = new Mock<IDownloader>();
-            downloaderMock.Setup(x => x.GetBaseUri()).Returns(new Uri(hostUrl));
             downloaderMock.Setup(x => x.TryDownloadFileIfExists(It.IsAny<Uri>(), It.IsAny<string>(), It.IsAny<bool>())).ReturnsAsync(true);
             sut = new SonarWebServerStub(downloaderMock.Object, version, logger, null);
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
@@ -243,7 +243,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                 .Where(x => ((int)x >= 300 || (int)x < 200) && x != HttpStatusCode.Forbidden && x != HttpStatusCode.NotFound) // Those have specific tested behavior
                 .Select(x => new object[] { x });
 
-
         [TestMethod]
         [DynamicData(nameof(UnsuccessfulHttpCodeData))]
         public async Task TryDownloadIfExists_UnsuccessfulHttpCode_ShouldThrowWithLog(HttpStatusCode code)
@@ -313,7 +312,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             logger.AssertDebugLogged($"Downloading file from {BaseUrl}{RelativeUrl} to {fileName}...");
             logger.AssertWarningLogged("To analyze private projects make sure the scanner user has 'Browse' permission.");
         }
-
 
         [TestMethod]
         [DynamicData(nameof(UnsuccessfulHttpCodeData))]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
@@ -153,21 +153,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             logger.AssertNoWarningsLogged();
         }
 
-        [TestMethod]
-        [DataRow("https://sonarsource.com/", "https://sonarsource.com/")]
-        [DataRow("https://sonarsource.com", "https://sonarsource.com/")]
-        [DataRow("https://sonarsource.com/sonarlint", "https://sonarsource.com/sonarlint/")]
-        [DataRow("https://sonarsource.com/sonarlint/", "https://sonarsource.com/sonarlint/")]
-        public void GetBaseUri_ValidUrl_ShouldAlwaysEndsWithSlash(string baseUrl, string expectedUrl)
-        {
-            var sut = new WebClientDownloader(new HttpClient(), baseUrl, Mock.Of<ILogger>());
-
-            var result = sut.GetBaseUri();
-
-            result.ToString().Should().EndWith("/");
-            result.ToString().Should().Be(expectedUrl);
-        }
-
         private static HttpClient MockHttpClient(HttpResponseMessage responseMessage)
         {
             var httpMessageHandlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
@@ -24,7 +24,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -94,7 +93,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         [TestMethod]
-        public async Task DownloadResource_ReturnsTheResponse()
+        public async Task DownloadResource_HttpCodeOk_ReturnsTheResponse()
         {
             var logger = new TestLogger();
             var response = new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(TestContent) };
@@ -104,6 +103,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             responseMessage.Should().Be(response);
             logger.AssertDebugLogged($"Downloading from {BaseUrl}{RelativeUrl}...");
+            logger.AssertNoWarningsLogged();
         }
 
         [TestMethod]
@@ -153,32 +153,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var text = await sut.Download(RelativeUrl, true);
 
             text.Should().BeNull();
-            logger.AssertDebugLogged($"Downloading from {BaseUrl}{RelativeUrl}...");
-            logger.AssertNoWarningsLogged();
-        }
-
-        [TestMethod]
-        public async Task TryGetLicenseInformation_HttpCodeOk_SucceedWithLog()
-        {
-            var logger = new TestLogger();
-            var sut = CreateSut(logger, HttpStatusCode.OK);
-
-            var text = await sut.TryGetLicenseInformation(RelativeUrl);
-
-            text.Should().NotBeNull();
-            logger.AssertDebugLogged($"Downloading from {BaseUrl}{RelativeUrl}...");
-            logger.AssertNoWarningsLogged();
-        }
-
-        [TestMethod]
-        public async Task TryGetLicenseInformation_HttpCodeUnauthorized_ShouldThrowWithLog()
-        {
-            var logger = new TestLogger();
-            var sut = CreateSut(logger, HttpStatusCode.Unauthorized);
-
-            Func<Task> act = async () => await sut.TryGetLicenseInformation(RelativeUrl);
-
-            await act.Should().ThrowExactlyAsync<ArgumentException>().WithMessage("The token you provided doesn't have sufficient rights to check license.");
             logger.AssertDebugLogged($"Downloading from {BaseUrl}{RelativeUrl}...");
             logger.AssertNoWarningsLogged();
         }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
@@ -130,6 +130,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             text.Should().Be(TestContent);
             testLogger.AssertDebugLogged("Downloading from https://www.sonarsource.com/api/relative...");
+            testLogger.AssertNoWarningsLogged();
+            testLogger.AssertNoErrorsLogged();
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
@@ -193,18 +193,18 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         [TestMethod]
-        public async Task Download_HttpClientThrow_ShouldThrowAndLogError()
+        public async Task Download_HttpClientThrowAnyException_ShouldThrowAndLogError()
         {
             var httpMessageHandlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             httpMessageHandlerMock
                 .Protected()
-                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).ThrowsAsync(new HttpRequestException("error"));
+                .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>()).ThrowsAsync(new Exception("error"));
             var sut = new WebClientDownloader(new HttpClient(httpMessageHandlerMock.Object), BaseUrl, testLogger);
 
             Func<Task> act = async () =>  await sut.Download("api/relative", true);
 
-            await act.Should().ThrowAsync<HttpRequestException>();
-            testLogger.Errors.Should().HaveCount(1);
+            await act.Should().ThrowAsync<Exception>();
+            testLogger.AssertSingleErrorExists("An error occured when calling 'https://www.sonarsource.com/api/relative': error");
         }
 
         [TestMethod]
@@ -220,7 +220,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             Func<Task> act = async () =>  await sut.Download("api/relative", true);
 
             await act.Should().ThrowAsync<HttpRequestException>();
-            testLogger.Errors.Should().HaveCount(1);
             testLogger.AssertSingleErrorExists("Unable to connect to server. Please check if the server is running and if the address is correct. Url: 'https://www.sonarsource.com/api/relative'.");
         }
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
@@ -221,7 +221,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             await act.Should().ThrowAsync<HttpRequestException>();
             testLogger.Errors.Should().HaveCount(1);
-            testLogger.AssertErrorLogged("Unable to connect to server. Please check if the server is running and if the address is correct. Url: 'https://www.sonarsource.com/api/relative'.");
+            testLogger.AssertSingleErrorExists("Unable to connect to server. Please check if the server is running and if the address is correct. Url: 'https://www.sonarsource.com/api/relative'.");
         }
 
         [TestMethod]

--- a/Tests/TestUtilities/TempFile.cs
+++ b/Tests/TestUtilities/TempFile.cs
@@ -1,16 +1,32 @@
-﻿using System;
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
 using System.IO;
 
 namespace TestUtilities
 {
     public sealed class TempFile : IDisposable
     {
-        public string FileName { get; }
+        public string FileName { get; } = Path.GetRandomFileName();
 
-        public TempFile()
-        {
-            FileName = Path.GetRandomFileName();
-        }
         public void Dispose()
         {
             if (File.Exists(FileName))

--- a/Tests/TestUtilities/TempFile.cs
+++ b/Tests/TestUtilities/TempFile.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.IO;
+
+namespace TestUtilities
+{
+    public class TempFile : IDisposable
+    {
+        public string FileName { get; }
+
+        public TempFile()
+        {
+            FileName = Path.GetRandomFileName();
+        }
+        public void Dispose()
+        {
+            if (File.Exists(FileName))
+            {
+                File.Delete(FileName);
+            }
+        }
+    }
+}

--- a/Tests/TestUtilities/TempFile.cs
+++ b/Tests/TestUtilities/TempFile.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace TestUtilities
 {
-    public class TempFile : IDisposable
+    public sealed class TempFile : IDisposable
     {
         public string FileName { get; }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IDownloader.cs
@@ -50,7 +50,5 @@ namespace SonarScanner.MSBuild.PreProcessor
         Task<Stream> DownloadStream(Uri url);
 
         Task<HttpResponseMessage> DownloadResource(Uri url);
-
-        Uri GetBaseUri();
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IDownloader.cs
@@ -35,20 +35,22 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// </summary>
         /// <returns>False if the url does not exist, true if the contents were downloaded successfully.
         /// Exceptions are thrown for other web failures.</returns>
-        Task<Tuple<bool, string>> TryDownloadIfExists(Uri url, bool logPermissionDenied = false);
+        Task<Tuple<bool, string>> TryDownloadIfExists(string url, bool logPermissionDenied = false);
 
         /// <summary>
         /// Attempts to download the specified file.
         /// </summary>
+        /// <param name="url"></param>
         /// <param name="targetFilePath">The file to which the downloaded data should be saved.</param>
+        /// <param name="logPermissionDenied"></param>
         /// <returns>False if the url does not exist, true if the data was downloaded successfully.
         /// Exceptions are thrown for other web failures.</returns>
-        Task<bool> TryDownloadFileIfExists(Uri url, string targetFilePath, bool logPermissionDenied = false);
+        Task<bool> TryDownloadFileIfExists(string url, string targetFilePath, bool logPermissionDenied = false);
 
-        Task<string> Download(Uri url, bool logPermissionDenied = false);
+        Task<string> Download(string url, bool logPermissionDenied = false);
 
-        Task<Stream> DownloadStream(Uri url);
+        Task<Stream> DownloadStream(string url);
 
-        Task<HttpResponseMessage> DownloadResource(Uri url);
+        Task<HttpResponseMessage> DownloadResource(string url);
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IDownloader.cs
@@ -40,9 +40,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// <summary>
         /// Attempts to download the specified file.
         /// </summary>
-        /// <param name="url"></param>
         /// <param name="targetFilePath">The file to which the downloaded data should be saved.</param>
-        /// <param name="logPermissionDenied"></param>
         /// <returns>False if the url does not exist, true if the data was downloaded successfully.
         /// Exceptions are thrown for other web failures.</returns>
         Task<bool> TryDownloadFileIfExists(string url, string targetFilePath, bool logPermissionDenied = false);

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -82,20 +82,19 @@ namespace SonarScanner.MSBuild.PreProcessor
 
         private async Task<Version> QueryServerVersion(IDownloader downloader)
         {
-            var uri = new Uri(downloader.GetBaseUri(), "api/server/version");
             try
             {
-                var contents = await downloader.Download(uri);
+                var contents = await downloader.Download(new Uri("api/server/version"));
                 return new Version(contents.Split('-').First());
             }
             catch (HttpRequestException e) when (e.InnerException is WebException { Status: WebExceptionStatus.ConnectFailure })
             {
-                logger.LogError(Resources.ERR_UnableToConnectToServer, uri);
+                logger.LogError(Resources.ERR_UnableToConnectToServer);
                 return null;
             }
             catch (Exception e)
             {
-                logger.LogError(Resources.ERR_ErrorDuringWebCall, uri, e.Message);
+                logger.LogError(Resources.ERR_ErrorDuringWebCall, e.Message);
                 return null;
             }
         }

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -20,10 +20,6 @@
 
 using System;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.PreProcessor.Roslyn;
@@ -90,14 +86,8 @@ namespace SonarScanner.MSBuild.PreProcessor
                 var contents = await downloader.Download("api/server/version");
                 return new Version(contents.Split('-').First());
             }
-            catch (HttpRequestException e) when (e.InnerException is WebException { Status: WebExceptionStatus.ConnectFailure })
+            catch (Exception)
             {
-                logger.LogError(Resources.ERR_UnableToConnectToServer);
-                return null;
-            }
-            catch (Exception e)
-            {
-                logger.LogError(Resources.ERR_ErrorDuringWebCall, e.Message);
                 return null;
             }
         }

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -84,7 +84,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         {
             try
             {
-                var contents = await downloader.Download(new Uri("api/server/version"));
+                var contents = await downloader.Download("api/server/version");
                 return new Version(contents.Split('-').First());
             }
             catch (HttpRequestException e) when (e.InnerException is WebException { Status: WebExceptionStatus.ConnectFailure })

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -22,6 +22,8 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.PreProcessor.Roslyn;
@@ -82,6 +84,7 @@ namespace SonarScanner.MSBuild.PreProcessor
 
         private async Task<Version> QueryServerVersion(IDownloader downloader)
         {
+            logger.LogDebug(Resources.MSG_FetchingVersion);
             try
             {
                 var contents = await downloader.Download("api/server/version");

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -252,7 +252,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Downloading from {0}{1} failed. Http status code is {2}..
+        ///   Looks up a localized string similar to Downloading from {0} failed. Http status code is {1}..
         /// </summary>
         internal static string MSG_DownloadFailed {
             get {
@@ -261,7 +261,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Downloading from {0}{1}....
+        ///   Looks up a localized string similar to Downloading from {0}....
         /// </summary>
         internal static string MSG_Downloading {
             get {
@@ -279,7 +279,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Downloading file from {0}{1} to {2}....
+        ///   Looks up a localized string similar to Downloading file to {0}....
         /// </summary>
         internal static string MSG_DownloadingFile {
             get {
@@ -338,6 +338,15 @@ namespace SonarScanner.MSBuild.PreProcessor {
         internal static string MSG_FetchingRules {
             get {
                 return ResourceManager.GetString("MSG_FetchingRules", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fetching server version....
+        /// </summary>
+        internal static string MSG_FetchingVersion {
+            get {
+                return ResourceManager.GetString("MSG_FetchingVersion", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -114,7 +114,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occured when calling &apos;{0}&apos;: {1}.
+        ///   Looks up a localized string similar to An error occured when calling: {0}.
         /// </summary>
         internal static string ERR_ErrorDuringWebCall {
             get {
@@ -132,7 +132,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to connect to server. Please check if the server is running and if the address is correct. Url: &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Unable to connect to server. Please check if the server is running and if the address is correct..
         /// </summary>
         internal static string ERR_UnableToConnectToServer {
             get {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -114,7 +114,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occured when calling: {0}.
+        ///   Looks up a localized string similar to An error occured when calling &apos;{0}&apos;: {1}.
         /// </summary>
         internal static string ERR_ErrorDuringWebCall {
             get {
@@ -132,7 +132,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to connect to server. Please check if the server is running and if the address is correct..
+        ///   Looks up a localized string similar to Unable to connect to server. Please check if the server is running and if the address is correct. Url: &apos;{0}&apos;..
         /// </summary>
         internal static string ERR_UnableToConnectToServer {
             get {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -261,7 +261,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Downloading from {0}....
+        ///   Looks up a localized string similar to Downloading from {0}{1}....
         /// </summary>
         internal static string MSG_Downloading {
             get {
@@ -279,7 +279,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Downloading file from {0} to {1}....
+        ///   Looks up a localized string similar to Downloading file from {0}{1} to {2}....
         /// </summary>
         internal static string MSG_DownloadingFile {
             get {
@@ -288,7 +288,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Downloading {0} from {1} to {2}.
+        ///   Looks up a localized string similar to Downloading {0} to {1}.
         /// </summary>
         internal static string MSG_DownloadingZip {
             get {
@@ -315,7 +315,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fetching properties for project &apos;{0}&apos; from {1}....
+        ///   Looks up a localized string similar to Fetching properties for project &apos;{0}&apos;....
         /// </summary>
         internal static string MSG_FetchingProjectProperties {
             get {
@@ -324,7 +324,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fetching quality profile for project &apos;{0}&apos; from {1}....
+        ///   Looks up a localized string similar to Fetching quality profile for project &apos;{0}&apos;....
         /// </summary>
         internal static string MSG_FetchingQualityProfile {
             get {
@@ -333,7 +333,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fetching rules for quality profile &apos;{0}&apos; from {1}....
+        ///   Looks up a localized string similar to Fetching rules for quality profile &apos;{0}&apos;....
         /// </summary>
         internal static string MSG_FetchingRules {
             get {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -252,7 +252,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Downloading from {0} failed. Http status code is {1}..
+        ///   Looks up a localized string similar to Downloading from {0}{1} failed. Http status code is {2}..
         /// </summary>
         internal static string MSG_DownloadFailed {
             get {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -169,10 +169,10 @@ Use '/?' or '/h' to see the help message.</value>
     <value>Your SonarQube instance seems to have an invalid license. Please check it. Server url: {0}</value>
   </data>
   <data name="ERR_UnableToConnectToServer" xml:space="preserve">
-    <value>Unable to connect to server. Please check if the server is running and if the address is correct. Url: '{0}'.</value>
+    <value>Unable to connect to server. Please check if the server is running and if the address is correct.</value>
   </data>
   <data name="ERR_ErrorDuringWebCall" xml:space="preserve">
-    <value>An error occured when calling '{0}': {1}</value>
+    <value>An error occured when calling: {0}</value>
   </data>
   <data name="MSG_CE_Detected_LicenseValid" xml:space="preserve">
     <value>SonarQube Community Edition detected, license is valid.</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -190,7 +190,7 @@ Use '/?' or '/h' to see the help message.</value>
     <value>Downloading from {0}{1}...</value>
   </data>
   <data name="MSG_DownloadFailed" xml:space="preserve">
-    <value>Downloading from {0} failed. Http status code is {1}.</value>
+    <value>Downloading from {0}{1} failed. Http status code is {2}.</value>
   </data>
   <data name="MSG_DownloadingFile" xml:space="preserve">
     <value>Downloading file from {0}{1} to {2}...</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -187,13 +187,13 @@ Use '/?' or '/h' to see the help message.</value>
     <value>Creating config and output folders...</value>
   </data>
   <data name="MSG_Downloading" xml:space="preserve">
-    <value>Downloading from {0}{1}...</value>
+    <value>Downloading from {0}...</value>
   </data>
   <data name="MSG_DownloadFailed" xml:space="preserve">
-    <value>Downloading from {0}{1} failed. Http status code is {2}.</value>
+    <value>Downloading from {0} failed. Http status code is {1}.</value>
   </data>
   <data name="MSG_DownloadingFile" xml:space="preserve">
-    <value>Downloading file from {0}{1} to {2}...</value>
+    <value>Downloading file to {0}...</value>
   </data>
   <data name="MSG_DownloadingZip" xml:space="preserve">
     <value>Downloading {0} to {1}</value>
@@ -206,6 +206,9 @@ Use '/?' or '/h' to see the help message.</value>
   </data>
   <data name="MSG_FetchingAnalysisConfiguration" xml:space="preserve">
     <value>Fetching analysis configuration settings...</value>
+  </data>
+  <data name="MSG_FetchingVersion" xml:space="preserve">
+    <value>Fetching server version...</value>
   </data>
   <data name="MSG_FetchingProjectProperties" xml:space="preserve">
     <value>Fetching properties for project '{0}'...</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -169,10 +169,10 @@ Use '/?' or '/h' to see the help message.</value>
     <value>Your SonarQube instance seems to have an invalid license. Please check it. Server url: {0}</value>
   </data>
   <data name="ERR_UnableToConnectToServer" xml:space="preserve">
-    <value>Unable to connect to server. Please check if the server is running and if the address is correct.</value>
+    <value>Unable to connect to server. Please check if the server is running and if the address is correct. Url: '{0}'.</value>
   </data>
   <data name="ERR_ErrorDuringWebCall" xml:space="preserve">
-    <value>An error occured when calling: {0}</value>
+    <value>An error occured when calling '{0}': {1}</value>
   </data>
   <data name="MSG_CE_Detected_LicenseValid" xml:space="preserve">
     <value>SonarQube Community Edition detected, license is valid.</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -187,16 +187,16 @@ Use '/?' or '/h' to see the help message.</value>
     <value>Creating config and output folders...</value>
   </data>
   <data name="MSG_Downloading" xml:space="preserve">
-    <value>Downloading from {0}...</value>
+    <value>Downloading from {0}{1}...</value>
   </data>
   <data name="MSG_DownloadFailed" xml:space="preserve">
     <value>Downloading from {0} failed. Http status code is {1}.</value>
   </data>
   <data name="MSG_DownloadingFile" xml:space="preserve">
-    <value>Downloading file from {0} to {1}...</value>
+    <value>Downloading file from {0}{1} to {2}...</value>
   </data>
   <data name="MSG_DownloadingZip" xml:space="preserve">
-    <value>Downloading {0} from {1} to {2}</value>
+    <value>Downloading {0} to {1}</value>
   </data>
   <data name="MSG_DownloadingCache" xml:space="preserve">
     <value>Downloading cache. Project key: {0}, branch: {1}.</value>
@@ -208,13 +208,13 @@ Use '/?' or '/h' to see the help message.</value>
     <value>Fetching analysis configuration settings...</value>
   </data>
   <data name="MSG_FetchingProjectProperties" xml:space="preserve">
-    <value>Fetching properties for project '{0}' from {1}...</value>
+    <value>Fetching properties for project '{0}'...</value>
   </data>
   <data name="MSG_FetchingQualityProfile" xml:space="preserve">
-    <value>Fetching quality profile for project '{0}' from {1}...</value>
+    <value>Fetching quality profile for project '{0}'...</value>
   </data>
   <data name="MSG_FetchingRules" xml:space="preserve">
-    <value>Fetching rules for quality profile '{0}' from {1}...</value>
+    <value>Fetching rules for quality profile '{0}'...</value>
   </data>
   <data name="MSG_Forbidden_BrowsePermission" xml:space="preserve">
     <value>To analyze private projects make sure the scanner user has 'Browse' permission.</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
@@ -149,7 +149,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             catch (HttpRequestException e) when (e.InnerException is WebException { Status: WebExceptionStatus.ConnectFailure })
             {
                 logger.LogError(Resources.ERR_UnableToConnectToServer, $"{client.BaseAddress}{url}");
-                return null;
+                throw;
             }
             catch (Exception e)
             {

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
@@ -41,13 +41,13 @@ namespace SonarScanner.MSBuild.PreProcessor
             client.BaseAddress = WebUtils.CreateUri(baseUri);
         }
 
-        public async Task<HttpResponseMessage> DownloadResource(Uri url)
+        public async Task<HttpResponseMessage> DownloadResource(string url)
         {
             logger.LogDebug(Resources.MSG_Downloading, client.BaseAddress, url);
             return await client.GetAsync(url).ConfigureAwait(false);
         }
 
-        public async Task<Tuple<bool, string>> TryDownloadIfExists(Uri url, bool logPermissionDenied = false)
+        public async Task<Tuple<bool, string>> TryDownloadIfExists(string url, bool logPermissionDenied = false)
         {
             logger.LogDebug(Resources.MSG_Downloading, client.BaseAddress, url);
             var response = await client.GetAsync(url).ConfigureAwait(false);
@@ -76,7 +76,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             return new Tuple<bool, string>(false, null);
         }
 
-        public async Task<bool> TryDownloadFileIfExists(Uri url, string targetFilePath, bool logPermissionDenied = false)
+        public async Task<bool> TryDownloadFileIfExists(string url, string targetFilePath, bool logPermissionDenied = false)
         {
             logger.LogDebug(Resources.MSG_DownloadingFile, client.BaseAddress, url, targetFilePath);
             var response = await client.GetAsync(url).ConfigureAwait(false);
@@ -108,7 +108,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             return false;
         }
 
-        public async Task<string> Download(Uri url, bool logPermissionDenied = false)
+        public async Task<string> Download(string url, bool logPermissionDenied = false)
         {
             logger.LogDebug(Resources.MSG_Downloading, client.BaseAddress, url);
             var response = await client.GetAsync(url).ConfigureAwait(false);
@@ -119,7 +119,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             }
             else
             {
-                logger.LogInfo(Resources.MSG_DownloadFailed, url, response.StatusCode);
+                logger.LogInfo(Resources.MSG_DownloadFailed, client.BaseAddress, url, response.StatusCode);
             }
 
             if (logPermissionDenied && response.StatusCode == HttpStatusCode.Forbidden)
@@ -131,7 +131,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             return null;
         }
 
-        public async Task<Stream> DownloadStream(Uri url)
+        public async Task<Stream> DownloadStream(string url)
         {
             logger.LogDebug(Resources.MSG_Downloading, client.BaseAddress, url);
             var response = await client.GetAsync(url);
@@ -141,7 +141,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             }
             else
             {
-                logger.LogInfo(Resources.MSG_DownloadFailed, url, response.StatusCode);
+                logger.LogInfo(Resources.MSG_DownloadFailed, client.BaseAddress, url, response.StatusCode);
                 return null;
             }
         }

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
@@ -31,7 +31,6 @@ namespace SonarScanner.MSBuild.PreProcessor
     {
         private readonly ILogger logger;
         private readonly HttpClient client;
-        private readonly Uri baseUri;
 
         public WebClientDownloader(HttpClient client, string baseUri, ILogger logger)
         {
@@ -39,20 +38,18 @@ namespace SonarScanner.MSBuild.PreProcessor
             Contract.ThrowIfNullOrWhitespace(baseUri, nameof(baseUri));
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-            this.baseUri = WebUtils.CreateUri(baseUri);
+            client.BaseAddress = WebUtils.CreateUri(baseUri);
         }
 
         public async Task<HttpResponseMessage> DownloadResource(Uri url)
         {
-            logger.LogDebug(Resources.MSG_Downloading, url);
+            logger.LogDebug(Resources.MSG_Downloading, client.BaseAddress, url);
             return await client.GetAsync(url).ConfigureAwait(false);
         }
 
-        public Uri GetBaseUri() => baseUri;
-
         public async Task<Tuple<bool, string>> TryDownloadIfExists(Uri url, bool logPermissionDenied = false)
         {
-            logger.LogDebug(Resources.MSG_Downloading, url);
+            logger.LogDebug(Resources.MSG_Downloading, client.BaseAddress, url);
             var response = await client.GetAsync(url).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
@@ -81,7 +78,7 @@ namespace SonarScanner.MSBuild.PreProcessor
 
         public async Task<bool> TryDownloadFileIfExists(Uri url, string targetFilePath, bool logPermissionDenied = false)
         {
-            logger.LogDebug(Resources.MSG_DownloadingFile, url, targetFilePath);
+            logger.LogDebug(Resources.MSG_DownloadingFile, client.BaseAddress, url, targetFilePath);
             var response = await client.GetAsync(url).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
@@ -113,7 +110,7 @@ namespace SonarScanner.MSBuild.PreProcessor
 
         public async Task<string> Download(Uri url, bool logPermissionDenied = false)
         {
-            logger.LogDebug(Resources.MSG_Downloading, url);
+            logger.LogDebug(Resources.MSG_Downloading, client.BaseAddress, url);
             var response = await client.GetAsync(url).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
@@ -136,7 +133,7 @@ namespace SonarScanner.MSBuild.PreProcessor
 
         public async Task<Stream> DownloadStream(Uri url)
         {
-            logger.LogDebug(Resources.MSG_Downloading, url);
+            logger.LogDebug(Resources.MSG_Downloading, client.BaseAddress, url);
             var response = await client.GetAsync(url);
             if (response.IsSuccessStatusCode)
             {

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
@@ -99,6 +99,8 @@ namespace SonarScanner.MSBuild.PreProcessor
 
         public async Task<string> Download(string url, bool logPermissionDenied = false)
         {
+            Contract.ThrowIfNullOrWhitespace(url, nameof(url));
+
             var response = await GetAsync(url);
 
             if (response.IsSuccessStatusCode)

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
@@ -146,9 +146,14 @@ namespace SonarScanner.MSBuild.PreProcessor
                 logger.LogDebug(Resources.MSG_Downloading, response.RequestMessage.RequestUri);
                 return response;
             }
-            catch (HttpRequestException e)
+            catch (HttpRequestException e) when (e.InnerException is WebException { Status: WebExceptionStatus.ConnectFailure })
             {
-                logger.LogError(e.Message);
+                logger.LogError(Resources.ERR_UnableToConnectToServer, $"{client.BaseAddress}{url}");
+                return null;
+            }
+            catch (Exception e)
+            {
+                logger.LogError(Resources.ERR_ErrorDuringWebCall, $"{client.BaseAddress}{url}", e.Message);
                 throw;
             }
         }

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
@@ -120,14 +120,9 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
         {
             var uri = GetUri("api/properties?resource={0}", projectId);
             logger.LogDebug(Resources.MSG_FetchingProjectProperties, projectId);
-            var result = await ExecuteWithLogs(async () =>
-            {
-                var contents = await downloader.Download(uri, true);
-                var properties = JArray.Parse(contents);
-                return properties.ToDictionary(p => p["key"].ToString(), p => p["value"].ToString());
-            });
-
-            return CheckTestProjectPattern(result);
+            var contents = await downloader.Download(uri, true);
+            var properties = JArray.Parse(contents);
+            return CheckTestProjectPattern(properties.ToDictionary(p => p["key"].ToString(), p => p["value"].ToString()));
         }
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
@@ -44,7 +44,7 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
         public override async Task<bool> IsServerLicenseValid()
         {
             logger.LogDebug(Resources.MSG_CheckingLicenseValidity);
-            var uri = GetUri("api/editions/is_valid_license");
+            var uri = "api/editions/is_valid_license";
             var response = await downloader.DownloadResource(uri);
             if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
@@ -97,7 +97,7 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
             try
             {
                 logger.LogInfo(Resources.MSG_DownloadingCache, localSettings.ProjectKey, branch);
-                var uri = GetUri("api/analysis_cache/get?project={0}&branch={1}", localSettings.ProjectKey, branch);
+                var uri = WebUtils.Escape("api/analysis_cache/get?project={0}&branch={1}", localSettings.ProjectKey, branch);
                 using var stream = await downloader.DownloadStream(uri);
                 return ParseCacheEntries(stream);
             }
@@ -118,7 +118,7 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
 
         private async Task<IDictionary<string, string>> DownloadComponentPropertiesLegacy(string projectId)
         {
-            var uri = GetUri("api/properties?resource={0}", projectId);
+            var uri = WebUtils.Escape("api/properties?resource={0}", projectId);
             logger.LogDebug(Resources.MSG_FetchingProjectProperties, projectId);
             var contents = await downloader.Download(uri, true);
             var properties = JArray.Parse(contents);

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
@@ -44,8 +44,7 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
         public override async Task<bool> IsServerLicenseValid()
         {
             logger.LogDebug(Resources.MSG_CheckingLicenseValidity);
-            var uri = "api/editions/is_valid_license";
-            var response = await downloader.DownloadResource(uri);
+            var response = await downloader.DownloadResource("api/editions/is_valid_license");
             if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
                 logger.LogError(Resources.ERR_InvalidCredentials);

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
@@ -113,7 +113,7 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
                 ? await base.DownloadComponentProperties(component)
                 : await DownloadComponentPropertiesLegacy(component);
 
-        protected override Uri AddOrganization(Uri uri) =>
+        protected override string AddOrganization(string uri) =>
             serverVersion.CompareTo(new Version(6, 3)) < 0 ? uri : base.AddOrganization(uri);
 
         private async Task<IDictionary<string, string>> DownloadComponentPropertiesLegacy(string projectId)

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
@@ -119,13 +119,13 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
         private async Task<IDictionary<string, string>> DownloadComponentPropertiesLegacy(string projectId)
         {
             var uri = GetUri("api/properties?resource={0}", projectId);
-            logger.LogDebug(Resources.MSG_FetchingProjectProperties, projectId, uri);
+            logger.LogDebug(Resources.MSG_FetchingProjectProperties, projectId);
             var result = await ExecuteWithLogs(async () =>
             {
                 var contents = await downloader.Download(uri, true);
                 var properties = JArray.Parse(contents);
                 return properties.ToDictionary(p => p["key"].ToString(), p => p["value"].ToString());
-            }, uri);
+            });
 
             return CheckTestProjectPattern(result);
         }

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServer.cs
@@ -222,13 +222,13 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
             return settings;
         }
 
-        protected Uri GetUri(string query, params string[] args) =>
-            new(WebUtils.Escape(query, args));
+        protected string GetUri(string query, params string[] args) =>
+            WebUtils.Escape(query, args);
 
-        protected virtual Uri AddOrganization(Uri uri) =>
+        protected virtual string AddOrganization(string uri) =>
             string.IsNullOrEmpty(organization)
                 ? uri
-                : new Uri(uri + $"&organization={WebUtility.UrlEncode(organization)}");
+                : uri + $"&organization={WebUtility.UrlEncode(organization)}";
 
         private Dictionary<string, string> ParseSettingsResponse(string contents)
         {

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServer.cs
@@ -114,9 +114,7 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
 
         public async Task<IEnumerable<string>> GetAllLanguages()
         {
-            var uri = "api/languages/list";
-            var contents = await downloader.Download(uri);
-
+            var contents = await downloader.Download("api/languages/list");
             var langArray = JObject.Parse(contents).Value<JArray>("languages");
             return langArray.Select(obj => obj["key"].ToString());
         }
@@ -176,9 +174,8 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
             var contents = projectFound.Item2;
             if (projectFound is { Item1: false })
             {
-                uri = "api/settings/values";
                 logger.LogDebug("No settings for project {0}. Getting global settings...", component);
-                contents = await downloader.Download(uri);
+                contents = await downloader.Download("api/settings/values");
             }
 
             return ParseSettingsResponse(contents);
@@ -203,7 +200,7 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
         protected virtual string AddOrganization(string uri) =>
             string.IsNullOrEmpty(organization)
                 ? uri
-                : uri + $"&organization={WebUtility.UrlEncode(organization)}";
+                : $"{uri}&organization={WebUtility.UrlEncode(organization)}";
 
         private Dictionary<string, string> ParseSettingsResponse(string contents)
         {


### PR DESCRIPTION
Fixes #1484

As part of #1484, now relying on relative URL path only:

- Base URL set in the `HttpClient.BaseAddress`
- `IDownloader` using string only for handling relative path.
