### PR TITLE
Ignore CS7035 in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -229,6 +229,9 @@ dotnet_naming_style.I_style.capitalization = pascal_case
 [*]
 dotnet_diagnostic.S1451.severity = warning      # For UTs - Track lack of copyright and license headers
 
+# CS7035: it expects the build number to fit in 16 bits, our build numbers are bigger https://github.com/dotnet/roslyn/issues/17024#issuecomment-1669503201
+dotnet_diagnostic.CS7035.severity = none
+
 # ----------------------------------------------------------------------------------------------------------------------
 # StyleCop.Analyzers rules - note that the URLs below are for tag 1.1.118
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
see explanation in https://github.com/SonarSource/sonar-scanner-msbuild/pull/1688#issue-1890326418