### PR TITLE
fix(BUILD-3172): pin CycloneDX version to 2.7.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,7 +144,7 @@ stages:
                 custom: tool
                 feedsToUse: 'select'
                 includeNuGetOrg: true
-                arguments: 'install --global CycloneDX'
+                arguments: 'install --global CycloneDX --version 2.7.0'
             - task: DotNetCoreCLI@2
               displayName: Dotnet generate SBOM
               inputs:
@@ -444,21 +444,21 @@ stages:
                 SONAR_CFAMILYPLUGIN_VERSION: "6.41.0.60884"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
                 MSBUILD_PATH: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe"
                 JDKVERSION: "1.17"
-                TEST_SUITE: "**/SonarQubeTestSuite.java"               
+                TEST_SUITE: "**/SonarQubeTestSuite.java"
               vs2019_latest99:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE[9.9]"
                 SONAR_CFAMILYPLUGIN_VERSION: "6.41.0.60884"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
                 MSBUILD_PATH: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe"
                 JDKVERSION: "1.17"
-                TEST_SUITE: "**/SonarQubeTestSuite.java"                
+                TEST_SUITE: "**/SonarQubeTestSuite.java"
               vs2022_latest99:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE[9.9]"
                 SONAR_CFAMILYPLUGIN_VERSION: "6.41.0.60884" # LATEST_RELEASE of CFAMILY is not compatible with old SQ
                 MSBUILD_PATH: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\MSBuild\\Current\\Bin\\MSBuild.exe"
                 JDKVERSION: "1.17"
-                TEST_SUITE: "**/SonarQubeTestSuite.java"                
+                TEST_SUITE: "**/SonarQubeTestSuite.java"
               vs2022_latest:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE"


### PR DESCRIPTION
Fixes BUILD-3172
