### PR TITLE
BUILD-2943 Adapt sonar-scanner-msbuild replace set-output (deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         id: get_version
         run: |
           IFS=. read major minor patch build <<< "${{ github.event.release.tag_name }}"
-          echo "build=${build}" >> "$GITHUB_OUTPUT"
+          echo "build=${build}" >> $GITHUB_OUTPUT
       - name: Promote Artifact
         id: jfrog
         run: |


### PR DESCRIPTION
# BUILD-2943 Adapt sonar-scanner-msbuild

## Changes
* replace set-output (deprecated) marked for removal
  That way it can still work as expected [after 31st of May](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
