### PR TITLE
[DO NOT MERGE] Deprecate the old choco packages

### DIFF
--- a/AssemblyInfo.Shared.cs
+++ b/AssemblyInfo.Shared.cs
@@ -21,9 +21,9 @@
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("5.15.0")]
-[assembly: AssemblyFileVersion("5.15.0.0")]
-[assembly: AssemblyInformationalVersion("Version:5.15.0.0 Branch:not-set Sha1:not-set")]
+[assembly: AssemblyVersion("5.16.0")]
+[assembly: AssemblyFileVersion("5.16.0.0")]
+[assembly: AssemblyInformationalVersion("Version:5.16.0.0 Branch:not-set Sha1:not-set")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SonarSource and Microsoft")]
 [assembly: AssemblyCopyright("Copyright © SonarSource and Microsoft 2015-2023")]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -364,34 +364,6 @@ stages:
                   $sbomJsonPath = Get-Item "$(Build.SourcesDirectory)\build\bom.json"
 
                   Write-Host "Generating the chocolatey packages"
-                  $classicZipHash = (Get-FileHash $classicScannerZipPath -Algorithm SHA256).hash
-                  $net46ps1 = "nuspec\chocolatey\chocolateyInstall-net46.ps1"
-                  (Get-Content $net46ps1) `
-                    -Replace '-Checksum "not-set"', "-Checksum $classicZipHash" `
-                    -Replace "__PackageVersion__", "$version" `
-                  | Set-Content $net46ps1
-
-                  $dotnetZipHash = (Get-FileHash $dotnetScannerZipPath -Algorithm SHA256).hash
-                  $netcoreps1 = "nuspec\chocolatey\chocolateyInstall-netcoreapp2.0.ps1"
-                  (Get-Content $netcoreps1) `
-                    -Replace '-Checksum "not-set"', "-Checksum $dotnetZipHash" `
-                    -Replace "__PackageVersion__", "$version" `
-                  | Set-Content $netcoreps1
-
-                  $dotnetZipHash3 = (Get-FileHash $dotnetScannerZipPath3 -Algorithm SHA256).hash
-                  $netcoreps13 = "nuspec\chocolatey\chocolateyInstall-netcoreapp3.0.ps1"
-                  (Get-Content $netcoreps13) `
-                    -Replace '-Checksum "not-set"', "-Checksum $dotnetZipHash3" `
-                    -Replace "__PackageVersion__", "$version" `
-                  | Set-Content $netcoreps13
-
-                  $dotnetZipHash5 = (Get-FileHash $dotnetScannerZipPath5 -Algorithm SHA256).hash
-                  $netcoreps15 = "nuspec\chocolatey\chocolateyInstall-net5.0.ps1"
-                  (Get-Content $netcoreps15) `
-                    -Replace '-Checksum "not-set"', "-Checksum $dotnetZipHash5" `
-                    -Replace "__PackageVersion__", "$version" `
-                  | Set-Content $netcoreps15
-
                   choco pack nuspec\chocolatey\sonarscanner-msbuild-net46.nuspec `
                   --outputdirectory $artifactsFolder `
                   --version $version

--- a/nuspec/chocolatey/chocolateyInstall-net46.ps1
+++ b/nuspec/chocolatey/chocolateyInstall-net46.ps1
@@ -1,5 +1,0 @@
-﻿Install-ChocolateyZipPackage "sonarscanner-msbuild-net46" `
-    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/__PackageVersion__/sonar-scanner-msbuild-__PackageVersion__-net46.zip" `
-    -UnzipLocation "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" `
-    -ChecksumType 'sha256' `
-    -Checksum "not-set"

--- a/nuspec/chocolatey/chocolateyInstall-net5.0.ps1
+++ b/nuspec/chocolatey/chocolateyInstall-net5.0.ps1
@@ -1,5 +1,0 @@
-﻿Install-ChocolateyZipPackage "sonarscanner-msbuild-net5.0" `
-    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/__PackageVersion__/sonar-scanner-msbuild-__PackageVersion__-net5.0.zip" `
-    -UnzipLocation "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" `
-    -ChecksumType 'sha256' `
-    -Checksum "not-set"

--- a/nuspec/chocolatey/chocolateyInstall-netcoreapp2.0.ps1
+++ b/nuspec/chocolatey/chocolateyInstall-netcoreapp2.0.ps1
@@ -1,5 +1,0 @@
-﻿Install-ChocolateyZipPackage "sonarscanner-msbuild-netcoreapp2.0" `
-    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/__PackageVersion__/sonar-scanner-msbuild-__PackageVersion__-netcoreapp2.0.zip" `
-    -UnzipLocation "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" `
-    -ChecksumType 'sha256' `
-    -Checksum "not-set"

--- a/nuspec/chocolatey/chocolateyInstall-netcoreapp3.0.ps1
+++ b/nuspec/chocolatey/chocolateyInstall-netcoreapp3.0.ps1
@@ -1,5 +1,0 @@
-﻿Install-ChocolateyZipPackage "sonarscanner-msbuild-netcoreapp3.0" `
-    -Url "https://github.com/SonarSource/sonar-scanner-msbuild/releases/download/__PackageVersion__/sonar-scanner-msbuild-__PackageVersion__-netcoreapp3.0.zip" `
-    -UnzipLocation "$(Split-Path -parent $MyInvocation.MyCommand.Definition)" `
-    -ChecksumType 'sha256' `
-    -Checksum "not-set"

--- a/nuspec/chocolatey/sonarscanner-msbuild-net46.nuspec
+++ b/nuspec/chocolatey/sonarscanner-msbuild-net46.nuspec
@@ -4,27 +4,27 @@
   <metadata>
     <id>sonarscanner-msbuild-net46</id>
     <version>1.0.0</version>
-    <title>SonarScanner for MSBuild .Net Fwk 4.6</title>
+    <title>[Deprecated] SonarScanner for MSBuild .Net Fwk 4.6</title>
     <authors>SonarSource,Microsoft</authors>
     <owners>SonarSource</owners>
     <projectUrl>http://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>
     <projectSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild</projectSourceUrl>
     <packageSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild/tree/master/nuspec/chocolatey</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/SonarSource/sonar-scanner-msbuild/cdd1f588/icon.png</iconUrl>
     <licenseUrl>https://github.com/SonarSource/sonar-scanner-msbuild/blob/master/LICENSE.txt</licenseUrl>
     <docsUrl>https://redirect.sonarsource.com/doc/install-configure-scanner-msbuild.html</docsUrl>
     <mailingListUrl>https://community.sonarsource.com/</mailingListUrl>
     <bugTrackerUrl>https://github.com/SonarSource/sonar-scanner-msbuild/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</summary>
-    <description>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</description>
+    <summary>[Deprecated] The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</summary>
+    <description>**Deprecated**: .NET Framework 4.6 is not supported anymore. There is now a single package `sonarscanner-net-framework`, for *.NET Framework 4.6.2* and above.</description>
     <tags>sonarqube sonarcloud msbuild scanner sonarsource sonar sonar-scanner sonarscanner</tags>
     <copyright>SonarSource SA and Microsoft Corporation</copyright>
     <releaseNotes>
 All release notes for SonarScanner MSBuild .Net Core can be found on the GitHub site - https://github.com/SonarSource/sonar-scanner-msbuild/releases
     </releaseNotes>
+    <dependencies>
+      <dependency id="sonarscanner-net-framework" />
+    </dependencies>    
   </metadata>
-  <files>
-    <file src="chocolateyInstall-net46.ps1" target="tools\chocolateyInstall.ps1" />
-  </files>
+  <files />
 </package>

--- a/nuspec/chocolatey/sonarscanner-msbuild-net5.0.nuspec
+++ b/nuspec/chocolatey/sonarscanner-msbuild-net5.0.nuspec
@@ -4,27 +4,27 @@
   <metadata>
     <id>sonarscanner-msbuild-net50</id>
     <version>1.0.0</version>
-    <title>SonarScanner for MSBuild .Net 5.0</title>
+    <title>[Deprecated] SonarScanner for MSBuild .Net 5.0</title>
     <authors>SonarSource,Microsoft</authors>
     <owners>SonarSource</owners>
     <projectUrl>http://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>
     <projectSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild</projectSourceUrl>
     <packageSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild/tree/master/nuspec/chocolatey</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/SonarSource/sonar-scanner-msbuild/cdd1f588/icon.png</iconUrl>
     <licenseUrl>https://github.com/SonarSource/sonar-scanner-msbuild/blob/master/LICENSE.txt</licenseUrl>
     <docsUrl>https://redirect.sonarsource.com/doc/install-configure-scanner-msbuild.html</docsUrl>
     <mailingListUrl>https://community.sonarsource.com/</mailingListUrl>
     <bugTrackerUrl>https://github.com/SonarSource/sonar-scanner-msbuild/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</summary>
-    <description>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</description>
+    <summary>[Deprecated] The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</summary>
+    <description>**Deprecated**: there is now a single package `sonarscanner-net`, for *.NET Core 3.1* and *.NET 5.0* and above.</description>
     <tags>sonarqube sonarcloud msbuild scanner sonarsource sonar sonar-scanner sonarscanner</tags>
     <copyright>SonarSource SA and Microsoft Corporation</copyright>
     <releaseNotes>
 All release notes for SonarScanner MSBuild .Net Core can be found on the GitHub site - https://github.com/SonarSource/sonar-scanner-msbuild/releases
     </releaseNotes>
+    <dependencies>
+      <dependency id="sonarscanner-net" />
+    </dependencies>     
   </metadata>
-  <files>
-    <file src="chocolateyInstall-net5.0.ps1" target="tools\chocolateyInstall.ps1" />
-  </files>
+  <files />
 </package>

--- a/nuspec/chocolatey/sonarscanner-msbuild-netcoreapp2.0.nuspec
+++ b/nuspec/chocolatey/sonarscanner-msbuild-netcoreapp2.0.nuspec
@@ -4,27 +4,27 @@
   <metadata>
     <id>sonarscanner-msbuild-netcoreapp2.0</id>
     <version>1.0.0</version>
-    <title>SonarScanner for MSBuild .Net Core 2.0</title>
+    <title>[Deprecated] SonarScanner for MSBuild .Net Core 2.0</title>
     <authors>SonarSource,Microsoft</authors>
     <owners>SonarSource</owners>
     <projectUrl>http://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>
     <projectSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild</projectSourceUrl>
     <packageSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild/tree/master/nuspec/chocolatey</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/SonarSource/sonar-scanner-msbuild/cdd1f588/icon.png</iconUrl>
     <licenseUrl>https://github.com/SonarSource/sonar-scanner-msbuild/blob/master/LICENSE.txt</licenseUrl>
     <docsUrl>https://redirect.sonarsource.com/doc/install-configure-scanner-msbuild.html</docsUrl>
     <mailingListUrl>https://community.sonarsource.com/</mailingListUrl>
     <bugTrackerUrl>https://github.com/SonarSource/sonar-scanner-msbuild/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</summary>
-    <description>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</description>
+    <summary>[Deprecated] The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</summary>
+    <description>**Deprecated**: .NET Core 2.0 is not supported anymore. There is now a single package `sonarscanner-net`, for *.NET Core 3.1* and *.NET 5.0* and above.</description>
     <tags>sonarqube sonarcloud msbuild scanner sonarsource sonar sonar-scanner sonarscanner</tags>
     <copyright>SonarSource SA and Microsoft Corporation</copyright>
     <releaseNotes>
 All release notes for SonarScanner MSBuild .Net Core can be found on the GitHub site - https://github.com/SonarSource/sonar-scanner-msbuild/releases
     </releaseNotes>
+    <dependencies>
+      <dependency id="sonarscanner-net" />
+    </dependencies>     
   </metadata>
-  <files>
-    <file src="chocolateyInstall-netcoreapp2.0.ps1" target="tools\chocolateyInstall.ps1" />
-  </files>
+  <files />
 </package>

--- a/nuspec/chocolatey/sonarscanner-msbuild-netcoreapp3.0.nuspec
+++ b/nuspec/chocolatey/sonarscanner-msbuild-netcoreapp3.0.nuspec
@@ -4,27 +4,27 @@
   <metadata>
     <id>sonarscanner-msbuild-netcoreapp30</id>
     <version>1.0.0</version>
-    <title>SonarScanner for MSBuild .Net Core 3.0</title>
+    <title>[Deprecated] SonarScanner for MSBuild .Net Core 3.0</title>
     <authors>SonarSource,Microsoft</authors>
     <owners>SonarSource</owners>
     <projectUrl>http://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>
     <projectSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild</projectSourceUrl>
     <packageSourceUrl>https://github.com/SonarSource/sonar-scanner-msbuild/tree/master/nuspec/chocolatey</packageSourceUrl>
-    <iconUrl>https://cdn.rawgit.com/SonarSource/sonar-scanner-msbuild/cdd1f588/icon.png</iconUrl>
     <licenseUrl>https://github.com/SonarSource/sonar-scanner-msbuild/blob/master/LICENSE.txt</licenseUrl>
     <docsUrl>https://redirect.sonarsource.com/doc/install-configure-scanner-msbuild.html</docsUrl>
     <mailingListUrl>https://community.sonarsource.com/</mailingListUrl>
     <bugTrackerUrl>https://github.com/SonarSource/sonar-scanner-msbuild/issues</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <summary>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</summary>
-    <description>The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</description>
+    <summary>[Deprecated] The SonarScanner for MSBuild allows easy analysis of any .NET project with SonarCloud/SonarQube.</summary>
+    <description>**Deprecated**: .NET Core 3.0 is not supported anymore. There is now a single package `sonarscanner-net`, for *.NET Core 3.1* and *.NET 5.0* and above.</description>
     <tags>sonarqube sonarcloud msbuild scanner sonarsource sonar sonar-scanner sonarscanner</tags>
     <copyright>SonarSource SA and Microsoft Corporation</copyright>
     <releaseNotes>
 All release notes for SonarScanner MSBuild .Net Core can be found on the GitHub site - https://github.com/SonarSource/sonar-scanner-msbuild/releases
     </releaseNotes>
+    <dependencies>
+      <dependency id="sonarscanner-net" />
+    </dependencies>     
   </metadata>
-  <files>
-    <file src="chocolateyInstall-netcoreapp3.0.ps1" target="tools\chocolateyInstall.ps1" />
-  </files>
+  <files />
 </package>

--- a/nuspec/netcoreglobaltool/dotnet-sonarscanner.nuspec
+++ b/nuspec/netcoreglobaltool/dotnet-sonarscanner.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>dotnet-sonarscanner</id>
-    <version>5.15.0</version>
+    <version>5.16.0</version>
     <title>SonarScanner for .Net Core</title>
     <authors>SonarSource,Microsoft</authors>
     <projectUrl>http://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>

--- a/scripts/version/Version.props
+++ b/scripts/version/Version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MainVersion>5.15.0</MainVersion>
+    <MainVersion>5.16.0</MainVersion>
     <BuildNumber>0</BuildNumber>
     <Sha1>not-set</Sha1>
     <BranchName>not-set</BranchName>


### PR DESCRIPTION
Issue: https://github.com/SonarSource/sonar-scanner-msbuild/issues/1817

This PR is used to create choco packages for 5.16.0, that should deprecate old .NET-version-specific choco packages, and redirect to the new ones. The PR should stay in draft and never merged to `master`.

This PR will have to be closed once the issue is solved and moved to Done.