### PR TITLE
Upgrade net46 to net462

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
@@ -82,9 +82,7 @@ Use '/?' or '/h' to see the help message.");
             using var lockedFile = new FileStream(Path.Combine(configDirectory, "LockedFile.txt"), FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None);
 
             (await preProcessor.Execute(CreateArgs())).Should().BeFalse();
-            factory.Logger.AssertErrorLogged(
-@$"Failed to create an empty directory '{configDirectory}'. Please check that there are no open or read-only files in the directory and that you have the necessary read/write permissions.
-  Detailed error message: The process cannot access the file 'LockedFile.txt' because it is being used by another process.");
+            factory.Logger.Errors.Should().ContainMatch($"Failed to create an empty directory '{configDirectory}'. Please check that there are no open or read-only files in the directory and that you have the necessary read/write permissions.*  Detailed error message: The process cannot access the file 'LockedFile.txt' because it is being used by another process.");
         }
 
         [TestMethod]

--- a/scripts/package-artifacts.ps1
+++ b/scripts/package-artifacts.ps1
@@ -2,7 +2,7 @@
     $destination = "$fullBuildOutputDir\sonarscanner-msbuild-net46"
     $sourceRoot = "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462"
 
-    if (!(Test-Path -path )) {New-Item $destination -Type Directory}
+    if (!(Test-Path -path $destination)) {New-Item $destination -Type Directory}
     if (!(Test-Path -path "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets")) {New-Item "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets" -Type Directory}
 
     Copy-Item -Path "$sourceRoot\Microsoft.VisualStudio.Setup.Configuration.Interop.dll" -Destination $destination

--- a/scripts/package-artifacts.ps1
+++ b/scripts/package-artifacts.ps1
@@ -1,18 +1,18 @@
 ﻿function Package-Net46Scanner(){
     if (!(Test-Path -path "$fullBuildOutputDir\sonarscanner-msbuild-net46")) {New-Item "$fullBuildOutputDir\sonarscanner-msbuild-net46" -Type Directory}
     if (!(Test-Path -path "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets")) {New-Item "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets" -Type Directory}
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net46\Microsoft.VisualStudio.Setup.Configuration.Interop.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net46\Newtonsoft.Json.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net46\SonarScanner.MSBuild.Common.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net46\SonarScanner.MSBuild.Shim.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net46\SonarScanner.MSBuild.TFS.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net46\SonarScanner.MSBuild.TFSProcessor.exe" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net46\SonarScanner.MSBuild.TFSProcessor.exe.config" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net46\System.Runtime.InteropServices.RuntimeInformation.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net46\System.ValueTuple.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\Microsoft.VisualStudio.Setup.Configuration.Interop.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\Newtonsoft.Json.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\SonarScanner.MSBuild.Common.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\SonarScanner.MSBuild.Shim.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\SonarScanner.MSBuild.TFS.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\SonarScanner.MSBuild.TFSProcessor.exe" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\SonarScanner.MSBuild.TFSProcessor.exe.config" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\System.Runtime.InteropServices.RuntimeInformation.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\System.ValueTuple.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
     Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\Targets\*" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets" -Recurse
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild\bin\Release\net46\*" -Exclude "*.pdb" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46" -Recurse
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\bin\Release\net46\SonarScanner.MSBuild.Tasks.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild\bin\Release\net462\*" -Exclude "*.pdb" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46" -Recurse
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\bin\Release\net462\SonarScanner.MSBuild.Tasks.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
     [System.IO.Compression.ZipFile]::ExtractToDirectory("$scannerCliDownloadDir\$scannerCliArtifact", "$fullBuildOutputDir\sonarscanner-msbuild-net46")
     Compress-Archive -Path $fullBuildOutputDir\sonarscanner-msbuild-net46\* -DestinationPath $fullBuildOutputDir\sonarscanner-msbuild-net46.zip -Force
 }

--- a/scripts/package-artifacts.ps1
+++ b/scripts/package-artifacts.ps1
@@ -1,24 +1,27 @@
-﻿function Package-Net46Scanner(){
-    if (!(Test-Path -path "$fullBuildOutputDir\sonarscanner-msbuild-net46")) {New-Item "$fullBuildOutputDir\sonarscanner-msbuild-net46" -Type Directory}
+﻿function Package-Net46Scanner() {
+    $destination = "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+    $sourceRoot = "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462"
+
+    if (!(Test-Path -path )) {New-Item $destination -Type Directory}
     if (!(Test-Path -path "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets")) {New-Item "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets" -Type Directory}
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\Microsoft.VisualStudio.Setup.Configuration.Interop.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\Newtonsoft.Json.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\SonarScanner.MSBuild.Common.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\SonarScanner.MSBuild.Shim.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\SonarScanner.MSBuild.TFS.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\SonarScanner.MSBuild.TFSProcessor.exe" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\SonarScanner.MSBuild.TFSProcessor.exe.config" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\System.Runtime.InteropServices.RuntimeInformation.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462\System.ValueTuple.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+
+    Copy-Item -Path "$sourceRoot\Microsoft.VisualStudio.Setup.Configuration.Interop.dll" -Destination $destination
+    Copy-Item -Path "$sourceRoot\Newtonsoft.Json.dll" -Destination $destination
+    Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.Common.dll" -Destination $destination
+    Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.Shim.dll" -Destination $destination
+    Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.TFS.dll" -Destination $destination
+    Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.TFSProcessor.exe" -Destination $destination
+    Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.TFSProcessor.exe.config" -Destination $destination
+    Copy-Item -Path "$sourceRoot\System.Runtime.InteropServices.RuntimeInformation.dll" -Destination $destination
+    Copy-Item -Path "$sourceRoot\System.ValueTuple.dll" -Destination $destination
     Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\Targets\*" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets" -Recurse
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild\bin\Release\net462\*" -Exclude "*.pdb" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46" -Recurse
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\bin\Release\net462\SonarScanner.MSBuild.Tasks.dll" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46"
-    [System.IO.Compression.ZipFile]::ExtractToDirectory("$scannerCliDownloadDir\$scannerCliArtifact", "$fullBuildOutputDir\sonarscanner-msbuild-net46")
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild\bin\Release\net462\*" -Exclude "*.pdb" -Destination $destination -Recurse
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\bin\Release\net462\SonarScanner.MSBuild.Tasks.dll" -Destination $destination
+    [System.IO.Compression.ZipFile]::ExtractToDirectory("$scannerCliDownloadDir\$scannerCliArtifact", $destination)
     Compress-Archive -Path $fullBuildOutputDir\sonarscanner-msbuild-net46\* -DestinationPath $fullBuildOutputDir\sonarscanner-msbuild-net46.zip -Force
 }
 
-function Package-NetScanner([string]$sourcetfm, [string]$targettfm)
-{
+function Package-NetScanner([string]$sourcetfm, [string]$targettfm) {
     if (!(Test-Path -path "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm")) {New-Item "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm" -Type Directory}
     if (!(Test-Path -path "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm\Targets")) {New-Item "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm\Targets" -Type Directory}
     Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\Targets\*" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm\Targets" -Recurse
@@ -36,6 +39,7 @@ function Package-NetScanner([string]$sourcetfm, [string]$targettfm)
     [System.IO.Compression.ZipFile]::ExtractToDirectory("$scannerCliDownloadDir\$scannerCliArtifact", "$fullBuildOutputDir\sonarscanner-msbuild-$targettfm")
     Compress-Archive -Path $fullBuildOutputDir\sonarscanner-msbuild-$targettfm\* -DestinationPath $fullBuildOutputDir\sonarscanner-msbuild-$targettfm.zip -Force
 }
+
 function Download-ScannerCli() {
     $artifactoryUrlEnv = "ARTIFACTORY_URL"
     

--- a/src/DotnetVersions.props
+++ b/src/DotnetVersions.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ScannerNetStandardVersion>netstandard2.0</ScannerNetStandardVersion>
     <ScannerNetCoreVersion>netcoreapp2.1;netcoreapp3.1</ScannerNetCoreVersion>
-    <ScannerNetFxVersion>net46</ScannerNetFxVersion>
+    <ScannerNetFxVersion>net462</ScannerNetFxVersion>
     <ScannerNetVersion>net5.0</ScannerNetVersion>
   </PropertyGroup>
 

--- a/src/SonarScanner.MSBuild.Common/SingleGlobalInstanceMutex.cs
+++ b/src/SonarScanner.MSBuild.Common/SingleGlobalInstanceMutex.cs
@@ -58,7 +58,7 @@ namespace SonarScanner.MSBuild.Common
 
         private static Mutex CreateMutex(string name)
         {
-#if NET462
+#if NETFRAMEWORK
             // Concurrent builds could be run under different user accounts, so we need to allow all users to wait on the mutex
             var mutexSecurity = new MutexSecurity();
             mutexSecurity.AddAccessRule(new MutexAccessRule(new SecurityIdentifier(WellKnownSidType.WorldSid, null),

--- a/src/SonarScanner.MSBuild.Common/SingleGlobalInstanceMutex.cs
+++ b/src/SonarScanner.MSBuild.Common/SingleGlobalInstanceMutex.cs
@@ -58,7 +58,7 @@ namespace SonarScanner.MSBuild.Common
 
         private static Mutex CreateMutex(string name)
         {
-#if NET46
+#if NET462
             // Concurrent builds could be run under different user accounts, so we need to allow all users to wait on the mutex
             var mutexSecurity = new MutexSecurity();
             mutexSecurity.AddAccessRule(new MutexAccessRule(new SecurityIdentifier(WellKnownSidType.WorldSid, null),

--- a/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
@@ -84,7 +84,7 @@ namespace SonarScanner.MSBuild.PostProcessor
             var propertyResult = GenerateAndValidatePropertiesFile(config);
             if (propertyResult.FullPropertiesFilePath != null)
             {
-#if NET46
+#if NET462
                 ProcessCoverageReport(config, Path.Combine(config.SonarConfigDir, FileConstants.ConfigFileName), propertyResult.FullPropertiesFilePath);
 #endif
                 var result = false;
@@ -92,7 +92,7 @@ namespace SonarScanner.MSBuild.PostProcessor
                 {
                     result = InvokeSonarScanner(provider, config, propertyResult.FullPropertiesFilePath);
                 }
-#if NET46
+#if NET462
                 if (settings.BuildEnvironment == BuildEnvironment.LegacyTeamBuild)
                 {
                     ProcessSummaryReportBuilder(config, result, Path.Combine(config.SonarConfigDir, FileConstants.ConfigFileName), propertyResult.FullPropertiesFilePath);
@@ -206,7 +206,7 @@ namespace SonarScanner.MSBuild.PostProcessor
             return true;
         }
 
-#if NET46
+#if NET462
 
         private void ProcessSummaryReportBuilder(AnalysisConfig config, bool ranToCompletion, String sonarAnalysisConfigFilePath, string propertiesFilePath)
         {

--- a/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
@@ -84,7 +84,7 @@ namespace SonarScanner.MSBuild.PostProcessor
             var propertyResult = GenerateAndValidatePropertiesFile(config);
             if (propertyResult.FullPropertiesFilePath != null)
             {
-#if NET462
+#if NETFRAMEWORK
                 ProcessCoverageReport(config, Path.Combine(config.SonarConfigDir, FileConstants.ConfigFileName), propertyResult.FullPropertiesFilePath);
 #endif
                 var result = false;
@@ -92,7 +92,7 @@ namespace SonarScanner.MSBuild.PostProcessor
                 {
                     result = InvokeSonarScanner(provider, config, propertyResult.FullPropertiesFilePath);
                 }
-#if NET462
+#if NETFRAMEWORK
                 if (settings.BuildEnvironment == BuildEnvironment.LegacyTeamBuild)
                 {
                     ProcessSummaryReportBuilder(config, result, Path.Combine(config.SonarConfigDir, FileConstants.ConfigFileName), propertyResult.FullPropertiesFilePath);
@@ -206,7 +206,7 @@ namespace SonarScanner.MSBuild.PostProcessor
             return true;
         }
 
-#if NET462
+#if NETFRAMEWORK
 
         private void ProcessSummaryReportBuilder(AnalysisConfig config, bool ranToCompletion, String sonarAnalysisConfigFilePath, string propertiesFilePath)
         {

--- a/src/SonarScanner.MSBuild.Shim/RuntimeInformationWrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/RuntimeInformationWrapper.cs
@@ -18,10 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-#if NET46
-using System.Runtime.InteropServices;
-#endif
-
 namespace SonarScanner.MSBuild.Shim
 {
     /* Class for ease mocking in UT */

--- a/src/SonarScanner.MSBuild/Program.cs
+++ b/src/SonarScanner.MSBuild/Program.cs
@@ -44,7 +44,7 @@ namespace SonarScanner.MSBuild
         public static async Task<int> Execute(string[] args, ILogger logger)
         {
             Utilities.LogAssemblyVersion(logger, Resources.AssemblyDescription);
-#if NET46
+#if NET462
             logger.LogInfo("Using the .NET Framework version of the Scanner for MSBuild");
 #else
             logger.LogInfo("Using the .NET Core version of the Scanner for MSBuild");

--- a/src/SonarScanner.MSBuild/Program.cs
+++ b/src/SonarScanner.MSBuild/Program.cs
@@ -44,7 +44,7 @@ namespace SonarScanner.MSBuild
         public static async Task<int> Execute(string[] args, ILogger logger)
         {
             Utilities.LogAssemblyVersion(logger, Resources.AssemblyDescription);
-#if NET462
+#if NETFRAMEWORK
             logger.LogInfo("Using the .NET Framework version of the Scanner for MSBuild");
 #else
             logger.LogInfo("Using the .NET Core version of the Scanner for MSBuild");


### PR DESCRIPTION
This change is temporary to allow us to progress on the sprint. We will have to update the packaging to reflect PMs decision.

Upgrade to Net 462 as it is needed for the https://www.nuget.org/packages/Microsoft.CodeCoverage.IO package.

See also [MMF-2777](https://sonarsource.atlassian.net/browse/MMF-2777)

[MMF-2777]: https://sonarsource.atlassian.net/browse/MMF-2777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Part of #1652