### PR TITLE
Rename sonarscanner-msbuild-net46 to sonarscanner-net-framework

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -282,7 +282,7 @@ stages:
                   . (Join-Path "scripts" "variables.ps1")
 
                   Download-ScannerCli
-                  Package-Net46Scanner
+                  Package-NetFramework
                   Package-NetScanner "netcoreapp3.1" "netcoreapp3.0"
                 pwsh: true
 
@@ -354,18 +354,18 @@ stages:
                   $artifactsFolder = "$env:BUILD_SOURCESDIRECTORY\\build"
                   $version = $leakPeriodVersion + '.' + $env:BUILD_BUILDID
 
-                  $classicScannerZipPath = Get-Item "$artifactsFolder\\sonarscanner-msbuild-net46.zip"
+                  $classicScannerZipPath = Get-Item "$artifactsFolder\\sonarscanner-net-framework.zip"
                   $dotnetScannerZipPath3 = Get-Item "$artifactsFolder\\sonarscanner-msbuild-netcoreapp3.0.zip"
                   $dotnetScannerGlobalToolPath = Get-Item "$artifactsFolder\\dotnet-sonarscanner.$leakPeriodVersion.nupkg"
                   $sbomJsonPath = Get-Item "$(Build.SourcesDirectory)\build\bom.json"
 
                   Write-Host "Generating the chocolatey packages"
                   $classicZipHash = (Get-FileHash $classicScannerZipPath -Algorithm SHA256).hash
-                  $net46ps1 = "nuspec\chocolatey\chocolateyInstall-net46.ps1"
-                  (Get-Content $net46ps1) `
+                  $netFrameworkPs1 = "nuspec\chocolatey\chocolateyInstall-net-framework.ps1"
+                  (Get-Content $netFrameworkPs1) `
                     -Replace '-Checksum "not-set"', "-Checksum $classicZipHash" `
                     -Replace "__PackageVersion__", "$version" `
-                  | Set-Content $net46ps1
+                  | Set-Content $netFrameworkPs1
 
                   $dotnetZipHash3 = (Get-FileHash $dotnetScannerZipPath3 -Algorithm SHA256).hash
                   $netcoreps13 = "nuspec\chocolatey\chocolateyInstall-netcoreapp3.0.ps1"
@@ -374,7 +374,7 @@ stages:
                     -Replace "__PackageVersion__", "$version" `
                   | Set-Content $netcoreps13
 
-                  choco pack nuspec\chocolatey\sonarscanner-msbuild-net46.nuspec `
+                  choco pack nuspec\chocolatey\sonarscanner-net-framework.nuspec `
                   --outputdirectory $artifactsFolder `
                   --version $version
 
@@ -388,7 +388,7 @@ stages:
                    -Replace 'classicScannerZipPath', "$classicScannerZipPath" `
                    -Replace 'dotnet3ScannerZipPath', "$dotnetScannerZipPath3" `
                    -Replace 'dotnetScannerGlobalToolPath', "$dotnetScannerGlobalToolPath" `
-                   -Replace 'classicScannerChocoPath', "$artifactsFolder\\sonarscanner-msbuild-net46.$version.nupkg" `
+                   -Replace 'classicScannerChocoPath', "$artifactsFolder\\sonarscanner-net-framework.$version.nupkg" `
                    -Replace 'dotnetcore3ScannerChocoPath', "$artifactsFolder\\sonarscanner-msbuild-netcoreapp30.$version.nupkg" `
                    -Replace 'sbomPath', "$sbomJsonPath" `
                   | Set-Content $pomFile
@@ -439,7 +439,7 @@ stages:
                 targetType: 'inline'
                 script: |
                   $artifactsFolder = "$env:BUILD_SOURCESDIRECTORY\\build"
-                  Rename-Item -Path "$artifactsFolder\\sonarscanner-msbuild-net46.zip" -NewName sonar-scanner-msbuild-$(SONAR_PROJECT_VERSION).$(Build.BuildId)-net46.zip
+                  Rename-Item -Path "$artifactsFolder\\sonarscanner-net-framework.zip" -NewName sonar-scanner-$(SONAR_PROJECT_VERSION).$(Build.BuildId)-net-framework.zip
                   Rename-Item -Path "$artifactsFolder\\sonarscanner-msbuild-netcoreapp3.0.zip" -NewName sonar-scanner-msbuild-$(SONAR_PROJECT_VERSION).$(Build.BuildId)-netcoreapp3.0.zip
 
             - task: PowerShell@2
@@ -575,7 +575,7 @@ stages:
                   Write-Host "##vso[task.setvariable variable=SONAR_PROJECT_VERSION]$projectVersion"
 
                   Set-Location "$(Pipeline.Workspace)/scanner-packages"
-                  Get-ChildItem -Filter *net46.zip | Select-Object -First 1 | Expand-Archive -DestinationPath scanner -Force
+                  Get-ChildItem -Filter *net-framework.zip | Select-Object -First 1 | Expand-Archive -DestinationPath scanner -Force
 
             - task: Maven@3
               displayName: 'Run Maven ITs for $(PRODUCT) $(SQ_VERSION)'

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -153,7 +153,7 @@
                   <goal>get</goal>
                 </goals>
                 <configuration>
-                  <artifact>org.sonarsource.scanner.msbuild:sonar-scanner-msbuild:${scannerForMSBuild.version}:zip:net46</artifact>
+                  <artifact>org.sonarsource.scanner.msbuild:sonar-scanner:${scannerForMSBuild.version}:zip:net-framework</artifact>
                 </configuration>
               </execution>
             </executions>

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/IncrementalPRAnalysisSonarCloudTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/IncrementalPRAnalysisSonarCloudTest.java
@@ -53,7 +53,7 @@ class IncrementalPRAnalysisSonarCloudTest {
   private final static Logger LOG = LoggerFactory.getLogger(IncrementalPRAnalysisSonarCloudTest.class);
   private final static Integer COMMAND_TIMEOUT = 2 * 60 * 1000;
   private final static String SCANNER_PATH = System.getenv("SCANNER_PATH") == null
-    ? "../build/sonarscanner-msbuild-net46/SonarScanner.MSBuild.exe" // On the local machine, the scanner is prepared by ci-build.ps1 script.
+    ? "../build/sonarscanner-net-framework/SonarScanner.MSBuild.exe" // On the local machine, the scanner is prepared by ci-build.ps1 script.
     : System.getenv("SCANNER_PATH");
   private final static String[] prArguments = {
     "/d:sonar.pullrequest.base=master",

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -240,7 +240,7 @@ class ScannerMSBuildTest {
     int expectedTestProjectIssues = isTestProjectSupported() ? 1 : 0;
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     Path projectDir = TestUtils.projectDir(basePath, "ExcludedTest");
-    ScannerForMSBuild build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_False", projectDir, token, ScannerClassifier.NET_FRAMEWORK_46)
+    ScannerForMSBuild build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_False", projectDir, token, ScannerClassifier.NET_FRAMEWORK)
       // don't exclude test projects
       .setProperty("sonar.dotnet.excludeTestProjects", "false");
 
@@ -251,7 +251,7 @@ class ScannerMSBuildTest {
   void testExcludedAndTest_ExcludeTestProject() throws Exception {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     Path projectDir = TestUtils.projectDir(basePath, "ExcludedTest");
-    ScannerForMSBuild build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_True", projectDir, token, ScannerClassifier.NET_FRAMEWORK_46)
+    ScannerForMSBuild build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_True", projectDir, token, ScannerClassifier.NET_FRAMEWORK)
       // exclude test projects
       .setProperty("sonar.dotnet.excludeTestProjects", "true");
 
@@ -263,7 +263,7 @@ class ScannerMSBuildTest {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     Path projectDir = TestUtils.projectDir(basePath, "ExcludedTest");
     EnvironmentVariable sonarQubeScannerParams = new EnvironmentVariable("SONARQUBE_SCANNER_PARAMS", "{\"sonar.dotnet.excludeTestProjects\":\"true\",\"sonar.verbose\":\"true\"}");
-    ScannerForMSBuild build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_True_FromAzureDevOps", projectDir, token, ScannerClassifier.NET_FRAMEWORK_46);
+    ScannerForMSBuild build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_True_FromAzureDevOps", projectDir, token, ScannerClassifier.NET_FRAMEWORK);
 
     testExcludedAndTest(build, "ExcludedTest_True_FromAzureDevOps", projectDir, token, 0, Collections.singletonList(sonarQubeScannerParams));
   }
@@ -277,7 +277,7 @@ class ScannerMSBuildTest {
     ORCHESTRATOR.getServer().provisionProject(projectKeyName, projectKeyName);
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(projectKeyName, "cs", "ProfileForTest");
 
-    ScannerForMSBuild beginStep = TestUtils.newScannerBegin(ORCHESTRATOR, projectKeyName, projectDir, token, ScannerClassifier.NET_FRAMEWORK_46);
+    ScannerForMSBuild beginStep = TestUtils.newScannerBegin(ORCHESTRATOR, projectKeyName, projectDir, token, ScannerClassifier.NET_FRAMEWORK);
     ORCHESTRATOR.executeBuild(beginStep);
 
     EnvironmentVariable sonarQubeScannerParams = new EnvironmentVariable("SONARQUBE_SCANNER_PARAMS", "{\"sonar.dotnet.excludeTestProjects\" }");
@@ -300,7 +300,7 @@ class ScannerMSBuildTest {
 
     Path projectDir = TestUtils.projectDir(basePath, "ConsoleMultiLanguage");
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK_46));
+    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild");
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);
 
@@ -332,7 +332,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "ExternalIssues.VB");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK_46));
+    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild");
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);
 
@@ -427,7 +427,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "ProjectUnderTest");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK_46));
+    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild", "/p:ExcludeProjectsFromAnalysis=true");
     BuildResult result = ORCHESTRATOR.executeBuildQuietly(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("end"));
@@ -447,7 +447,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "ProjectUnderTest");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK_46));
+    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild");
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);
 
@@ -467,7 +467,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "AssemblyAttribute");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK_46));
+    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild");
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);
 
@@ -485,7 +485,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "ExternalIssues.CS");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK_46));
+    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild");
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);
 
@@ -607,7 +607,7 @@ class ScannerMSBuildTest {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
     ORCHESTRATOR.executeBuild(
-      TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK_46));
+      TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
 
     TestUtils.runNuGet(ORCHESTRATOR, projectDir, true, "restore");
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, Collections.emptyList(), 180 * 1000, "/t:Rebuild", "/nr:false");
@@ -836,7 +836,7 @@ class ScannerMSBuildTest {
 
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ScannerForMSBuild scanner = TestUtils.newScannerBegin(ORCHESTRATOR, "IgnoreIssuesDoesNotRemoveSourceGenerator", projectDir, token, ScannerClassifier.NET_FRAMEWORK_46)
+    ScannerForMSBuild scanner = TestUtils.newScannerBegin(ORCHESTRATOR, "IgnoreIssuesDoesNotRemoveSourceGenerator", projectDir, token, ScannerClassifier.NET_FRAMEWORK)
       .setProperty("sonar.cs.roslyn.ignoreIssues", "true");
 
     ORCHESTRATOR.executeBuild(scanner);
@@ -1221,7 +1221,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, projectName);
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK_46));
+    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
     TestUtils.runNuGet(ORCHESTRATOR, projectDir, false, "restore");
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild", "/nr:false");
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerClassifier.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerClassifier.java
@@ -26,7 +26,7 @@ import java.nio.file.Paths;
 
 public enum ScannerClassifier {
   NETCORE_3_1("netcoreapp3.0"),
-  NET_FRAMEWORK_46("net46");
+  NET_FRAMEWORK("net-framework");
 
   private final String classifier;
 
@@ -39,7 +39,10 @@ public enum ScannerClassifier {
   }
 
   public String toZipName() {
-    return "sonarscanner-msbuild-" + classifier + ".zip";
+    if (classifier.equals(NETCORE_3_1.classifier)){
+      return "sonarscanner-msbuild-" + classifier + ".zip";
+    }
+    return "sonarscanner-" + classifier + ".zip";
   }
 
   public Location toLocation(String scannerLocation) {
@@ -47,6 +50,6 @@ public enum ScannerClassifier {
   }
 
   public boolean isDotNetCore() {
-    return !classifier.equals(NET_FRAMEWORK_46.classifier);
+    return classifier.equals(NETCORE_3_1.classifier);
   }
 }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
@@ -79,7 +79,7 @@ public class TestUtils {
 
   private static MavenLocation getScannerMavenLocation(String scannerVersion, ScannerClassifier classifier) {
     String groupId = "org.sonarsource.scanner.msbuild";
-    String artifactId = "sonar-scanner-msbuild";
+    String artifactId = "sonar-scanner";
     return MavenLocation.builder()
       .setGroupId(groupId)
       .setArtifactId(artifactId)
@@ -96,7 +96,7 @@ public class TestUtils {
   }
 
   public static ScannerForMSBuild newScanner(Orchestrator orchestrator, Path projectDir, String token) {
-    return newScanner(orchestrator, projectDir, ScannerClassifier.NET_FRAMEWORK_46, token);
+    return newScanner(orchestrator, projectDir, ScannerClassifier.NET_FRAMEWORK, token);
   }
 
   public static ScannerForMSBuild newScannerBegin(Orchestrator orchestrator, String projectKeyName, Path projectDir, String token, ScannerClassifier classifier) {
@@ -349,11 +349,11 @@ public class TestUtils {
   }
 
   public static BuildResult executeEndStepAndDumpResults(Orchestrator orchestrator, Path projectDir, String projectKey, String token) {
-    return executeEndStepAndDumpResults(orchestrator, projectDir, projectKey, token, ScannerClassifier.NET_FRAMEWORK_46, Collections.emptyList());
+    return executeEndStepAndDumpResults(orchestrator, projectDir, projectKey, token, ScannerClassifier.NET_FRAMEWORK, Collections.emptyList());
   }
 
   public static BuildResult executeEndStepAndDumpResults(Orchestrator orchestrator, Path projectDir, String projectKey, String token, List<EnvironmentVariable> environmentVariables) {
-    return executeEndStepAndDumpResults(orchestrator, projectDir, projectKey, token, ScannerClassifier.NET_FRAMEWORK_46, environmentVariables);
+    return executeEndStepAndDumpResults(orchestrator, projectDir, projectKey, token, ScannerClassifier.NET_FRAMEWORK, environmentVariables);
   }
 
   public static BuildResult executeEndStepAndDumpResults(Orchestrator orchestrator,

--- a/nuspec/chocolatey/chocolateyInstall-net-framework.ps1
+++ b/nuspec/chocolatey/chocolateyInstall-net-framework.ps1
@@ -1,0 +1,5 @@
+﻿Install-ChocolateyZipPackage "sonarscanner-net-framework" `
+    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/__PackageVersion__/sonar-scanner-__PackageVersion__-net-framework.zip" `
+    -UnzipLocation "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" `
+    -ChecksumType 'sha256' `
+    -Checksum "not-set"

--- a/nuspec/chocolatey/chocolateyInstall-net46.ps1
+++ b/nuspec/chocolatey/chocolateyInstall-net46.ps1
@@ -1,5 +1,0 @@
-﻿Install-ChocolateyZipPackage "sonarscanner-msbuild-net46" `
-    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/__PackageVersion__/sonar-scanner-msbuild-__PackageVersion__-net46.zip" `
-    -UnzipLocation "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" `
-    -ChecksumType 'sha256' `
-    -Checksum "not-set"

--- a/nuspec/chocolatey/sonarscanner-net-framework.nuspec
+++ b/nuspec/chocolatey/sonarscanner-net-framework.nuspec
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<!-- Do not remove this test for UTF-8: if “Ω” doesn't appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <id>sonarscanner-msbuild-net46</id>
+    <id>sonarscanner-net-framework</id>
     <version>1.0.0</version>
-    <title>SonarScanner for MSBuild .Net Fwk 4.6</title>
+    <title>SonarScanner for .NET Framework</title>
     <authors>SonarSource,Microsoft</authors>
     <owners>SonarSource</owners>
-    <projectUrl>http://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>
+    <projectUrl>https://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>
     <projectSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild</projectSourceUrl>
     <packageSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild/tree/master/nuspec/chocolatey</packageSourceUrl>
     <iconUrl>https://cdn.rawgit.com/SonarSource/sonar-scanner-msbuild/cdd1f588/icon.png</iconUrl>
@@ -16,8 +16,8 @@
     <mailingListUrl>https://community.sonarsource.com/</mailingListUrl>
     <bugTrackerUrl>https://github.com/SonarSource/sonar-scanner-msbuild/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</summary>
-    <description>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</description>
+    <summary>The SonarScanner for .NET allows easy analysis of any .NET project with SonarCloud/SonarQube.</summary>
+    <description>The SonarScanner for .NET allows easy analysis of any .NET project with SonarCloud/SonarQube.</description>
     <tags>sonarqube sonarcloud msbuild scanner sonarsource sonar sonar-scanner sonarscanner</tags>
     <copyright>SonarSource SA and Microsoft Corporation</copyright>
     <releaseNotes>
@@ -25,6 +25,6 @@ All release notes for SonarScanner MSBuild .Net Core can be found on the GitHub 
     </releaseNotes>
   </metadata>
   <files>
-    <file src="chocolateyInstall-net46.ps1" target="tools\chocolateyInstall.ps1" />
+    <file src="chocolateyInstall-net-framework.ps1" target="tools\chocolateyInstall.ps1" />
   </files>
 </package>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <groupId>org.sonarsource.scanner.msbuild</groupId>
-  <artifactId>sonar-scanner-msbuild</artifactId>
+  <artifactId>sonar-scanner</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SonarScanner.MSBuild</name>
@@ -46,7 +46,7 @@
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <gitRepositoryName>sonar-scanner-msbuild</gitRepositoryName>
     <!-- Release: enable publication to Bintray -->
-    <artifactsToPublish>${project.groupId}:${project.artifactId}:zip:net46,${project.groupId}:${project.artifactId}:zip:netcoreapp3.0</artifactsToPublish>
+    <artifactsToPublish>${project.groupId}:${project.artifactId}:zip:net-framework,${project.groupId}:${project.artifactId}:zip:netcoreapp3.0</artifactsToPublish>
   </properties>
 
   <build>
@@ -67,7 +67,7 @@
                 <artifact>
                   <file>classicScannerZipPath</file>
                   <type>zip</type>
-                  <classifier>net46</classifier>
+                  <classifier>net-framework</classifier>
                 </artifact>
                 <artifact>
                   <file>dotnet3ScannerZipPath</file>
@@ -81,7 +81,7 @@
                 <artifact>
                   <file>classicScannerChocoPath</file>
                   <type>nupkg</type>
-                  <classifier>net46</classifier>
+                  <classifier>net-framework</classifier>
                 </artifact>
                 <artifact>
                   <file>dotnetcore3ScannerChocoPath</file>

--- a/scripts/ci-build.ps1
+++ b/scripts/ci-build.ps1
@@ -15,9 +15,9 @@ function Build-Scanner() {
     Write-Host "Build for SonarScanner has completed."
 }
 
-function CleanAndRecreate-BuildDirectories([string]$tfm) {
-    if (Test-Path("$fullBuildOutputDir\sonarscanner-msbuild-$tfm")) {
-        Remove-Item "$fullBuildOutputDir\sonarscanner-msbuild-$tfm\*" -Recurse -Force
+function CleanAndRecreate-BuildDirectories([string]$suffix) {
+    if (Test-Path("$fullBuildOutputDir\sonarscanner-$suffix")) {
+        Remove-Item "$fullBuildOutputDir\sonarscanner-$suffix\*" -Recurse -Force
     }
 }
 
@@ -28,14 +28,14 @@ try {
     . (Join-Path $PSScriptRoot "package-artifacts.ps1")
     . (Join-Path $PSScriptRoot "variables.ps1")
 
-    CleanAndRecreate-BuildDirectories "net46"
-    CleanAndRecreate-BuildDirectories "netcoreapp3.0"
+    CleanAndRecreate-BuildDirectories "net-framework"
+    CleanAndRecreate-BuildDirectories "msbuild-netcoreapp3.0"
     Download-ScannerCli
 
     Build-TFSProcessor
     Build-Scanner
 
-    Package-Net46Scanner
+    Package-NetFramework
     Package-NetScanner "netcoreapp3.1" "netcoreapp3.0"
 
     Write-Host -ForegroundColor Green "SUCCESS: CI job was successful!"

--- a/scripts/package-artifacts.ps1
+++ b/scripts/package-artifacts.ps1
@@ -1,9 +1,10 @@
-﻿function Package-Net46Scanner() {
-    $destination = "$fullBuildOutputDir\sonarscanner-msbuild-net46"
+﻿function Package-NetFramework() {
+    $destination = "$fullBuildOutputDir\sonarscanner-net-framework"
+    $destinationTargets = "$destination\Targets"
     $sourceRoot = "$PSScriptRoot\..\src\SonarScanner.MSBuild.TFS.Classic\bin\Release\net462"
 
     if (!(Test-Path -path $destination)) {New-Item $destination -Type Directory}
-    if (!(Test-Path -path "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets")) {New-Item "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets" -Type Directory}
+    if (!(Test-Path -path "$destinationTargets")) {New-Item "$destinationTargets" -Type Directory}
 
     Copy-Item -Path "$sourceRoot\Microsoft.CodeCoverage.IO.dll" -Destination $destination
     Copy-Item -Path "$sourceRoot\Newtonsoft.Json.dll" -Destination $destination
@@ -14,11 +15,11 @@
     Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.TFSProcessor.exe.config" -Destination $destination
     Copy-Item -Path "$sourceRoot\System.Runtime.InteropServices.RuntimeInformation.dll" -Destination $destination
     Copy-Item -Path "$sourceRoot\System.ValueTuple.dll" -Destination $destination
-    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\Targets\*" -Destination "$fullBuildOutputDir\sonarscanner-msbuild-net46\Targets" -Recurse
+    Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\Targets\*" -Destination "$destinationTargets" -Recurse
     Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild\bin\Release\net462\*" -Exclude "*.pdb" -Destination $destination -Recurse
     Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\bin\Release\net462\SonarScanner.MSBuild.Tasks.dll" -Destination $destination
     [System.IO.Compression.ZipFile]::ExtractToDirectory("$scannerCliDownloadDir\$scannerCliArtifact", $destination)
-    Compress-Archive -Path $fullBuildOutputDir\sonarscanner-msbuild-net46\* -DestinationPath $fullBuildOutputDir\sonarscanner-msbuild-net46.zip -Force
+    Compress-Archive -Path "$destination\*" -DestinationPath "$destination.zip" -Force
 }
 
 function Package-NetScanner([string]$sourcetfm, [string]$targettfm) {

--- a/scripts/sign.ps1
+++ b/scripts/sign.ps1
@@ -8,9 +8,9 @@
     }
 }
 
-Write-Host "Signing .NET 4.6 assemblies"
-Sign-Assemblies "build\sonarscanner-msbuild-net46\Sonar*.dll"
-Write-Host "[Completed]Signing .NET 4.6 assemblies"
+Write-Host "Signing .NET Framework assemblies"
+Sign-Assemblies "build\sonarscanner-net-framework\Sonar*.dll"
+Write-Host "[Completed] Signing .NET Framework assemblies"
 
 Write-Host "Signing .NET Core 3 assemblies"
 Sign-Assemblies "build\sonarscanner-msbuild-netcoreapp3.0\Sonar*.dll"


### PR DESCRIPTION
Fixes #1769

This commit also changes the package name on repox. This part was not included in the specification since we were not aware that we publish also on repox.

The repox packages are used by the orchestrator to download the scanner. If there are consumers that need to reference the latest version, they will have to update the artifactId from "sonar-scanner-msbuild" to "sonar-scanner".

I've tested the ps1 script for the chocolatey package with:
 
```powershell
  # Test the choco nuget file
  $version = "6.0.0.81085"
  $classicScannerZipPath = Get-Item .\build\sonarscanner-net-framework.zip
  $classicZipHash = (Get-FileHash $classicScannerZipPath -Algorithm SHA256).hash
  $netFrameworkPs1 = "nuspec\chocolatey\chocolateyInstall-net-framework.ps1"
  (Get-Content $netFrameworkPs1) -Replace '-Checksum "not-set"', "-Checksum $classicZipHash" -Replace "__PackageVersion__", "$version" | Set-Content $netFrameworkPs1
```

Old vs new generated paths:
```
https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/5.15.0.80890/sonar-scanner-msbuild-5.15.0.80890-net46.zip
https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/6.0.0.81085/sonar-scanner-6.0.0.81085-net-framework.zip
```


