### PR TITLE
Remove out of date comment about OriginalRulesetFilePath

### DIFF
--- a/src/SonarScanner.MSBuild.Common/AnalysisConfig/AnalyzerSettings.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisConfig/AnalyzerSettings.cs
@@ -26,18 +26,18 @@ namespace SonarScanner.MSBuild.Common
 {
     /// <summary>
     /// Data class containing the information required to configure
-    /// the compiler for Roslyn analysis
+    /// the compiler for Roslyn analysis.
     /// </summary>
-    /// <remarks>This class is XML-serializable</remarks>
+    /// <remarks>This class is XML-serializable.</remarks>
     public class AnalyzerSettings
     {
         /// <summary>
-        /// Language which this settings refers to
+        /// Language which this settings refers to.
         /// </summary>
         public string Language { get; set; }
 
         /// <summary>
-        /// Path to the ruleset file for the Roslyn analyzers
+        /// Path to the ruleset file for the Roslyn analyzers.
         /// </summary>
         public string RulesetPath { get; set; }
 
@@ -47,15 +47,15 @@ namespace SonarScanner.MSBuild.Common
         public string DeactivatedRulesetPath { get; set; }
 
         /// <summary>
-        /// File paths for all of the assemblies to pass to the compiler as analyzers
+        /// File paths for all of the assemblies to pass to the compiler as analyzers.
         /// </summary>
-        /// <remarks>This includes analyzer assemblies and their dependencies</remarks>
+        /// <remarks>This includes analyzer assemblies and their dependencies.</remarks>
         [XmlArray]
         [XmlArrayItem("AnalyzerPlugin")]
         public List<AnalyzerPlugin> AnalyzerPlugins { get; set; }
 
         /// <summary>
-        /// File paths for all files to pass as "AdditionalFiles" to the compiler
+        /// File paths for all files to pass as "AdditionalFiles" to the compiler.
         /// </summary>
         [XmlArray]
         [XmlArrayItem("Path")]

--- a/src/SonarScanner.MSBuild.Tasks/GetAnalyzerSettings.cs
+++ b/src/SonarScanner.MSBuild.Tasks/GetAnalyzerSettings.cs
@@ -232,12 +232,6 @@ namespace SonarScanner.MSBuild.Tasks
 
         private string CreateMergedRuleset(AnalyzerSettings languageSpecificSettings)
         {
-            // The original ruleset should have been provided to the task.
-            // This should never be null when using the default targets
-            // (if the user hasn't specified anything then it will be the
-            // Microsoft minimum recommended tooleset).
-            // However, we'll be defensive and handle nulls in case the
-            // user has customised their build.
             if (OriginalRulesetFilePath == null)
             {
                 // If the project doesn't already have a ruleset can just


### PR DESCRIPTION
After running an analysis with MSBuild17, I actually realized that the comment is not correct.
It states that the OriginalRulesetFilePath will never be null when the user does not provide a ruleset.
It actually is null, so not to create any confusion I am removing the comment.
