### PR TITLE
Display a message if the version cannot be parsed

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -50,7 +50,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         [TestMethod]
-        public async Task CreateSonarWebService_RequestServerVersionFailedDueToGenericException_ShouldReturnNull()
+        public async Task CreateSonarWebService_RequestServerVersionThrows_ShouldReturnNullAndLogError()
         {
             var sut = new PreprocessorObjectFactory(logger);
             var downloader =  new Mock<IDownloader>(MockBehavior.Strict);
@@ -60,7 +60,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             result.Should().BeNull();
             logger.AssertNoWarningsLogged();
-            logger.AssertNoErrorsLogged();
+            logger.AssertSingleErrorExists("An error occured while querying the server version! Please check if the server is running and if the address is correct.");
         }
 
         [TestMethod]
@@ -85,21 +85,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             result.Should().BeNull();
             logger.AssertSingleErrorExists("The URL (myhost:222) provided does not contain the scheme. Please include 'http://' or 'https://' at the beginning.");
             logger.AssertNoWarningsLogged();
-        }
-
-        [TestMethod]
-        public async Task CreateSonarWebService_RequestServerVersionFailedDueToHttpRequestException_ShouldReturnNull()
-        {
-            var sut = new PreprocessorObjectFactory(logger);
-            var exception = new HttpRequestException(string.Empty, new WebException(string.Empty, WebExceptionStatus.ConnectFailure));
-            var downloader =  new Mock<IDownloader>(MockBehavior.Strict);
-            downloader.Setup(x => x.Download(It.IsAny<string>(), It.IsAny<bool>())).Throws(exception);
-
-            var result = await sut.CreateSonarWebServer(CreateValidArguments(), downloader.Object);
-
-            result.Should().BeNull();
-            logger.AssertNoWarningsLogged();
-            logger.AssertNoErrorsLogged();
         }
 
         [DataTestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderTest.cs
@@ -97,6 +97,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var text = await reader.ReadToEndAsync();
             text.Should().Be(TestContent);
             testLogger.AssertDebugLogged("Downloading from https://www.sonarsource.com/api/relative...");
+            testLogger.AssertDebugLogged("Response received from https://www.sonarsource.com/api/relative...");
+            testLogger.AssertNoErrorsLogged();
         }
 
         [TestMethod]
@@ -208,7 +210,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             Func<Task> act = async () =>  await sut.Download("api/relative", true);
 
             await act.Should().ThrowAsync<Exception>();
-            testLogger.AssertSingleErrorExists("An error occured when calling 'https://www.sonarsource.com/api/relative': error");
+            testLogger.AssertSingleErrorExists("Unable to connect to server. Please check if the server is running and if the address is correct. Url: 'https://www.sonarsource.com/api/relative'.");
         }
 
         [TestMethod]

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -106,6 +106,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             }
             catch (Exception)
             {
+                logger.LogError(Resources.ERR_ErrorWhenQueryingServerVersion);
                 return null;
             }
         }

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -114,11 +114,11 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occured when calling &apos;{0}&apos;: {1}.
+        ///   Looks up a localized string similar to An error occured while querying the server version! Please check if the server is running and if the address is correct..
         /// </summary>
-        internal static string ERR_ErrorDuringWebCall {
+        internal static string ERR_ErrorWhenQueryingServerVersion {
             get {
-                return ResourceManager.GetString("ERR_ErrorDuringWebCall", resourceCulture);
+                return ResourceManager.GetString("ERR_ErrorWhenQueryingServerVersion", resourceCulture);
             }
         }
         
@@ -536,6 +536,15 @@ namespace SonarScanner.MSBuild.PreProcessor {
         internal static string MSG_Processing_PullRequest_RequestPrepareRead {
             get {
                 return ResourceManager.GetString("MSG_Processing_PullRequest_RequestPrepareRead", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Response received from {0}....
+        /// </summary>
+        internal static string MSG_ResponseReceived {
+            get {
+                return ResourceManager.GetString("MSG_ResponseReceived", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -171,9 +171,6 @@ Use '/?' or '/h' to see the help message.</value>
   <data name="ERR_UnableToConnectToServer" xml:space="preserve">
     <value>Unable to connect to server. Please check if the server is running and if the address is correct. Url: '{0}'.</value>
   </data>
-  <data name="ERR_ErrorDuringWebCall" xml:space="preserve">
-    <value>An error occured when calling '{0}': {1}</value>
-  </data>
   <data name="ERR_MissingOrganization" xml:space="preserve">
     <value>Organization parameter (/o:"&lt;organization&gt;") is required and needs to be provided!</value>
   </data>
@@ -182,6 +179,9 @@ Use '/?' or '/h' to see the help message.</value>
   </data>
   <data name="ERR_MissingUriScheme" xml:space="preserve">
     <value>The URL ({0}) provided does not contain the scheme. Please include 'http://' or 'https://' at the beginning.</value>
+  </data>
+  <data name="ERR_ErrorWhenQueryingServerVersion" xml:space="preserve">
+    <value>An error occured while querying the server version! Please check if the server is running and if the address is correct.</value>
   </data>
   <data name="MSG_CE_Detected_LicenseValid" xml:space="preserve">
     <value>SonarQube Community Edition detected, license is valid.</value>
@@ -197,6 +197,9 @@ Use '/?' or '/h' to see the help message.</value>
   </data>
   <data name="MSG_Downloading" xml:space="preserve">
     <value>Downloading from {0}...</value>
+  </data>
+  <data name="MSG_ResponseReceived" xml:space="preserve">
+    <value>Response received from {0}...</value>
   </data>
   <data name="MSG_DownloadFailed" xml:space="preserve">
     <value>Downloading from {0} failed. Http status code is {1}.</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloader.cs
@@ -104,7 +104,6 @@ namespace SonarScanner.MSBuild.PreProcessor
             Contract.ThrowIfNullOrWhitespace(url, nameof(url));
 
             var response = await GetAsync(url);
-
             if (response.IsSuccessStatusCode)
             {
                 return await response.Content.ReadAsStringAsync();
@@ -144,18 +143,15 @@ namespace SonarScanner.MSBuild.PreProcessor
         {
             try
             {
+                logger.LogDebug(Resources.MSG_Downloading, $"{client.BaseAddress}{url}");
                 var response = await client.GetAsync(url);
-                logger.LogDebug(Resources.MSG_Downloading, response.RequestMessage.RequestUri);
+                logger.LogDebug(Resources.MSG_ResponseReceived, response.RequestMessage.RequestUri);
                 return response;
-            }
-            catch (HttpRequestException e) when (e.InnerException is WebException { Status: WebExceptionStatus.ConnectFailure })
-            {
-                logger.LogError(Resources.ERR_UnableToConnectToServer, $"{client.BaseAddress}{url}");
-                throw;
             }
             catch (Exception e)
             {
-                logger.LogError(Resources.ERR_ErrorDuringWebCall, $"{client.BaseAddress}{url}", e.Message);
+                logger.LogError(Resources.ERR_UnableToConnectToServer, $"{client.BaseAddress}{url}");
+                logger.LogDebug((e.InnerException ?? e).ToString());
                 throw;
             }
         }


### PR DESCRIPTION
- If a wrong URL is used (that is up and returns NotFound), the scanner was terminating without logging anything.
- If the server certificate was not valid, a wrong message was logged.
