### PR TITLE
When no parameter is given, the S4NET prints the help message

### DIFF
--- a/Tests/SonarScanner.MSBuild.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Test/ArgumentProcessorTests.cs
@@ -69,11 +69,18 @@ namespace SonarScanner.MSBuild.Test
         [TestMethod]
         public void ArgProc_Help()
         {
-            ArgumentProcessor.IsHelp(new string[] { "sad", "/d:s=r", "/h" }).Should().BeTrue();
-            ArgumentProcessor.IsHelp(new string[] { "sad", "/d:s=r", "/hr" }).Should().BeFalse();
+            ArgumentProcessor.IsHelp(new[] { "/other", "-other" }).Should().BeFalse();
 
-            ArgumentProcessor.IsHelp(new string[] { "sad", "/d:s=r", "/?" }).Should().BeTrue();
-            ArgumentProcessor.IsHelp(new string[] { "sad", "/d:s=r", "/??" }).Should().BeFalse();
+            ArgumentProcessor.IsHelp(Array.Empty<string>()).Should().BeTrue();
+
+            ArgumentProcessor.IsHelp(new[] { "/?", "/other" }).Should().BeTrue();
+            ArgumentProcessor.IsHelp(new[] { "-?", "-other" }).Should().BeTrue();
+
+            ArgumentProcessor.IsHelp(new[] { "/h", "/other" }).Should().BeTrue();
+            ArgumentProcessor.IsHelp(new[] { "-h", "-other" }).Should().BeTrue();
+
+            ArgumentProcessor.IsHelp(new[] { "/help", "/other" }).Should().BeTrue();
+            ArgumentProcessor.IsHelp(new[] { "-help", "-other" }).Should().BeTrue();
         }
 
         [TestMethod]

--- a/src/SonarScanner.MSBuild.Common/CommandLine/CommandLineFlagPrefix.cs
+++ b/src/SonarScanner.MSBuild.Common/CommandLine/CommandLineFlagPrefix.cs
@@ -24,7 +24,7 @@ namespace SonarScanner.MSBuild.Common.CommandLine
 {
     public static class CommandLineFlagPrefix
     {
-        private static readonly char[] Prefixes = new[] { '-', '/' };
+        private static readonly char[] Prefixes = { '-', '/' };
 
         public static string[] GetPrefixedFlags(params string[] flags)
         {

--- a/src/SonarScanner.MSBuild/ArgumentProcessor.cs
+++ b/src/SonarScanner.MSBuild/ArgumentProcessor.cs
@@ -73,19 +73,9 @@ namespace SonarScanner.MSBuild
 
         #region Public methods
 
-        public static bool IsHelp(string[] commandLineArgs)
-        {
-            var helpPrefixes = CommandLineFlagPrefix.GetPrefixedFlags("h", "?");
-
-            foreach (var helpPrefix in helpPrefixes)
-            {
-                if (commandLineArgs.Contains(helpPrefix))
-                {
-                    return true;
-                }
-            }
-            return false;
-        }
+        public static bool IsHelp(string[] commandLineArgs) =>
+            commandLineArgs.Length == 0
+            || CommandLineFlagPrefix.GetPrefixedFlags("?", "h", "help").Any(commandLineArgs.Contains);
 
         /// <summary>
         /// Attempts to process the supplied command line arguments and reports any errors using the logger.

--- a/src/SonarScanner.MSBuild/ArgumentProcessor.cs
+++ b/src/SonarScanner.MSBuild/ArgumentProcessor.cs
@@ -149,6 +149,7 @@ namespace SonarScanner.MSBuild
             else if (!hasBeginVerb && !hasEndVerb) // neither
             {
                 // Backwards compatibility - decide the phase based on the number of arguments passed
+                // See: https://github.com/SonarSource/sonar-scanner-msbuild/issues/1540
                 phase = originalArgCount == 0 ? AnalysisPhase.PostProcessing : AnalysisPhase.PreProcessing;
                 logger.LogWarning(Resources.WARN_CmdLine_v09_Compat);
             }


### PR DESCRIPTION
Fixes #1279
