### PR TITLE
Ignore CS7035

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -226,6 +226,9 @@ dotnet_naming_style.I_style.capitalization = pascal_case
 # Rules
 # ----------------------------------------------------------------------------------------------------------------------
 
+# CS7035: it expects the build number to fit in 16 bits, our build numbers are bigger https://github.com/dotnet/roslyn/issues/17024#issuecomment-1669503201
+dotnet_diagnostic.CS7035.severity = none
+
 [*]
 dotnet_diagnostic.S1451.severity = warning      # For UTs - Track lack of copyright and license headers
 


### PR DESCRIPTION
CS7035 expects the build number to fit in 16 bits, our build numbers are bigger

https://github.com/dotnet/roslyn/issues/17024#issuecomment-1669503201

Failing QG:
https://sonarcloud.io/project/issues?resolved=false&sinceLeakPeriod=true&id=sonarscanner-msbuild&open=AYqCBY2i9xtiP7AT2xsl