### PR TITLE
Manually bump Microsoft.VisualStudio.Setup.Configuration.Interop from 3.5.2145 to 3.6.2115

### DIFF
--- a/Tests/SonarScanner.MSBuild.TFS.Test/SonarScanner.MSBuild.TFS.Test.csproj
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/SonarScanner.MSBuild.TFS.Test.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.5.2145" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.6.2115" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/SonarScanner.MSBuild.Tasks.IntegrationTest.csproj
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/SonarScanner.MSBuild.Tasks.IntegrationTest.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Framework" Version="17.6.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.5.2145" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.6.2115" />
     <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.820" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />

--- a/src/SonarScanner.MSBuild.TFS.Classic/SonarScanner.MSBuild.TFS.Classic.csproj
+++ b/src/SonarScanner.MSBuild.TFS.Classic/SonarScanner.MSBuild.TFS.Classic.csproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <Reference Include="System.Net.Http" />
     <PackageReference Include="Newtonsoft.Json" version="13.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.5.2145" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.6.2115" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Replacement for [this Dependabot PR](https://github.com/SonarSource/sonar-scanner-msbuild/pull/1589) that failed and could not be revived.
