### PR TITLE
Add option to specify temporary working directory

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/SonarPropertiesTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/SonarPropertiesTests.cs
@@ -37,6 +37,7 @@ namespace SonarScanner.MSBuild.Common.Test
             SonarProperties.HostUrl,
             SonarProperties.LogLevel,
             SonarProperties.Organization,
+            SonarProperties.PluginCacheDirectory,
             SonarProperties.ProjectBaseDir,
             SonarProperties.ProjectBranch,
             SonarProperties.ProjectKey,

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/EmbeddedAnalyzerInstallerTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/EmbeddedAnalyzerInstallerTests.cs
@@ -36,7 +36,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public TestContext TestContext { get; set; }
 
         private const string DownloadEmbeddedFileMethodName = "TryDownloadEmbeddedFile";
-                
+
         [TestMethod]
         public void Constructor_NullSonarQubeServer_ThrowsArgumentNullException() =>
             ((Action)(() => new EmbeddedAnalyzerInstaller(

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockAnalyzerInstaller.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockAnalyzerInstaller.cs
@@ -20,6 +20,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using FluentAssertions;
 using SonarScanner.MSBuild.Common;
@@ -29,6 +30,14 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 {
     internal class MockAnalyzerInstaller : IAnalyzerInstaller
     {
+        #region Constructors
+        public MockAnalyzerInstaller() { }
+
+        public MockAnalyzerInstaller(string localCacheDirectory) {
+            Directory.CreateDirectory(localCacheDirectory);
+        }
+        #endregion
+
         #region Test helpers
 
         public IList<AnalyzerPlugin> AnalyzerPluginsToReturn { get; set; }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockAnalyzerInstaller.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockAnalyzerInstaller.cs
@@ -33,7 +33,8 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         #region Constructors
         public MockAnalyzerInstaller() { }
 
-        public MockAnalyzerInstaller(string localCacheDirectory) {
+        public MockAnalyzerInstaller(string localCacheDirectory)
+        {
             Directory.CreateDirectory(localCacheDirectory);
         }
         #endregion

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockAnalyzerInstaller.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockAnalyzerInstaller.cs
@@ -30,15 +30,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 {
     internal class MockAnalyzerInstaller : IAnalyzerInstaller
     {
-        #region Constructors
-        public MockAnalyzerInstaller() { }
-
-        public MockAnalyzerInstaller(string localCacheDirectory)
-        {
-            Directory.CreateDirectory(localCacheDirectory);
-        }
-        #endregion
-
         #region Test helpers
 
         public IList<AnalyzerPlugin> AnalyzerPluginsToReturn { get; set; }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
@@ -33,7 +33,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public TestLogger Logger { get; } = new();
         public MockSonarWebServer Server { get; }
         public Mock<ITargetsInstaller> TargetsInstaller { get; } = new();
-        public MockRoslynAnalyzerProvider AnalyzerProvider { get; } = new() { SettingsToReturn = new AnalyzerSettings { RulesetPath = "c:\\xxx.ruleset" } };
+        public MockRoslynAnalyzerProvider AnalyzerProvider { get; private set; }
 
         public MockObjectFactory(TestLogger logger) : this() =>
             Logger = logger;
@@ -61,8 +61,10 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public ITargetsInstaller CreateTargetInstaller() =>
             TargetsInstaller.Object;
 
-        public IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server, string localCacheTempPath) =>
-            AnalyzerProvider;
+        public IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server, string localCacheTempPath)
+        {
+            return AnalyzerProvider = new(new MockAnalyzerInstaller(localCacheTempPath)) { SettingsToReturn = new AnalyzerSettings { RulesetPath = "c:\\xxx.ruleset" } };
+        }
 
         public BuildSettings ReadSettings()
         {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
@@ -64,6 +64,9 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server) =>
             AnalyzerProvider;
 
+        public IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server, string localCacheTempPath) =>
+            AnalyzerProvider;
+
         public BuildSettings ReadSettings()
         {
             var settings = BuildSettings.GetSettingsFromEnvironment(Logger);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
@@ -33,7 +33,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public TestLogger Logger { get; } = new();
         public MockSonarWebServer Server { get; }
         public Mock<ITargetsInstaller> TargetsInstaller { get; } = new();
-        public MockRoslynAnalyzerProvider AnalyzerProvider { get; private set; }
+        public MockRoslynAnalyzerProvider AnalyzerProvider { get; private set; } = new() { SettingsToReturn = new AnalyzerSettings { RulesetPath = "c:\\xxx.ruleset" } };
 
         public MockObjectFactory(TestLogger logger) : this() =>
             Logger = logger;
@@ -61,10 +61,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public ITargetsInstaller CreateTargetInstaller() =>
             TargetsInstaller.Object;
 
-        public IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server, string localCacheTempPath)
-        {
-            return AnalyzerProvider = new(new MockAnalyzerInstaller(localCacheTempPath)) { SettingsToReturn = new AnalyzerSettings { RulesetPath = "c:\\xxx.ruleset" } };
-        }
+        public IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server, string localCacheTempPath) => AnalyzerProvider;
 
         public BuildSettings ReadSettings()
         {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
@@ -33,7 +33,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public TestLogger Logger { get; } = new();
         public MockSonarWebServer Server { get; }
         public Mock<ITargetsInstaller> TargetsInstaller { get; } = new();
-        public MockRoslynAnalyzerProvider AnalyzerProvider { get; private set; } = new() { SettingsToReturn = new AnalyzerSettings { RulesetPath = "c:\\xxx.ruleset" } };
+        public MockRoslynAnalyzerProvider AnalyzerProvider { get; } = new() { SettingsToReturn = new AnalyzerSettings { RulesetPath = "c:\\xxx.ruleset" } };
 
         public MockObjectFactory(TestLogger logger) : this() =>
             Logger = logger;

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
@@ -61,9 +61,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public ITargetsInstaller CreateTargetInstaller() =>
             TargetsInstaller.Object;
 
-        public IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server) =>
-            AnalyzerProvider;
-
         public IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server, string localCacheTempPath) =>
             AnalyzerProvider;
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockRoslynAnalyzerProvider.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockRoslynAnalyzerProvider.cs
@@ -35,13 +35,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
         #endregion Test helpers
 
-        #region Constructors
-
-        public MockRoslynAnalyzerProvider() { }
-        public MockRoslynAnalyzerProvider(IAnalyzerInstaller analyzerInstaller) { }
-
-        #endregion Constructors
-
         #region IAnalyzerProvider methods
 
         AnalyzerSettings IAnalyzerProvider.SetupAnalyzer(BuildSettings buildSettings, IAnalysisPropertyProvider sonarProperties, IEnumerable<SonarRule> rules, string language)

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockRoslynAnalyzerProvider.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockRoslynAnalyzerProvider.cs
@@ -35,6 +35,13 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
         #endregion Test helpers
 
+        #region Constructors
+
+        public MockRoslynAnalyzerProvider() { }
+        public MockRoslynAnalyzerProvider(IAnalyzerInstaller analyzerInstaller) { }
+
+        #endregion Constructors
+
         #region IAnalyzerProvider methods
 
         AnalyzerSettings IAnalyzerProvider.SetupAnalyzer(BuildSettings buildSettings, IAnalysisPropertyProvider sonarProperties, IEnumerable<SonarRule> rules, string language)

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
@@ -217,8 +217,10 @@ Use '/?' or '/h' to see the help message.");
             var success = await preProcessor.Execute(args);
             success.Should().BeTrue("Expecting the pre-processing to complete successfully");
 
-            AssertDirectoryExists(tmpCachePath);
             AssertDirectoriesCreated(settings);
+
+            factory.AssertMethodCalled(nameof(MockObjectFactory.CreateRoslynAnalyzerProvider), 2); // C# and VBNet
+            factory.PluginCachePath.Should().Be(tmpCachePath);
 
             factory.TargetsInstaller.Verify(x => x.InstallLoaderTargets(scope.WorkingDir), Times.Once());
             factory.Server.AssertMethodCalled(nameof(ISonarWebServer.DownloadProperties), 1);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
@@ -194,6 +194,47 @@ Use '/?' or '/h' to see the help message.");
         }
 
         [TestMethod]
+        public async Task Execute_CreateCustomTempCachePath_SuccessCase()
+        {
+            // Checks end-to-end happy path for the pre-processor i.e.
+            // * arguments are parsed
+            // * targets are installed
+            // * server properties are fetched
+            // * rule sets are generated
+            // * config file is created
+            using var scope = new TestScope(TestContext);
+            var factory = new MockObjectFactory();
+            factory.Server.Data.SonarQubeVersion = new Version(9, 10, 1, 2);
+            var settings = factory.ReadSettings();
+            var preProcessor = new PreProcessor(factory, factory.Logger);
+
+            var tmpCachePath = Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).FullName, ".temp-cache");
+            var args = new List<string>(CreateArgs())
+            {
+                $"/d:sonar.plugin.cache.directory={tmpCachePath}",
+            };
+
+            var success = await preProcessor.Execute(args);
+            success.Should().BeTrue("Expecting the pre-processing to complete successfully");
+
+            AssertDirectoryExists(tmpCachePath);
+            AssertDirectoriesCreated(settings);
+
+            factory.TargetsInstaller.Verify(x => x.InstallLoaderTargets(scope.WorkingDir), Times.Once());
+            factory.Server.AssertMethodCalled(nameof(ISonarWebServer.DownloadProperties), 1);
+            factory.Server.AssertMethodCalled(nameof(ISonarWebServer.DownloadAllLanguages), 1);
+            factory.Server.AssertMethodCalled(nameof(ISonarWebServer.DownloadQualityProfile), 2); // C# and VBNet
+            factory.Server.AssertMethodCalled(nameof(ISonarWebServer.DownloadRules), 2); // C# and VBNet
+
+            factory.Logger.AssertInfoLogged("Cache data is empty. A full analysis will be performed.");
+            factory.Logger.AssertDebugLogged("Processing analysis cache");
+
+            var config = AssertAnalysisConfig(settings.AnalysisConfigFilePath, 2, factory.Logger);
+            config.SonarQubeVersion.Should().Be("9.10.1.2");
+            config.GetConfigValue(SonarProperties.PullRequestCacheBasePath, null).Should().Be(Path.GetDirectoryName(scope.WorkingDir));
+        }
+
+        [TestMethod]
         public async Task Execute_EndToEnd_SuccessCase_NoActiveRule()
         {
             using var scope = new TestScope(TestContext);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -19,8 +19,7 @@
  */
 
 using System;
-using System.Net;
-using System.Net.Http;
+using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -108,10 +107,11 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var sut = new PreprocessorObjectFactory(logger);
 
             var server = await sut.CreateSonarWebServer(validArgs, downloader);
+            var localCacheTempPath = Path.Combine(Path.GetTempPath(), ".sonarqube", "resources");
 
             server.Should().NotBeNull();
             sut.CreateTargetInstaller().Should().NotBeNull();
-            sut.CreateRoslynAnalyzerProvider(server).Should().NotBeNull();
+            sut.CreateRoslynAnalyzerProvider(server, localCacheTempPath).Should().NotBeNull();
         }
 
         [TestMethod]
@@ -132,7 +132,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         {
             var sut = new PreprocessorObjectFactory(logger);
 
-            Action act = () => sut.CreateRoslynAnalyzerProvider(null);
+            Action act = () => sut.CreateRoslynAnalyzerProvider(null, string.Empty);
 
             act.Should().ThrowExactly<ArgumentNullException>();
         }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -107,11 +107,10 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var sut = new PreprocessorObjectFactory(logger);
 
             var server = await sut.CreateSonarWebServer(validArgs, downloader);
-            var localCacheTempPath = Path.Combine(Path.GetTempPath(), ".sonarqube", "resources");
-
+            
             server.Should().NotBeNull();
             sut.CreateTargetInstaller().Should().NotBeNull();
-            sut.CreateRoslynAnalyzerProvider(server, localCacheTempPath).Should().NotBeNull();
+            sut.CreateRoslynAnalyzerProvider(server, string.Empty).Should().NotBeNull();
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -52,7 +52,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         public async Task CreateSonarWebService_RequestServerVersionThrows_ShouldReturnNullAndLogError()
         {
             var sut = new PreprocessorObjectFactory(logger);
-            var downloader =  new Mock<IDownloader>(MockBehavior.Strict);
+            var downloader = new Mock<IDownloader>(MockBehavior.Strict);
             downloader.Setup(x => x.Download(It.IsAny<string>(), It.IsAny<bool>())).Throws<InvalidOperationException>();
 
             var result = await sut.CreateSonarWebServer(CreateValidArguments(), downloader.Object);
@@ -107,7 +107,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             var sut = new PreprocessorObjectFactory(logger);
 
             var server = await sut.CreateSonarWebServer(validArgs, downloader);
-            
+
             server.Should().NotBeNull();
             sut.CreateTargetInstaller().Should().NotBeNull();
             sut.CreateRoslynAnalyzerProvider(server, string.Empty).Should().NotBeNull();

--- a/src/SonarScanner.MSBuild.Common/SonarProperties.cs
+++ b/src/SonarScanner.MSBuild.Common/SonarProperties.cs
@@ -52,7 +52,7 @@ namespace SonarScanner.MSBuild.Common
         public const string PullRequestBase = "sonar.pullrequest.base";
         public const string PullRequestCacheBasePath = "sonar.pullrequest.cache.basepath";
         public const string WorkingDirectory = "sonar.working.directory";
-        public const string WorkingTemporaryDirectory = "sonar.working.temp.directory";
+        public const string PluginCacheDirectory = "sonar.plugin.cache.directory";
         public const string Verbose = "sonar.verbose";
         public const string LogLevel = "sonar.log.level";
 

--- a/src/SonarScanner.MSBuild.Common/SonarProperties.cs
+++ b/src/SonarScanner.MSBuild.Common/SonarProperties.cs
@@ -52,6 +52,7 @@ namespace SonarScanner.MSBuild.Common
         public const string PullRequestBase = "sonar.pullrequest.base";
         public const string PullRequestCacheBasePath = "sonar.pullrequest.cache.basepath";
         public const string WorkingDirectory = "sonar.working.directory";
+        public const string WorkingTemporaryDirectory = "sonar.working.temp.directory";
         public const string Verbose = "sonar.verbose";
         public const string LogLevel = "sonar.log.level";
 

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IPreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IPreprocessorObjectFactory.cs
@@ -43,5 +43,10 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// Creates the component that provisions the Roslyn analyzers.
         /// </summary>
         IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server);
+
+        /// <summary>
+        /// Creates the component that provisions the Roslyn analyzers.
+        /// </summary>
+        IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server, string localCacheTempPath);
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IPreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IPreprocessorObjectFactory.cs
@@ -42,11 +42,6 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// <summary>
         /// Creates the component that provisions the Roslyn analyzers.
         /// </summary>
-        IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server);
-
-        /// <summary>
-        /// Creates the component that provisions the Roslyn analyzers.
-        /// </summary>
         IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server, string localCacheTempPath);
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -157,7 +157,7 @@ namespace SonarScanner.MSBuild.PreProcessor
 
                     // Generate Roslyn analyzers settings and rulesets
                     // It is null if the processing of server settings and active rules resulted in an empty ruleset
-                    var localCacheTempPath = args.GetSetting(SonarProperties.PluginCacheDirectory, Path.Combine(Path.GetTempPath(), ".sonarqube", "resources"));
+                    var localCacheTempPath = args.GetSetting(SonarProperties.PluginCacheDirectory, string.Empty);
                     var analyzerProvider = factory.CreateRoslynAnalyzerProvider(server, localCacheTempPath);
                     Debug.Assert(analyzerProvider != null, "Factory should not return null");
 

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -157,8 +157,8 @@ namespace SonarScanner.MSBuild.PreProcessor
 
                     // Generate Roslyn analyzers settings and rulesets
                     // It is null if the processing of server settings and active rules resulted in an empty ruleset
-                    var localCacheTempPath = args.GetSetting(SonarProperties.WorkingTemporaryDirectory, null);
-                    var analyzerProvider = factory.CreateRoslynAnalyzerProvider(server, GetLocalCacheDirectory(localCacheTempPath));
+                    var localCacheTempPath = args.GetSetting(SonarProperties.WorkingTemporaryDirectory, Path.Combine(Path.GetTempPath(), ".sonarqube", "resources"));
+                    var analyzerProvider = factory.CreateRoslynAnalyzerProvider(server, localCacheTempPath);
                     Debug.Assert(analyzerProvider != null, "Factory should not return null");
 
                     // Use the aggregate of local and server properties when generating the analyzer configuration
@@ -190,21 +190,6 @@ namespace SonarScanner.MSBuild.PreProcessor
 
             argumentsAndRuleSets.IsSuccess = true;
             return argumentsAndRuleSets;
-        }
-
-        /// <summary>
-        /// We want the resource cache to be in a well-known location so we can re-use files that have
-        /// already been installed.
-        /// </summary>
-        private static string GetLocalCacheDirectory(string localCacheTempPath)
-        {
-            if (string.IsNullOrWhiteSpace(localCacheTempPath))
-            {
-                // here we will allow the Embedded Analyzer Installer to build out the temporary directory
-                return null;
-            }
-
-            return Path.Combine(localCacheTempPath, ".sonarqube", "resources");
         }
 
         private sealed class ArgumentsAndRuleSets

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -157,7 +157,8 @@ namespace SonarScanner.MSBuild.PreProcessor
 
                     // Generate Roslyn analyzers settings and rulesets
                     // It is null if the processing of server settings and active rules resulted in an empty ruleset
-                    var analyzerProvider = factory.CreateRoslynAnalyzerProvider(server);
+                    var localCacheTempPath = args.GetSetting(SonarProperties.WorkingTemporaryDirectory, null);
+                    var analyzerProvider = factory.CreateRoslynAnalyzerProvider(server, GetLocalCacheDirectory(localCacheTempPath));
                     Debug.Assert(analyzerProvider != null, "Factory should not return null");
 
                     // Use the aggregate of local and server properties when generating the analyzer configuration
@@ -189,6 +190,21 @@ namespace SonarScanner.MSBuild.PreProcessor
 
             argumentsAndRuleSets.IsSuccess = true;
             return argumentsAndRuleSets;
+        }
+
+        /// <summary>
+        /// We want the resource cache to be in a well-known location so we can re-use files that have
+        /// already been installed.
+        /// </summary>
+        private static string GetLocalCacheDirectory(string localCacheTempPath)
+        {
+            if (string.IsNullOrWhiteSpace(localCacheTempPath))
+            {
+                // here we will allow the Embedded Analyzer Installer to build out the temporary directory
+                return null;
+            }
+
+            return Path.Combine(localCacheTempPath, ".sonarqube", "resources");
         }
 
         private sealed class ArgumentsAndRuleSets

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -157,7 +157,7 @@ namespace SonarScanner.MSBuild.PreProcessor
 
                     // Generate Roslyn analyzers settings and rulesets
                     // It is null if the processing of server settings and active rules resulted in an empty ruleset
-                    var localCacheTempPath = args.GetSetting(SonarProperties.WorkingTemporaryDirectory, Path.Combine(Path.GetTempPath(), ".sonarqube", "resources"));
+                    var localCacheTempPath = args.GetSetting(SonarProperties.PluginCacheDirectory, Path.Combine(Path.GetTempPath(), ".sonarqube", "resources"));
                     var analyzerProvider = factory.CreateRoslynAnalyzerProvider(server, localCacheTempPath);
                     Debug.Assert(analyzerProvider != null, "Factory should not return null");
 

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -96,6 +96,14 @@ namespace SonarScanner.MSBuild.PreProcessor
             return new RoslynAnalyzerProvider(new EmbeddedAnalyzerInstaller(server, logger), logger);
         }
 
+        public IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server, string localCacheTempPath)
+        {
+            server = server ?? throw new ArgumentNullException(nameof(server));
+            return string.IsNullOrWhiteSpace(localCacheTempPath)
+                ? CreateRoslynAnalyzerProvider(server)
+                : new RoslynAnalyzerProvider(new EmbeddedAnalyzerInstaller(server, localCacheTempPath, logger), logger);
+        }
+
         private async Task<Version> QueryServerVersion(IDownloader downloader)
         {
             logger.LogDebug(Resources.MSG_FetchingVersion);

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -90,18 +90,10 @@ namespace SonarScanner.MSBuild.PreProcessor
         public ITargetsInstaller CreateTargetInstaller() =>
             new TargetsInstaller(logger);
 
-        public IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server)
-        {
-            server = server ?? throw new ArgumentNullException(nameof(server));
-            return new RoslynAnalyzerProvider(new EmbeddedAnalyzerInstaller(server, logger), logger);
-        }
-
         public IAnalyzerProvider CreateRoslynAnalyzerProvider(ISonarWebServer server, string localCacheTempPath)
         {
             server = server ?? throw new ArgumentNullException(nameof(server));
-            return string.IsNullOrWhiteSpace(localCacheTempPath)
-                ? CreateRoslynAnalyzerProvider(server)
-                : new RoslynAnalyzerProvider(new EmbeddedAnalyzerInstaller(server, localCacheTempPath, logger), logger);
+            return new RoslynAnalyzerProvider(new EmbeddedAnalyzerInstaller(server, localCacheTempPath, logger), logger);
         }
 
         private async Task<Version> QueryServerVersion(IDownloader downloader)

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/EmbeddedAnalyzerInstaller.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/EmbeddedAnalyzerInstaller.cs
@@ -57,7 +57,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
             if (string.IsNullOrWhiteSpace(localCacheDirectory))
             {
                 // we may end up sending an empty string from the PreProcessor
-                // if the user does send a custom path, we will need to set it here.
+                // if the user does not specify a custom path, we will need to set it here.
                 localCacheDirectory = GetLocalCacheDirectory();
             }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/EmbeddedAnalyzerInstaller.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/EmbeddedAnalyzerInstaller.cs
@@ -56,7 +56,9 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn
         {
             if (string.IsNullOrWhiteSpace(localCacheDirectory))
             {
-                throw new ArgumentNullException(nameof(localCacheDirectory));
+                // we may end up sending an empty string from the PreProcessor
+                // if the user does send a custom path, we will need to set it here.
+                localCacheDirectory = GetLocalCacheDirectory();
             }
 
             this.server = server ?? throw new ArgumentNullException(nameof(server));


### PR DESCRIPTION
Fixes #1638

This should in theory allow the user to specify a temporary directory that will be used by the analyser for it's dll cache. 
