### PR TITLE
Make `begin`/`end` phase mandatory on command line

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/CommandLine/CommandLineParserTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/CommandLine/CommandLineParserTests.cs
@@ -295,7 +295,6 @@ namespace SonarScanner.MSBuild.Common.Test
 
             success.Should().BeFalse("Expecting parsing to fail");
             instances.Should().NotBeNull("Instances should not be null even if parsing fails");
-            AssertExpectedInstancesCount(0, instances);
 
             logger.AssertErrorsLogged();
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -374,8 +374,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                     "/d:unique=value5");
 
             // Assert
-            logger.AssertSingleErrorExists("-version:1.2", "1.2");
-            logger.AssertErrorsLogged(1);
+            logger.AssertErrorsLogged(3);
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -375,6 +375,9 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             // Assert
             logger.AssertErrorsLogged(3);
+            logger.AssertSingleErrorExists("dup1=value2", "value1");
+            logger.AssertSingleErrorExists("dup2=value4", "value3");
+            logger.AssertSingleErrorExists("version:1.2", "1.2");
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Test/ArgumentProcessorTests.cs
@@ -204,7 +204,7 @@ public class ArgumentProcessorTests
         logger.AssertErrorLogged(Resources.ERROR_CmdLine_NeitherBeginNorEndSupplied);
 
         // 5. Incorrect case -> treated as unrecognized argument -> invalid (missing verb)
-        logger = CheckProcessingFails(ValidUrl);
+        logger = CheckProcessingFails(ValidUrl, "BEGIN");
         logger.AssertErrorLogged(Resources.ERROR_CmdLine_NeitherBeginNorEndSupplied);
     }
 

--- a/Tests/SonarScanner.MSBuild.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Test/ArgumentProcessorTests.cs
@@ -70,18 +70,18 @@ public class ArgumentProcessorTests
     [TestMethod]
     public void ArgProc_Help()
     {
-        ArgumentProcessor.IsHelp(new[] { "/other", "-other" }).Should().BeFalse();
+        ArgumentProcessor.IsHelp(["/other", "-other"]).Should().BeFalse();
 
-        ArgumentProcessor.IsHelp(Array.Empty<string>()).Should().BeTrue();
+        ArgumentProcessor.IsHelp([]).Should().BeTrue();
 
-        ArgumentProcessor.IsHelp(new[] { "/?", "/other" }).Should().BeTrue();
-        ArgumentProcessor.IsHelp(new[] { "-?", "-other" }).Should().BeTrue();
+        ArgumentProcessor.IsHelp(["/?", "/other"]).Should().BeTrue();
+        ArgumentProcessor.IsHelp(["-?", "-other"]).Should().BeTrue();
 
-        ArgumentProcessor.IsHelp(new[] { "/h", "/other" }).Should().BeTrue();
-        ArgumentProcessor.IsHelp(new[] { "-h", "-other" }).Should().BeTrue();
+        ArgumentProcessor.IsHelp(["/h", "/other"]).Should().BeTrue();
+        ArgumentProcessor.IsHelp(["-h", "-other"]).Should().BeTrue();
 
-        ArgumentProcessor.IsHelp(new[] { "/help", "/other" }).Should().BeTrue();
-        ArgumentProcessor.IsHelp(new[] { "-help", "-other" }).Should().BeTrue();
+        ArgumentProcessor.IsHelp(["/help", "/other"]).Should().BeTrue();
+        ArgumentProcessor.IsHelp(["-help", "-other"]).Should().BeTrue();
     }
 
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.Test/ProgramTests.cs
+++ b/Tests/SonarScanner.MSBuild.Test/ProgramTests.cs
@@ -33,7 +33,7 @@ namespace SonarScanner.MSBuild.Test
         {
             var logger = new TestLogger();
 
-            var result = await Program.Execute(new[] { "/h", "/blah", "/xxx" }, logger);
+            var result = await Program.Execute(["/h", "/blah", "/xxx"], logger);
 
             result.Should().Be(0);
             logger.Warnings.Should().BeEmpty();
@@ -48,11 +48,11 @@ namespace SonarScanner.MSBuild.Test
         public void Execute_WhenInvalidDuplicateBeginArgument_ReturnsFalse()
         {
             var logger = new TestLogger();
-            var result = Program.Execute(new string[] { "begin", "begin" }, logger).Result;
+            var result = Program.Execute(["begin", "begin"], logger).Result;
 
             // Assert
             result.Should().Be(1);
-            logger.Errors.Should().HaveCount(1);
+            logger.Errors.Should().ContainSingle();
         }
     }
 }

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+
   <ItemGroup>
     <!-- Enable code generation for resource files -->
     <CodeGenerationEmbeddedResource Include="@(EmbeddedResource)" Exclude="**\*.??-??.resx" />

--- a/src/SonarScanner.MSBuild.Common/CommandLine/CommandLineParser.cs
+++ b/src/SonarScanner.MSBuild.Common/CommandLine/CommandLineParser.cs
@@ -86,7 +86,7 @@ namespace SonarScanner.MSBuild.Common
             var parsedOk = true;
 
             // List of values that have been recognized
-            IList<ArgumentInstance> recognized = new List<ArgumentInstance>();
+            List<ArgumentInstance> recognized = [];
 
             foreach (var arg in commandLineArgs)
             {
@@ -123,7 +123,7 @@ namespace SonarScanner.MSBuild.Common
             // as possible about the failures.
             parsedOk &= CheckRequiredArgumentsSupplied(recognized, logger);
 
-            argumentInstances = parsedOk ? recognized : Enumerable.Empty<ArgumentInstance>();
+            argumentInstances = recognized;
 
             return parsedOk;
         }

--- a/src/SonarScanner.MSBuild.PostProcessor/ArgumentProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/ArgumentProcessor.cs
@@ -74,7 +74,7 @@ namespace SonarScanner.MSBuild.PostProcessor
 
             // This call will fail if there are duplicate or missing arguments
             var parser = new CommandLineParser(Descriptors, false /* don't allow unrecognized arguments*/);
-            var parsedOk = parser.ParseArguments(commandLineArgs, logger, out IEnumerable<ArgumentInstance> arguments);
+            var parsedOk = parser.ParseArguments(commandLineArgs, logger, out var arguments);
 
             if (parsedOk)
             {

--- a/src/SonarScanner.MSBuild.PreProcessor/ArgumentProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ArgumentProcessor.cs
@@ -56,7 +56,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             new(id: ProjectNameId, prefixes: GetPrefixedFlags("name:", "n:"), required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_ProjectName),
             new(id: ProjectVersionId, prefixes: GetPrefixedFlags("version:", "v:"), required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_ProjectVersion),
             new(id: OrganizationId, prefixes: GetPrefixedFlags("organization:", "o:"), required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_Organization),
-            new(id: InstallLoaderTargetsId,prefixes: GetPrefixedFlags("install:"), required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_InstallTargets),
+            new(id: InstallLoaderTargetsId, prefixes: GetPrefixedFlags("install:"), required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_InstallTargets),
 
             FilePropertyProvider.Descriptor,
             CmdLineArgPropertyProvider.Descriptor

--- a/src/SonarScanner.MSBuild/ArgumentProcessor.cs
+++ b/src/SonarScanner.MSBuild/ArgumentProcessor.cs
@@ -96,7 +96,7 @@ public static class ArgumentProcessor
             Debug.Assert(globalFileProperties != null, "When parse is valid, expected global file properties to be non-null");
 
             var properties = new AggregatePropertiesProvider(cmdLineProperties, globalFileProperties);
-            var baseChildArgs = RemoveBootstrapperArgs(commandLineArgs);
+            var baseChildArgs = commandLineArgs.Except(new[] { BeginVerb, EndVerb }).ToList(); // We don't want to forward these to the pre- or post- processor.
 
             settings = phase == AnalysisPhase.PreProcessing
                 ? CreatePreProcessorSettings(baseChildArgs, properties, globalFileProperties, logger)
@@ -155,13 +155,4 @@ public static class ArgumentProcessor
 
     private static IBootstrapperSettings CreateSettings(AnalysisPhase phase, IEnumerable<string> childArgs, IAnalysisPropertyProvider properties, ILogger logger) =>
         new BootstrapperSettings(phase, childArgs, VerbosityCalculator.ComputeVerbosity(properties, logger), logger);
-
-    /// <summary>
-    /// Strips out any arguments that are only relevant to the bootstrapper from the user-supplied command line arguments.
-    /// </summary>
-    /// <remarks>We don't want to forward these arguments to the pre- or post- processor.</remarks>
-    private static IList<string> RemoveBootstrapperArgs(string[] commandLineArgs) =>
-        commandLineArgs == null
-        ? throw new ArgumentNullException(nameof(commandLineArgs))
-        : commandLineArgs.Except(new[] { BeginVerb, EndVerb }).ToList();
 }

--- a/src/SonarScanner.MSBuild/ArgumentProcessor.cs
+++ b/src/SonarScanner.MSBuild/ArgumentProcessor.cs
@@ -26,191 +26,142 @@ using System.Linq;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.Common.CommandLine;
 
-namespace SonarScanner.MSBuild
+namespace SonarScanner.MSBuild;
+
+/// <summary>
+/// Processes the command line arguments.
+/// Supports the standard property-related arguments automatically (i.e. /d: and /s:).
+/// The appropriate "additionalDescriptors" should be supplied to provide support for other command line arguments.
+/// </summary>
+public static class ArgumentProcessor
 {
-    /// <summary>
-    /// Processes the command line arguments.
-    /// Supports the standard property-related arguments automatically (i.e. /d: and /s:).
-    /// The appropriate "additionalDescriptors" should be supplied to provide support for other command line arguments.
-    /// </summary>
-    public static class ArgumentProcessor
+    // FIX: this code is very similar to that in the pre-processor. Consider refactoring to avoid duplication
+    // once the other argument and properties-writing tickets have been completed.
+
+    #region Arguments definitions
+
+    private const string BeginId = "begin.id";
+    private const string EndId = "end.id";
+    public const string HelpId = "help.id";
+
+    public const string BeginVerb = "begin";
+    public const string EndVerb = "end";
+
+    // Initialize the set of valid descriptors.
+    // To add a new argument, just add it to the list.
+    private static readonly List<ArgumentDescriptor> Descriptors =
+        [
+            new(id: BeginId, prefixes: [BeginVerb], required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_Begin, isVerb: true),
+            new(id: EndId, prefixes: [EndVerb], required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_End, isVerb: true),
+            FilePropertyProvider.Descriptor,
+            CmdLineArgPropertyProvider.Descriptor
+        ];
+
+    static ArgumentProcessor()
     {
-        // FIX: this code is very similar to that in the pre-processor. Consider refactoring to avoid duplication
-        // once the other argument and properties-writing tickets have been completed.
-
-        #region Arguments definitions
-
-        private const string BeginId = "begin.id";
-        private const string EndId = "end.id";
-        public const string HelpId = "help.id";
-
-        public const string BeginVerb = "begin";
-        public const string EndVerb = "end";
-
-        private static IList<ArgumentDescriptor> Descriptors;
-
-        static ArgumentProcessor()
-        {
-            // Initialize the set of valid descriptors.
-            // To add a new argument, just add it to the list.
-            Descriptors = new List<ArgumentDescriptor>
-            {
-                new ArgumentDescriptor(
-                id: BeginId, prefixes: new string[] { BeginVerb }, required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_Begin, isVerb: true),
-
-                new ArgumentDescriptor(
-                id: EndId, prefixes: new string[] { EndVerb }, required: false, allowMultiple: false, description: Resources.CmdLine_ArgDescription_End, isVerb: true),
-
-                FilePropertyProvider.Descriptor,
-                CmdLineArgPropertyProvider.Descriptor
-            };
-
-            Debug.Assert(Descriptors.All(d => d.Prefixes != null && d.Prefixes.Any()), "All descriptors must provide at least one prefix");
-            Debug.Assert(Descriptors.Select(d => d.Id).Distinct().Count() == Descriptors.Count, "All descriptors must have a unique id");
-        }
-
-        #endregion Arguments definitions
-
-        #region Public methods
-
-        public static bool IsHelp(string[] commandLineArgs) =>
-            commandLineArgs.Length == 0
-            || CommandLineFlagPrefix.GetPrefixedFlags("?", "h", "help").Any(commandLineArgs.Contains);
-
-        /// <summary>
-        /// Attempts to process the supplied command line arguments and reports any errors using the logger.
-        /// Returns false if any parsing errors were encountered.
-        /// </summary>
-        public static bool TryProcessArgs(string[] commandLineArgs, ILogger logger, out IBootstrapperSettings settings)
-        {
-            if (commandLineArgs == null)
-            {
-                throw new ArgumentNullException(nameof(commandLineArgs));
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
-            settings = null;
-
-            // This call will fail if there are duplicate or missing arguments
-            var parser = new CommandLineParser(Descriptors, true /* allow unrecognized arguments*/);
-            var parsedOk = parser.ParseArguments(commandLineArgs, logger, out IEnumerable<ArgumentInstance> arguments);
-
-            // Handler for command line analysis properties
-            parsedOk &= CmdLineArgPropertyProvider.TryCreateProvider(arguments, logger, out IAnalysisPropertyProvider cmdLineProperties);
-
-            // Handler for property file
-            var asmPath = Path.GetDirectoryName(typeof(ArgumentProcessor).Assembly.Location);
-            parsedOk &= FilePropertyProvider.TryCreateProvider(arguments, asmPath, logger, out IAnalysisPropertyProvider globalFileProperties);
-
-            parsedOk &= TryGetPhase(commandLineArgs.Length, arguments, logger, out AnalysisPhase phase);
-
-            Debug.Assert(!parsedOk || cmdLineProperties != null);
-            Debug.Assert(!parsedOk || globalFileProperties != null);
-
-            if (parsedOk)
-            {
-                Debug.Assert(cmdLineProperties != null);
-                Debug.Assert(globalFileProperties != null);
-                IAnalysisPropertyProvider properties = new AggregatePropertiesProvider(cmdLineProperties, globalFileProperties);
-
-                var baseChildArgs = RemoveBootstrapperArgs(commandLineArgs);
-
-                if (phase == AnalysisPhase.PreProcessing)
-                {
-                    settings = CreatePreProcessorSettings(baseChildArgs, properties, globalFileProperties, logger);
-                }
-                else
-                {
-                    settings = CreatePostProcessorSettings(baseChildArgs, properties, logger);
-                }
-            }
-
-            return settings != null;
-        }
-
-        #endregion Public methods
-
-        #region Private methods
-
-        private static bool TryGetPhase(int originalArgCount, IEnumerable<ArgumentInstance> arguments, ILogger logger, out AnalysisPhase phase)
-        {
-            // The command line parser will already have checked for duplicates
-            var hasBeginVerb = ArgumentInstance.TryGetArgument(BeginId, arguments, out ArgumentInstance argumentInstance);
-            var hasEndVerb = ArgumentInstance.TryGetArgument(EndId, arguments, out argumentInstance);
-
-            if (hasBeginVerb && hasEndVerb) // both
-            {
-                phase = AnalysisPhase.Unspecified;
-                logger.LogError(Resources.ERROR_CmdLine_BothBeginAndEndSupplied);
-            }
-            else if (!hasBeginVerb && !hasEndVerb) // neither
-            {
-                // Backwards compatibility - decide the phase based on the number of arguments passed
-                // See: https://github.com/SonarSource/sonar-scanner-msbuild/issues/1540
-                phase = originalArgCount == 0 ? AnalysisPhase.PostProcessing : AnalysisPhase.PreProcessing;
-                logger.LogWarning(Resources.WARN_CmdLine_v09_Compat);
-            }
-            else // begin or end
-            {
-                phase = hasBeginVerb ? AnalysisPhase.PreProcessing : AnalysisPhase.PostProcessing;
-            }
-
-            return phase != AnalysisPhase.Unspecified;
-        }
-
-        private static IBootstrapperSettings CreatePreProcessorSettings(ICollection<string> childArgs, IAnalysisPropertyProvider properties, IAnalysisPropertyProvider globalFileProperties, ILogger logger)
-        {
-            // If we're using the default properties file then we need to pass it
-            // explicitly to the pre-processor (it's in a different folder and won't
-            // be able to find it otherwise).
-            if (globalFileProperties is FilePropertyProvider fileProvider && fileProvider.IsDefaultSettingsFile)
-            {
-                Debug.Assert(fileProvider.PropertiesFile != null);
-                Debug.Assert(!string.IsNullOrEmpty(fileProvider.PropertiesFile.FilePath), "Expecting the properties file path to be set");
-                childArgs.Add(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}{1}", FilePropertyProvider.Prefix, fileProvider.PropertiesFile.FilePath));
-            }
-
-            return CreateSettings(AnalysisPhase.PreProcessing, childArgs, properties, logger);
-        }
-
-        private static IBootstrapperSettings CreatePostProcessorSettings(IEnumerable<string> childArgs, IAnalysisPropertyProvider properties, ILogger logger)
-        {
-            return CreateSettings(AnalysisPhase.PostProcessing, childArgs, properties, logger);
-        }
-
-        private static IBootstrapperSettings CreateSettings(AnalysisPhase phase, IEnumerable<string> childArgs, IAnalysisPropertyProvider properties, ILogger logger)
-        {
-            return new BootstrapperSettings(
-                phase,
-                childArgs,
-                VerbosityCalculator.ComputeVerbosity(properties, logger),
-                logger);
-        }
-
-        /// <summary>
-        /// Strips out any arguments that are only relevant to the bootstrapper from the user-supplied
-        /// command line arguments
-        /// </summary>
-        /// <remarks>We don't want to forward these arguments to the pre- or post- processor</remarks>
-        private static IList<string> RemoveBootstrapperArgs(string[] commandLineArgs)
-        {
-            if (commandLineArgs == null)
-            {
-                throw new ArgumentNullException(nameof(commandLineArgs));
-            }
-
-            var excludedVerbs = new string[] { BeginVerb, EndVerb };
-            var excludedPrefixes = new string[] { };
-
-            return commandLineArgs
-                .Except(excludedVerbs)
-                .Where(arg => !excludedPrefixes.Any(e => arg.StartsWith(e, ArgumentDescriptor.IdComparison)))
-                .ToList();
-        }
-
-        #endregion Private methods
+        Debug.Assert(Descriptors.TrueForAll(d => d.Prefixes != null && d.Prefixes.Any()), "All descriptors must provide at least one prefix");
+        Debug.Assert(Descriptors.Select(d => d.Id).Distinct().Count() == Descriptors.Count, "All descriptors must have a unique id");
     }
+
+    #endregion Arguments definitions
+
+    public static bool IsHelp(string[] commandLineArgs) =>
+        commandLineArgs.Length == 0
+        || Array.Exists(CommandLineFlagPrefix.GetPrefixedFlags("?", "h", "help"), commandLineArgs.Contains);
+
+    /// <summary>
+    /// Attempts to process the supplied command line arguments and reports any errors using the logger.
+    /// Returns false if any parsing errors were encountered.
+    /// </summary>
+    public static bool TryProcessArgs(string[] commandLineArgs, ILogger logger, out IBootstrapperSettings settings)
+    {
+        _ = commandLineArgs ?? throw new ArgumentNullException(nameof(commandLineArgs));
+        _ = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        // This call will fail if there are duplicate or missing arguments
+        var parsedOk = new CommandLineParser(Descriptors, true).ParseArguments(commandLineArgs, logger, out var arguments);
+
+        // Handler for command line analysis properties
+        parsedOk &= CmdLineArgPropertyProvider.TryCreateProvider(arguments, logger, out var cmdLineProperties);
+
+        // Handler for property file
+        var asmPath = Path.GetDirectoryName(typeof(ArgumentProcessor).Assembly.Location);
+        parsedOk &= FilePropertyProvider.TryCreateProvider(arguments, asmPath, logger, out var globalFileProperties);
+
+        parsedOk &= TryGetPhase(arguments, logger, out var phase);
+
+        if (parsedOk)
+        {
+            Debug.Assert(cmdLineProperties != null, "When parse is valid, expected cmd line properties to be non-null");
+            Debug.Assert(globalFileProperties != null, "When parse is valid, expected global file properties to be non-null");
+
+            var properties = new AggregatePropertiesProvider(cmdLineProperties, globalFileProperties);
+            var baseChildArgs = RemoveBootstrapperArgs(commandLineArgs);
+
+            settings = phase == AnalysisPhase.PreProcessing
+                ? CreatePreProcessorSettings(baseChildArgs, properties, globalFileProperties, logger)
+                : CreatePostProcessorSettings(baseChildArgs, properties, logger);
+            return true;
+        }
+        else
+        {
+            settings = null;
+            return false;
+        }
+    }
+
+    private static bool TryGetPhase(IEnumerable<ArgumentInstance> arguments, ILogger logger, out AnalysisPhase phase)
+    {
+        // The command line parser will already have checked for duplicates
+        var hasBeginVerb = ArgumentInstance.TryGetArgument(BeginId, arguments, out var _);
+        var hasEndVerb = ArgumentInstance.TryGetArgument(EndId, arguments, out var _);
+
+        if (hasBeginVerb && hasEndVerb)
+        {
+            logger.LogError(Resources.ERROR_CmdLine_BothBeginAndEndSupplied);
+            phase = AnalysisPhase.Unspecified;
+            return false;
+        }
+        else if (!hasBeginVerb && !hasEndVerb)
+        {
+            logger.LogError(Resources.ERROR_CmdLine_NeitherBeginNorEndSupplied);
+            phase = AnalysisPhase.Unspecified;
+            return false;
+        }
+        else
+        {
+            phase = hasBeginVerb ? AnalysisPhase.PreProcessing : AnalysisPhase.PostProcessing;
+            return true;
+        }
+    }
+
+    private static IBootstrapperSettings CreatePreProcessorSettings(ICollection<string> childArgs, IAnalysisPropertyProvider properties, IAnalysisPropertyProvider globalFileProperties, ILogger logger)
+    {
+        // If we're using the default properties file then we need to pass it
+        // explicitly to the pre-processor (it's in a different folder and won't
+        // be able to find it otherwise).
+        if (globalFileProperties is FilePropertyProvider fileProvider && fileProvider.IsDefaultSettingsFile)
+        {
+            Debug.Assert(fileProvider.PropertiesFile != null, "Expected the properties file to be non-null");
+            Debug.Assert(!string.IsNullOrEmpty(fileProvider.PropertiesFile.FilePath), "Expected the properties file path to be set");
+            childArgs.Add(string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}{1}", FilePropertyProvider.Prefix, fileProvider.PropertiesFile.FilePath));
+        }
+
+        return CreateSettings(AnalysisPhase.PreProcessing, childArgs, properties, logger);
+    }
+
+    private static IBootstrapperSettings CreatePostProcessorSettings(IEnumerable<string> childArgs, IAnalysisPropertyProvider properties, ILogger logger) =>
+        CreateSettings(AnalysisPhase.PostProcessing, childArgs, properties, logger);
+
+    private static IBootstrapperSettings CreateSettings(AnalysisPhase phase, IEnumerable<string> childArgs, IAnalysisPropertyProvider properties, ILogger logger) =>
+        new BootstrapperSettings(phase, childArgs, VerbosityCalculator.ComputeVerbosity(properties, logger), logger);
+
+    /// <summary>
+    /// Strips out any arguments that are only relevant to the bootstrapper from the user-supplied command line arguments.
+    /// </summary>
+    /// <remarks>We don't want to forward these arguments to the pre- or post- processor.</remarks>
+    private static IList<string> RemoveBootstrapperArgs(string[] commandLineArgs) =>
+        commandLineArgs == null
+        ? throw new ArgumentNullException(nameof(commandLineArgs))
+        : commandLineArgs.Except(new[] { BeginVerb, EndVerb }).ToList();
 }

--- a/src/SonarScanner.MSBuild/ArgumentProcessor.cs
+++ b/src/SonarScanner.MSBuild/ArgumentProcessor.cs
@@ -140,7 +140,7 @@ public static class ArgumentProcessor
         // If we're using the default properties file then we need to pass it
         // explicitly to the pre-processor (it's in a different folder and won't
         // be able to find it otherwise).
-        if (globalFileProperties is FilePropertyProvider fileProvider && fileProvider.IsDefaultSettingsFile)
+        if (globalFileProperties is FilePropertyProvider { IsDefaultSettingsFile: true } fileProvider)
         {
             Debug.Assert(fileProvider.PropertiesFile != null, "Expected the properties file to be non-null");
             Debug.Assert(!string.IsNullOrEmpty(fileProvider.PropertiesFile.FilePath), "Expected the properties file path to be set");

--- a/src/SonarScanner.MSBuild/BootstrapperClass.cs
+++ b/src/SonarScanner.MSBuild/BootstrapperClass.cs
@@ -27,222 +27,220 @@ using System.Threading.Tasks;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.Common.Interfaces;
 
-namespace SonarScanner.MSBuild
+namespace SonarScanner.MSBuild;
+
+public class BootstrapperClass
 {
-    public class BootstrapperClass
+    private const int ErrorCode = 1;
+    private const int SuccessCode = 0;
+
+    private readonly IProcessorFactory processorFactory;
+    private readonly IBootstrapperSettings bootstrapSettings;
+    private readonly ILogger logger;
+    private readonly Func<string, Version> getAssemblyVersionFunc;
+
+    public BootstrapperClass(IProcessorFactory processorFactory, IBootstrapperSettings bootstrapSettings, ILogger logger)
+        : this(processorFactory, bootstrapSettings, logger, assemblyPath => AssemblyName.GetAssemblyName(assemblyPath).Version)
     {
-        private const int ErrorCode = 1;
-        private const int SuccessCode = 0;
+    }
 
-        private readonly IProcessorFactory processorFactory;
-        private readonly IBootstrapperSettings bootstrapSettings;
-        private readonly ILogger logger;
-        private readonly Func<string, Version> getAssemblyVersionFunc;
+    internal /* for testing */ BootstrapperClass(IProcessorFactory processorFactory,
+                                                 IBootstrapperSettings bootstrapSettings,
+                                                 ILogger logger,
+                                                 Func<string, Version> getAssemblyVersionFunc)
+    {
+        this.processorFactory = processorFactory;
+        this.bootstrapSettings = bootstrapSettings;
+        this.logger = logger;
+        this.getAssemblyVersionFunc = getAssemblyVersionFunc;
 
-        public BootstrapperClass(IProcessorFactory processorFactory, IBootstrapperSettings bootstrapSettings, ILogger logger)
-            : this(processorFactory, bootstrapSettings, logger, assemblyPath => AssemblyName.GetAssemblyName(assemblyPath).Version)
+        Debug.Assert(this.bootstrapSettings != null, "Bootstrapper settings should not be null");
+    }
+
+    /// <summary>
+    /// Bootstraps a begin or end step, based on the bootstrap settings.
+    /// </summary>
+    public async Task<int> Execute()
+    {
+        int exitCode;
+
+        logger.Verbosity = bootstrapSettings.LoggingVerbosity;
+        logger.ResumeOutput();
+
+        var phase = bootstrapSettings.Phase;
+        LogProcessingStarted(phase);
+
+        try
         {
+            exitCode = phase == AnalysisPhase.PreProcessing
+                ? await PreProcess()
+                : PostProcess();
+        }
+        catch (AnalysisException ex)
+        {
+            logger.LogError(ex.Message);
+            exitCode = ErrorCode;
         }
 
-        public BootstrapperClass(IProcessorFactory processorFactory,
-                                 IBootstrapperSettings bootstrapSettings,
-                                 ILogger logger,
-                                 Func<string, Version> getAssemblyVersionFunc)
-        {
-            this.processorFactory = processorFactory;
-            this.bootstrapSettings = bootstrapSettings;
-            this.logger = logger;
-            this.getAssemblyVersionFunc = getAssemblyVersionFunc;
+        LogProcessingCompleted(phase, exitCode);
+        return exitCode;
+    }
 
-            Debug.Assert(this.bootstrapSettings != null, "Bootstrapper settings should not be null");
-            Debug.Assert(this.bootstrapSettings.Phase != AnalysisPhase.Unspecified, "Expecting the processing phase to be specified");
+    private async Task<int> PreProcess()
+    {
+        logger.LogInfo(Resources.MSG_PreparingDirectories);
+
+        CleanSonarQubeDirectory();
+        if (!CopyDlls())
+        {
+            return ErrorCode;
         }
 
-        /// <summary>
-        /// Bootstraps a begin or end step, based on the bootstrap settings.
-        /// </summary>
-        public async Task<int> Execute()
+        logger.IncludeTimestamp = true;
+
+        var preProcessor = processorFactory.CreatePreProcessor();
+        Directory.SetCurrentDirectory(bootstrapSettings.TempDirectory);
+        var success = await preProcessor.Execute(bootstrapSettings.ChildCmdLineArgs.ToArray());
+
+        return success ? SuccessCode : ErrorCode;
+    }
+
+    private void CleanSonarQubeDirectory()
+    {
+        var rootDirectory = new DirectoryInfo(bootstrapSettings.TempDirectory);
+
+        if (!rootDirectory.Exists)
         {
-            int exitCode;
+            return;
+        }
 
-            logger.Verbosity = bootstrapSettings.LoggingVerbosity;
-            logger.ResumeOutput();
-
-            var phase = bootstrapSettings.Phase;
-            LogProcessingStarted(phase);
-
+        foreach (var directory in rootDirectory.GetDirectories())
+        {
             try
             {
-                exitCode = phase == AnalysisPhase.PreProcessing
-                    ? await PreProcess()
-                    : PostProcess();
+                directory.Delete(true);
             }
-            catch (AnalysisException ex)
+            catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
             {
-                logger.LogError(ex.Message);
-                exitCode = ErrorCode;
-            }
-
-            LogProcessingCompleted(phase, exitCode);
-            return exitCode;
-        }
-
-        private async Task<int> PreProcess()
-        {
-            logger.LogInfo(Resources.MSG_PreparingDirectories);
-
-            CleanSonarQubeDirectory();
-            if (!CopyDlls())
-            {
-                return ErrorCode;
-            }
-
-            logger.IncludeTimestamp = true;
-
-            var preProcessor = processorFactory.CreatePreProcessor();
-            Directory.SetCurrentDirectory(bootstrapSettings.TempDirectory);
-            var success = await preProcessor.Execute(bootstrapSettings.ChildCmdLineArgs.ToArray());
-
-            return success ? SuccessCode : ErrorCode;
-        }
-
-        private void CleanSonarQubeDirectory()
-        {
-            var rootDirectory = new DirectoryInfo(bootstrapSettings.TempDirectory);
-
-            if (!rootDirectory.Exists)
-            {
-                return;
-            }
-
-            foreach (var directory in rootDirectory.GetDirectories())
-            {
-                try
-                {
-                    directory.Delete(true);
-                }
-                catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
-                {
-                    logger.LogDebug($"Cannot delete directory: '{directory.FullName}' because {ex.Message}.");
-                }
-            }
-
-            foreach (var file in rootDirectory.GetFiles("*", SearchOption.AllDirectories))
-            {
-                try
-                {
-                    file.Delete();
-                }
-                catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
-                {
-                    logger.LogDebug($"Cannot delete file: '{file.FullName}' because {ex.Message}.");
-                }
+                logger.LogDebug($"Cannot delete directory: '{directory.FullName}' because {ex.Message}.");
             }
         }
 
-        private int PostProcess()
+        foreach (var file in rootDirectory.GetFiles("*", SearchOption.AllDirectories))
         {
-            logger.IncludeTimestamp = true;
-
-            if (!Directory.Exists(bootstrapSettings.TempDirectory))
+            try
             {
-                logger.LogError(Resources.ERROR_TempDirDoesNotExist);
-                return ErrorCode;
+                file.Delete();
             }
-
-            Directory.SetCurrentDirectory(bootstrapSettings.TempDirectory);
-            IBuildSettings teamBuildSettings = BuildSettings.GetSettingsFromEnvironment();
-            var config = GetAnalysisConfig(teamBuildSettings.AnalysisConfigFilePath);
-
-            bool succeeded;
-            if (config == null)
+            catch (Exception ex) when (ex is UnauthorizedAccessException || ex is IOException)
             {
-                succeeded = false;
+                logger.LogDebug($"Cannot delete file: '{file.FullName}' because {ex.Message}.");
+            }
+        }
+    }
+
+    private int PostProcess()
+    {
+        logger.IncludeTimestamp = true;
+
+        if (!Directory.Exists(bootstrapSettings.TempDirectory))
+        {
+            logger.LogError(Resources.ERROR_TempDirDoesNotExist);
+            return ErrorCode;
+        }
+
+        Directory.SetCurrentDirectory(bootstrapSettings.TempDirectory);
+        IBuildSettings teamBuildSettings = BuildSettings.GetSettingsFromEnvironment();
+        var config = GetAnalysisConfig(teamBuildSettings.AnalysisConfigFilePath);
+
+        bool succeeded;
+        if (config == null)
+        {
+            succeeded = false;
+        }
+        else
+        {
+            var postProcessor = processorFactory.CreatePostProcessor();
+            succeeded = postProcessor.Execute(bootstrapSettings.ChildCmdLineArgs.ToArray(), config, teamBuildSettings);
+        }
+
+        return succeeded ? SuccessCode : ErrorCode;
+    }
+
+    /// <summary>
+    /// Copies DLLs needed by the targets file that is loaded by MSBuild to the project's .sonarqube directory
+    /// </summary>
+    private bool CopyDlls()
+    {
+        var binDirPath = Path.Combine(bootstrapSettings.TempDirectory, "bin");
+        Directory.CreateDirectory(binDirPath);
+        string[] dllsToCopy = { "SonarScanner.MSBuild.Common.dll", "SonarScanner.MSBuild.Tasks.dll", "Newtonsoft.Json.dll" };
+
+        foreach (var dll in dllsToCopy)
+        {
+            var from = Path.Combine(bootstrapSettings.ScannerBinaryDirPath, dll);
+            var to = Path.Combine(binDirPath, dll);
+
+            if (!File.Exists(to))
+            {
+                File.Copy(from, to);
+            }
+            else if (getAssemblyVersionFunc(from).CompareTo(getAssemblyVersionFunc(to)) != 0)
+            {
+                logger.LogError(Resources.ERROR_DllLockedMultipleScanners);
+                return false;
             }
             else
             {
-                var postProcessor = processorFactory.CreatePostProcessor();
-                succeeded = postProcessor.Execute(bootstrapSettings.ChildCmdLineArgs.ToArray(), config, teamBuildSettings);
+                // do nothing
             }
-
-            return succeeded ? SuccessCode : ErrorCode;
         }
 
-        /// <summary>
-        /// Copies DLLs needed by the targets file that is loaded by MSBuild to the project's .sonarqube directory
-        /// </summary>
-        private bool CopyDlls()
-        {
-            var binDirPath = Path.Combine(bootstrapSettings.TempDirectory, "bin");
-            Directory.CreateDirectory(binDirPath);
-            string[] dllsToCopy = { "SonarScanner.MSBuild.Common.dll", "SonarScanner.MSBuild.Tasks.dll", "Newtonsoft.Json.dll" };
+        return true;
+    }
 
-            foreach (var dll in dllsToCopy)
+    /// <summary>
+    /// Attempts to load the analysis config file. The location of the file is
+    /// calculated from TeamBuild-specific environment variables.
+    /// Returns null if the required environment variables are not available.
+    /// </summary>
+    private AnalysisConfig GetAnalysisConfig(string configFilePath)
+    {
+        AnalysisConfig config = null;
+
+        if (configFilePath != null)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(configFilePath), "Expecting the analysis config file path to be set");
+
+            if (File.Exists(configFilePath))
             {
-                var from = Path.Combine(bootstrapSettings.ScannerBinaryDirPath, dll);
-                var to = Path.Combine(binDirPath, dll);
-
-                if (!File.Exists(to))
-                {
-                    File.Copy(from, to);
-                }
-                else if (getAssemblyVersionFunc(from).CompareTo(getAssemblyVersionFunc(to)) != 0)
-                {
-                    logger.LogError(Resources.ERROR_DllLockedMultipleScanners);
-                    return false;
-                }
-                else
-                {
-                    // do nothing
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Attempts to load the analysis config file. The location of the file is
-        /// calculated from TeamBuild-specific environment variables.
-        /// Returns null if the required environment variables are not available.
-        /// </summary>
-        private AnalysisConfig GetAnalysisConfig(string configFilePath)
-        {
-            AnalysisConfig config = null;
-
-            if (configFilePath != null)
-            {
-                Debug.Assert(!string.IsNullOrWhiteSpace(configFilePath), "Expecting the analysis config file path to be set");
-
-                if (File.Exists(configFilePath))
-                {
-                    config = AnalysisConfig.Load(configFilePath);
-                    config.LocalSettings = config.LocalSettings ?? new AnalysisProperties();
-                }
-                else
-                {
-                    logger.LogError(Resources.ERROR_ConfigFileNotFound, configFilePath);
-                }
-            }
-            return config;
-        }
-
-        private void LogProcessingStarted(AnalysisPhase phase)
-        {
-            var phaseLabel = phase == AnalysisPhase.PreProcessing ? Resources.PhaseLabel_PreProcessing : Resources.PhaseLabel_PostProcessing;
-            logger.LogInfo(Resources.MSG_ProcessingStarted, phaseLabel);
-        }
-
-        private void LogProcessingCompleted(AnalysisPhase phase, int exitCode)
-        {
-            var phaseLabel = phase == AnalysisPhase.PreProcessing ? Resources.PhaseLabel_PreProcessing : Resources.PhaseLabel_PostProcessing;
-            if (exitCode == ProcessRunner.ErrorCode)
-            {
-                logger.LogError(Resources.ERROR_ProcessingFailed, phaseLabel, exitCode);
+                config = AnalysisConfig.Load(configFilePath);
+                config.LocalSettings = config.LocalSettings ?? new AnalysisProperties();
             }
             else
             {
-                logger.LogInfo(Resources.MSG_ProcessingSucceeded, phaseLabel);
+                logger.LogError(Resources.ERROR_ConfigFileNotFound, configFilePath);
             }
+        }
+        return config;
+    }
+
+    private void LogProcessingStarted(AnalysisPhase phase)
+    {
+        var phaseLabel = phase == AnalysisPhase.PreProcessing ? Resources.PhaseLabel_PreProcessing : Resources.PhaseLabel_PostProcessing;
+        logger.LogInfo(Resources.MSG_ProcessingStarted, phaseLabel);
+    }
+
+    private void LogProcessingCompleted(AnalysisPhase phase, int exitCode)
+    {
+        var phaseLabel = phase == AnalysisPhase.PreProcessing ? Resources.PhaseLabel_PreProcessing : Resources.PhaseLabel_PostProcessing;
+        if (exitCode == ProcessRunner.ErrorCode)
+        {
+            logger.LogError(Resources.ERROR_ProcessingFailed, phaseLabel, exitCode);
+        }
+        else
+        {
+            logger.LogInfo(Resources.MSG_ProcessingSucceeded, phaseLabel);
         }
     }
 }

--- a/src/SonarScanner.MSBuild/Properties/AssemblyInfo.cs
+++ b/src/SonarScanner.MSBuild/Properties/AssemblyInfo.cs
@@ -19,7 +19,15 @@
  */
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("SonarScanner.MSBuild")]
 [assembly: AssemblyProduct("SonarScanner.MSBuild")]
 [assembly: AssemblyDescription("")]
+
+// FIXME: add public key
+#if SignAssembly
+[assembly: InternalsVisibleTo("SonarScanner.MSBuild.Test,PublicKey=FIXME")]
+#else
+[assembly: InternalsVisibleTo("SonarScanner.MSBuild.Test")]
+#endif

--- a/src/SonarScanner.MSBuild/Properties/InternalsVisibleTo.cs
+++ b/src/SonarScanner.MSBuild/Properties/InternalsVisibleTo.cs
@@ -20,9 +20,8 @@
 
 using System.Runtime.CompilerServices;
 
-// FIXME: add public key
 #if SignAssembly
-[assembly: InternalsVisibleTo("SonarScanner.MSBuild.Test,PublicKey=FIXME")]
+[assembly: InternalsVisibleTo("SonarScanner.MSBuild.Test,PublicKey=002400000480000094000000060200000024000052534131000400000100010081b4345a022cc0f4b42bdc795a5a7a1623c1e58dc2246645d751ad41ba98f2749dc5c4e0da3a9e09febcb2cd5b088a0f041f8ac24b20e736d8ae523061733782f9c4cd75b44f17a63714aced0b29a59cd1ce58d8e10ccdb6012c7098c39871043b7241ac4ab9f6b34f183db716082cd57c1ff648135bece256357ba735e67dc6")]
 #else
 [assembly: InternalsVisibleTo("SonarScanner.MSBuild.Test")]
 #endif

--- a/src/SonarScanner.MSBuild/Properties/InternalsVisibleTo.cs
+++ b/src/SonarScanner.MSBuild/Properties/InternalsVisibleTo.cs
@@ -18,8 +18,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Reflection;
+using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle("SonarScanner.MSBuild")]
-[assembly: AssemblyProduct("SonarScanner.MSBuild")]
-[assembly: AssemblyDescription("")]
+// FIXME: add public key
+#if SignAssembly
+[assembly: InternalsVisibleTo("SonarScanner.MSBuild.Test,PublicKey=FIXME")]
+#else
+[assembly: InternalsVisibleTo("SonarScanner.MSBuild.Test")]
+#endif

--- a/src/SonarScanner.MSBuild/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace SonarScanner.MSBuild {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -97,7 +97,16 @@ namespace SonarScanner.MSBuild {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {1} analysis could not be completed because the analysis configuration file could not be found: {0}..
+        ///   Looks up a localized string similar to Please specify the command &apos;begin&apos; or &apos;end&apos; to indicate whether pre- or post-processing is required..
+        /// </summary>
+        internal static string ERROR_CmdLine_NeitherBeginNorEndSupplied {
+            get {
+                return ResourceManager.GetString("ERROR_CmdLine_NeitherBeginNorEndSupplied", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarQube analysis could not be completed because the analysis configuration file could not be found: {0}..
         /// </summary>
         internal static string ERROR_ConfigFileNotFound {
             get {
@@ -194,15 +203,6 @@ namespace SonarScanner.MSBuild {
         internal static string PhaseLabel_PreProcessing {
             get {
                 return ResourceManager.GetString("PhaseLabel_PreProcessing", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Please specify the command &apos;begin&apos; or &apos;end&apos; to indicate whether pre- or post-processing is required. These parameters will become mandatory in a later release..
-        /// </summary>
-        internal static string WARN_CmdLine_v09_Compat {
-            get {
-                return ResourceManager.GetString("WARN_CmdLine_v09_Compat", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild/Resources.resx
+++ b/src/SonarScanner.MSBuild/Resources.resx
@@ -129,6 +129,9 @@
   <data name="ERROR_CmdLine_BothBeginAndEndSupplied" xml:space="preserve">
     <value>Invalid command line parameters. Please specify either 'begin' or 'end', not both.</value>
   </data>
+  <data name="ERROR_CmdLine_NeitherBeginNorEndSupplied" xml:space="preserve">
+    <value>Please specify the command 'begin' or 'end' to indicate whether pre- or post-processing is required.</value>
+  </data>
   <data name="ERROR_ConfigFileNotFound" xml:space="preserve">
     <value>SonarQube analysis could not be completed because the analysis configuration file could not be found: {0}.</value>
   </data>
@@ -163,9 +166,6 @@
   </data>
   <data name="PhaseLabel_PreProcessing" xml:space="preserve">
     <value>Pre-processing</value>
-  </data>
-  <data name="WARN_CmdLine_v09_Compat" xml:space="preserve">
-    <value>Please specify the command 'begin' or 'end' to indicate whether pre- or post-processing is required. These parameters will become mandatory in a later release.</value>
   </data>
   <data name="WARN_Deprecated_Entry_Point" xml:space="preserve">
     <value>------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1721 

Additional changes:
- Internals from `SonarScanner.MSBuild` have been exposed to `SonarScanner.MSBuild.Test` 
- CaYC: File based namespaces have been introduced on modified files: use the `Hide whitespaces` feature from GitHub for a better reviewing experience
- ~Changes language version from `9.0` to `latest` for all projects, allowing for the use of recent C# features (including more pattern matching and collections expressions from C# 12)~
  - Extracted into [a dedicated PR](https://github.com/SonarSource/sonar-scanner-msbuild/pull/1793)
- Changes the behavior of the log parser in presence of duplicated arguments (that is a blocking error)
  - Instead of clearing out the list of arguments, returns the valid arguments
  - The change allows to avoid having a second error message wrongly stating that when the verb is missing (whereas duplication made the command line arguments invalid, clearing out the arguments)
  - That also allows for a simplification of the code
 