### PR TITLE
Revert parent pom to 68.0.0.247 to ensure the ITs run

### DIFF
--- a/its/pom.xml
+++ b/its/pom.xml
@@ -6,7 +6,11 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>70.0.0.270</version>
+    <!--
+      When tested with parent 70.0 the ITs were not found but the run was green.
+      If you update this, please check the number of ITs in CI.
+    -->
+    <version>68.0.0.247</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
After the latest parent plugin update, the ITs were detecting 0 tests and the run was successful.

This PR rolls back that change.