### PR TITLE
Add comment with link to CodeCoverage issue

### DIFF
--- a/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
@@ -58,6 +58,7 @@ namespace SonarScanner.MSBuild.TFS.Classic
             var util = new CoverageFileUtility();
             try
             {
+                // Temporary work around until https://github.com/microsoft/codecoverage/issues/63 is fixed
                 using var dummy = new ApplicationCultureInfo(CultureInfo.InvariantCulture);
                 util.ConvertCoverageFile(
                     path: inputFilePath,


### PR DESCRIPTION
The `ApplicationCutureInfo` usage is a workaround for https://github.com/microsoft/codecoverage/issues/63. It should be removed once https://github.com/microsoft/codecoverage/issues/63 is resolved and published. A comment on the usage helps track the work and the future me's.