### PR TITLE
Revert "Bump scanner cli to 5.0.1.3006 (#1699)"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -438,7 +438,7 @@ stages:
                 SONAR_DOTNET_VERSION: '9.7.0.75501' # sonar-dotnet 9.8 will mention SQ 9.9 as minimum supported version
                 SONAR_CFAMILYPLUGIN_VERSION: "6.20.5.49286"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
                 MSBUILD_PATH: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe"
-                JDKVERSION: "1.17"
+                JDKVERSION: "1.11"
                 TEST_SUITE: "**/SonarQubeTestSuite.java"
               vs2022_latest89:
                 PRODUCT: "SonarQube"
@@ -446,7 +446,7 @@ stages:
                 SONAR_DOTNET_VERSION: '9.7.0.75501' # sonar-dotnet 9.8 will mention SQ 9.9 as minimum supported version
                 SONAR_CFAMILYPLUGIN_VERSION: "6.20.5.49286"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
                 MSBUILD_PATH: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\MSBuild\\Current\\Bin\\MSBuild.exe"
-                JDKVERSION: "1.17"
+                JDKVERSION: "1.11"
                 TEST_SUITE: "**/SonarQubeTestSuite.java"
               vs2017_latest99:
                 PRODUCT: "SonarQube"

--- a/scripts/variables.ps1
+++ b/scripts/variables.ps1
@@ -1,5 +1,5 @@
 ﻿$fullBuildOutputDir = "$PSScriptRoot\..\build"
-$scannerCliVersion = "5.0.1.3006"
+$scannerCliVersion = "4.8.1.3023"
 $scannerCliAssemblyName = "sonar-scanner-cli-$ScannerCliVersion"
 $scannerCliArtifact = "$scannerCliAssemblyName.zip"
 $scannerCliDownloadDir = "$fullBuildOutputDir\temp"

--- a/sonar-docs/analysis/scan/sonarscanner-for-msbuild.md
+++ b/sonar-docs/analysis/scan/sonarscanner-for-msbuild.md
@@ -36,7 +36,7 @@ It supports .Net Core on every platform (Windows, macOS, Linux).
 * At least the minimal version of Java supported by your SonarQube server
 <!-- /sonarqube -->
 <!-- sonarcloud -->
-* Java 17 or greater
+* Java 11 or greater
 <!-- /sonarcloud -->
 * The SDK corresponding to your build system:
 <!-- sonarqube -->

--- a/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
@@ -50,7 +50,7 @@ namespace SonarScanner.MSBuild.Shim
         private const string CmdLineArgPrefix = "-D";
 
         // This version needs to be in sync with version in scripts\variables.ps1.
-        private const string SonarScannerVersion = "5.0.1.3006";
+        private const string SonarScannerVersion = "4.8.1.3023";
 
         private readonly ILogger logger;
 


### PR DESCRIPTION
This reverts commit a4cdc9239598edf20ea79f26a267ee02bcc93106.

We decided to not drop yet the support for Java 11.
