### PR TITLE
Increase dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,11 @@ updates:
     schedule:
       interval: "daily"
     labels: [ ]     # Do not add default "dependency" label
+    open-pull-requests-limit: 20
 
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
       interval: "daily"
     labels: [ ]     # Do not add default "dependency" label
+    open-pull-requests-limit: 20


### PR DESCRIPTION
The default limit of 5 is not enough. We process these in batches, so we want all of them waiting for us. Instead of another batch of 5 appearing the next day after we process existing set.