### PR TITLE
Add fingerprint for our certificate

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -31,6 +31,9 @@
       <!-- protobuf-packages = Google.Protobuf -->
       <owners>Microsoft;sharwell;meirb;kzu;dotnetfoundation;castleproject;jonorossi;onovotny;fluentassertions;jamesnk;CycloneDX;grpc-packages;protobuf-packages</owners>
     </repository>
+    <author name="SonarSource">
+      <certificate fingerprint="FC4D3F3F815C1B56A656F1A5D9456AF04B469267D945786057175049B15A62A0" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+    </author>
     <author name="James Newton-King">
       <certificate fingerprint="A3AF7AF11EBB8EF729D2D91548509717E7E0FF55A129ABC3AEAA8A6940267641" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
         <!-- jamesnk = James Newton-King, author of Newtonsoft.Json-->


### PR DESCRIPTION
It was previously set directly on the machine, but it's too hard to change since we have to wait for the image to be built and deployed.

PR to remove it: https://github.com/SonarSource/re-ci-images/pull/447 
