### PR TITLE
Add NuGet authentication

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -4,6 +4,12 @@
     <clear />
     <add key="Repox Artifactory (proxy)" value="https://repox.jfrog.io/artifactory/api/nuget/nuget" />
   </packageSources>
+  <packageSourceCredentials>
+    <Repox_x0020_Artifactory_x0020__x0028_proxy_x0029_>
+      <add key="Username" value="%ARTIFACTORY_NUGET_USERNAME%" />
+      <add key="ClearTextPassword" value="%ARTIFACTORY_NUGET_PASSWORD%" />
+    </Repox_x0020_Artifactory_x0020__x0028_proxy_x0029_>
+  </packageSourceCredentials>
   <config>
     <add key="signatureValidationMode" value="require" />
   </config>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,6 +165,9 @@ stages:
 
             - task: DotNetCoreCLI@2
               displayName: Dotnet restore $(tfsProcessorSolution)
+              env:
+                ARTIFACTORY_NUGET_USERNAME: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
+                ARTIFACTORY_NUGET_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
               inputs:
                 command: 'restore'
                 projects: '$(tfsProcessorSolution)'
@@ -192,6 +195,9 @@ stages:
 
             - task: DotNetCoreCLI@2
               displayName: Dotnet restore $(solution)
+              env:
+                ARTIFACTORY_NUGET_USERNAME: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
+                ARTIFACTORY_NUGET_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
               inputs:
                 command: 'restore'
                 projects: '$(solution)'
@@ -201,6 +207,9 @@ stages:
 
             - task: DotNetCoreCLI@2
               displayName: Install CycloneDX
+              env:
+                ARTIFACTORY_NUGET_USERNAME: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
+                ARTIFACTORY_NUGET_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
               inputs:
                 command: custom
                 custom: tool
@@ -257,6 +266,9 @@ stages:
                 Run-Tests-With-Coverage Tests\SonarScanner.MSBuild.Test\SonarScanner.MSBuild.Test.csproj
                 Run-Tests-With-Coverage Tests\SonarScanner.MSBuild.Tasks.UnitTest\SonarScanner.MSBuild.Tasks.UnitTest.csproj # This one needs to be last to convert the coverage results, see Tests/Directory.Build.targets
               displayName: 'Run tests and compute coverage'
+              env:
+                ARTIFACTORY_NUGET_USERNAME: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
+                ARTIFACTORY_NUGET_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
 
             - task: PublishBuildArtifacts@1
               inputs:


### PR DESCRIPTION
Fixes #1795

This has been tested against a NuGet repository that requires authentication. (see 
BUILD-4368)
Until https://repox.jfrog.io/artifactory/api/nuget/nuget enforces authentication, it will work without authentication, issues may raise once authentication is enforced on this repository.