### PR TITLE
CodeCoverage.exe removal fixes

### DIFF
--- a/Tests/SonarScanner.MSBuild.TFS.Test/Classic/BinaryToXmlCoverageReportConverterTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/Classic/BinaryToXmlCoverageReportConverterTests.cs
@@ -200,6 +200,7 @@ Check that the downloaded code coverage file ({inputFilePath}) is valid by openi
             var expectedContent = XDocument.Load(expectedOutputFilePath);
             // All tags and attributes must appear in the same order for actual and expected. Comments, whitespace, and the like is ignored in the assertion.
             actualContent.Should().BeEquivalentTo(expectedContent);
+            logger.DebugMessages.Should().ContainSingle().Which.Should().Match(@"Converting coverage file '*\Sample.coverage' to '*\Conv_ConvertToXml_ToolConvertsSampleFile.xmlcoverage'.");
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.TFS.Test/Classic/BinaryToXmlCoverageReportConverterTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/Classic/BinaryToXmlCoverageReportConverterTests.cs
@@ -198,7 +198,7 @@ Check that the downloaded code coverage file ({inputFilePath}) is valid by openi
             File.Exists(outputFilePath).Should().BeTrue();
             var actualContent = XDocument.Load(outputFilePath);
             var expectedContent = XDocument.Load(expectedOutputFilePath);
-            // All tags and attributes must appear in the same order for actual and expected. Comments, whitespace, and the like is ignored in the assertion.
+            // All tags and attributes must appear in actual and expected. Comments, whitespace, ordering, and the like is ignored in the assertion.
             actualContent.Should().BeEquivalentTo(expectedContent);
             logger.DebugMessages.Should().ContainSingle().Which.Should().Match(@"Converting coverage file '*\Sample.coverage' to '*\Conv_ConvertToXml_ToolConvertsSampleFile.xmlcoverage'.");
         }
@@ -227,7 +227,7 @@ Check that the downloaded code coverage file ({inputFilePath}) is valid by openi
             File.Exists(outputFilePath).Should().BeTrue();
             var actualContent = XDocument.Load(outputFilePath);
             var expectedContent = XDocument.Load(expectedOutputFilePath);
-            // All tags and attributes must appear in the same order for actual and expected. Comments, whitespace, and the like is ignored in the assertion.
+            // All tags and attributes must appear in actual and expected. Comments, whitespace, ordering, and the like is ignored in the assertion.
             actualContent.Should().BeEquivalentTo(expectedContent);
         }
     }

--- a/scripts/package-artifacts.ps1
+++ b/scripts/package-artifacts.ps1
@@ -5,6 +5,7 @@
     if (!(Test-Path -path $destination)) {New-Item $destination -Type Directory}
     if (!(Test-Path -path "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets")) {New-Item "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets" -Type Directory}
 
+    Copy-Item -Path "$sourceRoot\Microsoft.CodeCoverage.IO.dll" -Destination $destination
     Copy-Item -Path "$sourceRoot\Newtonsoft.Json.dll" -Destination $destination
     Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.Common.dll" -Destination $destination
     Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.Shim.dll" -Destination $destination

--- a/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/BinaryToXmlCoverageReportConverter.cs
@@ -60,11 +60,8 @@ namespace SonarScanner.MSBuild.TFS.Classic
             {
                 // Temporary work around until https://github.com/microsoft/codecoverage/issues/63 is fixed
                 using var dummy = new ApplicationCultureInfo(CultureInfo.InvariantCulture);
-                util.ConvertCoverageFile(
-                    path: inputFilePath,
-                    outputPath: outputFilePath,
-                    includeSkippedFunctions: false,
-                    includeSkippedModules: false);
+                logger.LogDebug(Resources.CONV_DIAG_ConvertCoverageFile, inputFilePath, outputFilePath);
+                util.ConvertCoverageFile(path: inputFilePath, outputPath: outputFilePath, includeSkippedFunctions: false, includeSkippedModules: false);
             }
             catch (AggregateException aggregate) when (aggregate.InnerException is VanguardException)
             {

--- a/src/SonarScanner.MSBuild.TFS.Classic/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/Resources.Designer.cs
@@ -61,6 +61,15 @@ namespace SonarScanner.MSBuild.TFS.Classic {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Converting coverage file &apos;{0}&apos; to &apos;{1}&apos;..
+        /// </summary>
+        internal static string CONV_DIAG_ConvertCoverageFile {
+            get {
+                return ResourceManager.GetString("CONV_DIAG_ConvertCoverageFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to convert the identified code coverage file to XML. No code coverage information will be uploaded to SonarQube.
         ///Check that the downloaded code coverage file ({0}) is valid by opening it in Visual Studio. If it is not, check that the internet security settings on the build machine allow files to be downloaded from the Team Foundation Server machine..
         /// </summary>

--- a/src/SonarScanner.MSBuild.TFS.Classic/Resources.resx
+++ b/src/SonarScanner.MSBuild.TFS.Classic/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CONV_DIAG_ConvertCoverageFile" xml:space="preserve">
+    <value>Converting coverage file '{0}' to '{1}'.</value>
+  </data>
   <data name="CONV_ERROR_ConversionToolFailed" xml:space="preserve">
     <value>Failed to convert the identified code coverage file to XML. No code coverage information will be uploaded to SonarQube.
 Check that the downloaded code coverage file ({0}) is valid by opening it in Visual Studio. If it is not, check that the internet security settings on the build machine allow files to be downloaded from the Team Foundation Server machine.</value>


### PR DESCRIPTION
Fixes issues found during the test release of the extension:
* [x] Log message should be improved to contain the input and output file names
* [x] Package misses a dependency to `Microsoft.CodeCoverage.IO.dll`