### PR TITLE
Fix build: ensure that secrets are available during NuGet restore

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,13 +2,13 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Repox Artifactory (proxy)" value="https://repox.jfrog.io/artifactory/api/nuget/nuget" />
+    <add key="Repox" value="https://repox.jfrog.io/artifactory/api/nuget/v3/nuget/index.json" protocolVersion="3" />
   </packageSources>
   <packageSourceCredentials>
-    <Repox_x0020_Artifactory_x0020__x0028_proxy_x0029_>
+    <Repox>
       <add key="Username" value="%ARTIFACTORY_NUGET_USERNAME%" />
       <add key="ClearTextPassword" value="%ARTIFACTORY_NUGET_PASSWORD%" />
-    </Repox_x0020_Artifactory_x0020__x0028_proxy_x0029_>
+    </Repox>
   </packageSourceCredentials>
   <config>
     <add key="signatureValidationMode" value="require" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -529,8 +529,6 @@ stages:
             WINDOWSSDKTARGET: '10.0.17763.0'
             MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
             MAVEN_OPTS: '-Xmx3072m -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-            ARTIFACTORY_NUGET_USERNAME: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
-            ARTIFACTORY_NUGET_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
           pool: .net-bubble-aws-re-team-prod
           steps:
             - checkout: self
@@ -575,6 +573,8 @@ stages:
             - task: Maven@3
               displayName: 'Run Maven ITs for $(PRODUCT) $(SQ_VERSION)'
               env:
+                ARTIFACTORY_NUGET_USERNAME: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
+                ARTIFACTORY_NUGET_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
                 ARTIFACTORY_QA_READER_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
                 # For Orchestrator (https://github.com/SonarSource/orchestrator/commit/d5396c75ab77e6088afe58e61b0cd0693ac885f0)
                 ARTIFACTORY_ACCESS_TOKEN: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)

--- a/its/projects/ReproAzureFunctions/NuGet.Config
+++ b/its/projects/ReproAzureFunctions/NuGet.Config
@@ -2,8 +2,14 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Repox Artifactory (proxy)" value="https://repox.jfrog.io/artifactory/api/nuget/nuget" />
-= </packageSources>
+    <add key="Repox" value="https://repox.jfrog.io/artifactory/api/nuget/v3/nuget/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceCredentials>
+    <Repox>
+      <add key="Username" value="%ARTIFACTORY_NUGET_USERNAME%" />
+      <add key="ClearTextPassword" value="%ARTIFACTORY_NUGET_PASSWORD%" />
+    </Repox>
+  </packageSourceCredentials>
   <config>
     <add key="signatureValidationMode" value="require" />
   </config>

--- a/its/projects/VueWithAspBackend/NuGet.Config
+++ b/its/projects/VueWithAspBackend/NuGet.Config
@@ -2,8 +2,14 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Repox Artifactory (proxy)" value="https://repox.jfrog.io/artifactory/api/nuget/nuget" />
-= </packageSources>
+    <add key="Repox" value="https://repox.jfrog.io/artifactory/api/nuget/v3/nuget/index.json" protocolVersion="3" />
+  </packageSources>
+  <packageSourceCredentials>
+    <Repox>
+      <add key="Username" value="%ARTIFACTORY_NUGET_USERNAME%" />
+      <add key="ClearTextPassword" value="%ARTIFACTORY_NUGET_PASSWORD%" />
+    </Repox>
+  </packageSourceCredentials>
   <config>
     <add key="signatureValidationMode" value="require" />
   </config>


### PR DESCRIPTION
Identified problems:
- the nuget url was not correct, the recommended one is: https://repox.jfrog.io/artifactory/api/nuget/v3/nuget/index.json
- the protocol was not specified
- there are NuGet.config files dedicated to some ITs and those files were not updated to include the authentication section
- the nuget authentication credentials were not provided for the ITs