### PR TITLE
Temporarily disable code signing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,7 +131,7 @@ stages:
                 verbosityRestore: 'normal'  # Default is noisy 'Detailed'
             - task: DotNetCoreCLI@2
               env:
-                SignAssembly: 'true'
+                SignAssembly: 'false'  # Code signing is temporarily disabled until new certificate is properly set up
               condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
               displayName: 'Build and prepare signing $(tfsProcessorSolution)'
               inputs:
@@ -170,7 +170,7 @@ stages:
                 arguments: '-t -j -o build'
             - task: DotNetCoreCLI@2
               env:
-                SignAssembly: 'true'
+                SignAssembly: 'false'  # Code signing is temporarily disabled until new certificate is properly set up
               condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
               displayName: 'Build and prepare signing $(solution)'
               inputs:
@@ -245,6 +245,7 @@ stages:
               displayName: "Mend scan"
             - task: PowerShell@2
               displayName: Sign assemblies
+              enabled: false  # Code signing is temporarily disabled until new certificate is properly set up
               condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
               env:
                 SIGNTOOL_PATH: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.17763.0\\x64\\signtool.exe'
@@ -264,6 +265,7 @@ stages:
                 versioningScheme: 'off'
             - task: NuGetCommand@2
               displayName: "Sign NuGet packages"
+              enabled: false  # Code signing is temporarily disabled until new certificate is properly set up
               condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
               inputs:
                 command: 'custom'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -131,7 +131,7 @@ stages:
                 verbosityRestore: 'normal'  # Default is noisy 'Detailed'
             - task: DotNetCoreCLI@2
               env:
-                SignAssembly: 'false'  # Code signing is temporarily disabled until new certificate is properly set up
+                SignAssembly: 'false'  # ToDo: Code signing is temporarily disabled until new certificate is properly set up
               condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
               displayName: 'Build and prepare signing $(tfsProcessorSolution)'
               inputs:
@@ -170,7 +170,7 @@ stages:
                 arguments: '-t -j -o build'
             - task: DotNetCoreCLI@2
               env:
-                SignAssembly: 'false'  # Code signing is temporarily disabled until new certificate is properly set up
+                SignAssembly: 'false'  # ToDo: Code signing is temporarily disabled until new certificate is properly set up
               condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
               displayName: 'Build and prepare signing $(solution)'
               inputs:
@@ -245,7 +245,7 @@ stages:
               displayName: "Mend scan"
             - task: PowerShell@2
               displayName: Sign assemblies
-              enabled: false  # Code signing is temporarily disabled until new certificate is properly set up
+              enabled: false  # ToDo: Code signing is temporarily disabled until new certificate is properly set up
               condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
               env:
                 SIGNTOOL_PATH: 'C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.17763.0\\x64\\signtool.exe'
@@ -265,7 +265,7 @@ stages:
                 versioningScheme: 'off'
             - task: NuGetCommand@2
               displayName: "Sign NuGet packages"
-              enabled: false  # Code signing is temporarily disabled until new certificate is properly set up
+              enabled: false  # ToDo: Code signing is temporarily disabled until new certificate is properly set up
               condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
               inputs:
                 command: 'custom'


### PR DESCRIPTION
The current code signing certificate has expired. Until the new one is set up this PR will disable code signing to keep the builds green.
