### PR TITLE
Bump dependency versions as part of S4NET 6.0.0 release

### DIFF
--- a/src/SonarScanner.MSBuild.Tasks/SonarScanner.MSBuild.Tasks.csproj
+++ b/src/SonarScanner.MSBuild.Tasks/SonarScanner.MSBuild.Tasks.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Runtime dependencies used by tasks need to be copied by SonarScanner.MSBuild.BootstrapperClass.CopyDlls() -->
-    <PackageReference Include="Microsoft.Build" Version="17.6.3" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.6.3" />
+    <PackageReference Include="Microsoft.Build" Version="15.9.20" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.6" />
   </ItemGroup>

--- a/src/SonarScanner.MSBuild.Tasks/SonarScanner.MSBuild.Tasks.csproj
+++ b/src/SonarScanner.MSBuild.Tasks/SonarScanner.MSBuild.Tasks.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Runtime dependencies used by tasks need to be copied by SonarScanner.MSBuild.BootstrapperClass.CopyDlls() -->
-    <PackageReference Include="Microsoft.Build" Version="14.3.0" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="14.3.0" />
+    <PackageReference Include="Microsoft.Build" Version="17.6.3" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.6.3" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.6" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #1596

- Bump `Microsoft.Build` from **14.3.0** to **15.9.20**
- Bump `Microsoft.Build.Utilities.Core` from **14.3.0** to **15.9.20**