### PR TITLE
Fix analysis on MacOSX with .NET 8 when begin runtime doesn't match with build runtime

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
@@ -31,12 +31,7 @@ public class EnvironmentBasedPlatformHelperTests
     [TestMethod]
     public void GetFolderPath_WithUserProfile()
     {
-        var userProfile = Instance.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.None);
-        userProfile.Should().NotBeNull();
-        if (Instance.IsWindows())
-        {
-            userProfile.Should().Contain("");
-        }
+        Instance.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.None).Should().NotBeNull();
     }
 
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
@@ -31,7 +31,8 @@ public class EnvironmentBasedPlatformHelperTests
     [TestMethod]
     public void GetFolderPath_WithUserProfile()
     {
-        Instance.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.None).Should().NotBeNull();
+        Instance.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.None)
+            .Should().Be(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.None));
     }
 
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
@@ -31,7 +31,12 @@ public class EnvironmentBasedPlatformHelperTests
     [TestMethod]
     public void GetFolderPath_WithUserProfile()
     {
-        Instance.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.None).Should().NotBeNull();
+        var userProfile = Instance.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.None);
+        userProfile.Should().NotBeNull();
+        if (Instance.IsWindows())
+        {
+            userProfile.Should().Contain("");
+        }
     }
 
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
@@ -44,6 +44,6 @@ public class EnvironmentBasedPlatformHelperTests
     [TestMethod]
     public void IsWindowsAndMacOSX_AreMutuallyExclusive()
     {
-        (Instance.IsWindows() && Instance.IsMacOSX()).Should().BeFalse();
+        (Instance.IsWindows() && Instance.IsMacOs()).Should().BeFalse();
     }
 }

--- a/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static SonarScanner.MSBuild.Common.EnvironmentBasedPlatformHelper;
+
+namespace SonarScanner.MSBuild.Common.Test;
+
+[TestClass]
+public class EnvironmentBasedPlatformHelperTests
+{
+    [TestMethod]
+    public void GetFolderPath_WithUserProfile()
+    {
+        Instance.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.None).Should().NotBeNull();
+    }
+
+    [TestMethod]
+    public void DirectoryExists_WithCurrentDirectory()
+    {
+        Instance.DirectoryExists(Environment.CurrentDirectory).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void IsWindowsAndMacOSX_AreMutuallyExclusive()
+    {
+        (Instance.IsWindows() && Instance.IsMacOSX()).Should().BeFalse();
+    }
+}

--- a/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/EnvironmentBasedPlatformHelperTests.cs
@@ -40,10 +40,4 @@ public class EnvironmentBasedPlatformHelperTests
     {
         Instance.DirectoryExists(Environment.CurrentDirectory).Should().BeTrue();
     }
-
-    [TestMethod]
-    public void IsWindowsAndMacOSX_AreMutuallyExclusive()
-    {
-        (Instance.IsWindows() && Instance.IsMacOs()).Should().BeFalse();
-    }
 }

--- a/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
@@ -36,10 +36,10 @@ namespace SonarScanner.MSBuild.Common.Test
         {
             Action action;
 
-            action = new Action(() => MsBuildPathSettings(string.Empty, OS.Linux, DirectoryAlwaysExists).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(string.Empty, IPlatformHelper.OS.Unix, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
 
-            action = new Action(() => MsBuildPathSettings(path: null, OS.Linux, DirectoryAlwaysExists).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(path: null, IPlatformHelper.OS.Unix, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
         }
 
@@ -52,7 +52,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.UserProfile, "c:\\user profile"),
             };
 
-            var result = MsBuildPathSettings(paths, OS.Linux, DirectoryAlwaysExists).GetImportBeforePaths();
+            var result = MsBuildPathSettings(paths, IPlatformHelper.OS.Unix, DirectoryAlwaysExists).GetImportBeforePaths();
 
             result.Should().BeEquivalentTo(
                 Path.Combine("c:\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
@@ -75,7 +75,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.UserProfile, string.Empty),
             };
 
-            var action = new Action(() => MsBuildPathSettings(paths, OS.Linux, DirectoryAlwaysExists).GetImportBeforePaths());
+            var action = new Action(() => MsBuildPathSettings(paths, IPlatformHelper.OS.Unix, DirectoryAlwaysExists).GetImportBeforePaths());
 
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find user profile directory.");
         }
@@ -85,10 +85,10 @@ namespace SonarScanner.MSBuild.Common.Test
         {
             Action action;
 
-            action = new Action(() => MsBuildPathSettings(string.Empty, OS.Windows, DirectoryAlwaysExists).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(string.Empty, IPlatformHelper.OS.Windows, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
 
-            action = new Action(() => MsBuildPathSettings(path: null, OS.Windows, DirectoryAlwaysExists).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(path: null, IPlatformHelper.OS.Windows, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
         }
 
@@ -102,7 +102,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.SystemX86, "c:\\windows\\systemWOW64"),
             };
 
-            var settings = MsBuildPathSettings(paths, OS.Windows, DirectoryAlwaysExists);
+            var settings = MsBuildPathSettings(paths, IPlatformHelper.OS.Windows, DirectoryAlwaysExists);
 
             var result = settings.GetImportBeforePaths();
 
@@ -126,7 +126,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.SystemX86, "c:\\windows\\sysWOW64"),
             };
 
-            var settings = MsBuildPathSettings(paths, OS.Windows, DirectoryAlwaysExists);
+            var settings = MsBuildPathSettings(paths, IPlatformHelper.OS.Windows, DirectoryAlwaysExists);
 
             var result = settings.GetImportBeforePaths();
 
@@ -164,7 +164,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.SystemX86, "c:\\windows\\sysWOW64"),
             };
 
-            var settings = MsBuildPathSettings(paths, OS.Windows, path => !path.Contains("WOW64")); // paths with wow64 do not exist, others exist
+            var settings = MsBuildPathSettings(paths, IPlatformHelper.OS.Windows, path => !path.Contains("WOW64")); // paths with wow64 do not exist, others exist
 
             var result = settings.GetImportBeforePaths();
 
@@ -195,7 +195,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.SystemX86, "c:\\windows\\sysWOW64"),
             };
 
-            var settings = MsBuildPathSettings(paths, OS.Windows, path => !path.Contains("Sysnative")); // paths with Sysnative do not exist, others exist
+            var settings = MsBuildPathSettings(paths, IPlatformHelper.OS.Windows, path => !path.Contains("Sysnative")); // paths with Sysnative do not exist, others exist
 
             var result = settings.GetImportBeforePaths();
 
@@ -228,7 +228,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.UserProfile, "/Users/runner"),
             };
 
-            var result = MsBuildPathSettings(paths, OS.MacOSX, DirectoryAlwaysExists).GetImportBeforePaths();
+            var result = MsBuildPathSettings(paths, IPlatformHelper.OS.MacOSX, DirectoryAlwaysExists).GetImportBeforePaths();
 
             result.Should().Contain(new[]
             {
@@ -241,8 +241,8 @@ namespace SonarScanner.MSBuild.Common.Test
         public void GetGlobalTargetsPaths_WhenProgramFilesIsEmptyOrNull_Returns_Empty()
         {
             // Arrange
-            var testSubject1 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? null : "foo", OS.Windows, DirectoryAlwaysExists));
-            var testSubject2 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? string.Empty : "foo", OS.Windows, DirectoryAlwaysExists));
+            var testSubject1 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? null : "foo", IPlatformHelper.OS.Windows, DirectoryAlwaysExists));
+            var testSubject2 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? string.Empty : "foo", IPlatformHelper.OS.Windows, DirectoryAlwaysExists));
 
             // Act
             testSubject1.GetGlobalTargetsPaths().Should().BeEmpty();
@@ -258,7 +258,7 @@ namespace SonarScanner.MSBuild.Common.Test
             };
 
             // Arrange
-            var settings = MsBuildPathSettings(paths, OS.Windows, DirectoryAlwaysExists);
+            var settings = MsBuildPathSettings(paths, IPlatformHelper.OS.Windows, DirectoryAlwaysExists);
 
             // Act
             var result = settings.GetGlobalTargetsPaths().ToList();
@@ -271,7 +271,7 @@ namespace SonarScanner.MSBuild.Common.Test
 
         private MsBuildPathSettings MsBuildPathSettings(
             (Environment.SpecialFolder, string)[] paths,
-            OS os,
+            IPlatformHelper.OS os,
             Func<string, bool> directoryExistsFunc) =>
             new(new PlatformHelper((folder, option) =>
                 {
@@ -283,26 +283,18 @@ namespace SonarScanner.MSBuild.Common.Test
 
         private MsBuildPathSettings MsBuildPathSettings(
             string path,
-            OS os,
+            IPlatformHelper.OS os,
             Func<string, bool> directoryExistsFunc) =>
             new(new PlatformHelper((_, _) => path, os, directoryExistsFunc));
 
         private sealed class PlatformHelper(
             Func<Environment.SpecialFolder, Environment.SpecialFolderOption, string> pathFunc,
-            OS os,
+            IPlatformHelper.OS os,
             Func<string, bool> directoryExistsFunc) : IPlatformHelper
         {
+            public IPlatformHelper.OS OperatingSystem => os;
             public bool DirectoryExists(string path) => directoryExistsFunc(path);
             public string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option) => pathFunc(folder, option);
-            public bool IsMacOs() => os == OS.MacOSX;
-            public bool IsWindows() => os == OS.Windows;
-        }
-
-        private enum OS
-        {
-            Windows,
-            Linux,
-            MacOSX,
         }
     }
 }

--- a/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
@@ -36,10 +36,10 @@ namespace SonarScanner.MSBuild.Common.Test
         {
             Action action;
 
-            action = new Action(() => MsBuildPathSettings(string.Empty, IPlatformHelper.OS.Unix, DirectoryAlwaysExists).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(string.Empty, PlatformOS.Unix, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
 
-            action = new Action(() => MsBuildPathSettings(path: null, IPlatformHelper.OS.Unix, DirectoryAlwaysExists).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(path: null, PlatformOS.Unix, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
         }
 
@@ -52,7 +52,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.UserProfile, "c:\\user profile"),
             };
 
-            var result = MsBuildPathSettings(paths, IPlatformHelper.OS.Unix, DirectoryAlwaysExists).GetImportBeforePaths();
+            var result = MsBuildPathSettings(paths, PlatformOS.Unix, DirectoryAlwaysExists).GetImportBeforePaths();
 
             result.Should().BeEquivalentTo(
                 Path.Combine("c:\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
@@ -75,7 +75,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.UserProfile, string.Empty),
             };
 
-            var action = new Action(() => MsBuildPathSettings(paths, IPlatformHelper.OS.Unix, DirectoryAlwaysExists).GetImportBeforePaths());
+            var action = new Action(() => MsBuildPathSettings(paths, PlatformOS.Unix, DirectoryAlwaysExists).GetImportBeforePaths());
 
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find user profile directory.");
         }
@@ -85,10 +85,10 @@ namespace SonarScanner.MSBuild.Common.Test
         {
             Action action;
 
-            action = new Action(() => MsBuildPathSettings(string.Empty, IPlatformHelper.OS.Windows, DirectoryAlwaysExists).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(string.Empty, PlatformOS.Windows, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
 
-            action = new Action(() => MsBuildPathSettings(path: null, IPlatformHelper.OS.Windows, DirectoryAlwaysExists).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(path: null, PlatformOS.Windows, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
         }
 
@@ -102,7 +102,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.SystemX86, "c:\\windows\\systemWOW64"),
             };
 
-            var settings = MsBuildPathSettings(paths, IPlatformHelper.OS.Windows, DirectoryAlwaysExists);
+            var settings = MsBuildPathSettings(paths, PlatformOS.Windows, DirectoryAlwaysExists);
 
             var result = settings.GetImportBeforePaths();
 
@@ -126,7 +126,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.SystemX86, "c:\\windows\\sysWOW64"),
             };
 
-            var settings = MsBuildPathSettings(paths, IPlatformHelper.OS.Windows, DirectoryAlwaysExists);
+            var settings = MsBuildPathSettings(paths, PlatformOS.Windows, DirectoryAlwaysExists);
 
             var result = settings.GetImportBeforePaths();
 
@@ -164,7 +164,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.SystemX86, "c:\\windows\\sysWOW64"),
             };
 
-            var settings = MsBuildPathSettings(paths, IPlatformHelper.OS.Windows, path => !path.Contains("WOW64")); // paths with wow64 do not exist, others exist
+            var settings = MsBuildPathSettings(paths, PlatformOS.Windows, path => !path.Contains("WOW64")); // paths with wow64 do not exist, others exist
 
             var result = settings.GetImportBeforePaths();
 
@@ -195,7 +195,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.SystemX86, "c:\\windows\\sysWOW64"),
             };
 
-            var settings = MsBuildPathSettings(paths, IPlatformHelper.OS.Windows, path => !path.Contains("Sysnative")); // paths with Sysnative do not exist, others exist
+            var settings = MsBuildPathSettings(paths, PlatformOS.Windows, path => !path.Contains("Sysnative")); // paths with Sysnative do not exist, others exist
 
             var result = settings.GetImportBeforePaths();
 
@@ -228,7 +228,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.UserProfile, "/Users/runner"),
             };
 
-            var result = MsBuildPathSettings(paths, IPlatformHelper.OS.MacOSX, DirectoryAlwaysExists).GetImportBeforePaths();
+            var result = MsBuildPathSettings(paths, PlatformOS.MacOSX, DirectoryAlwaysExists).GetImportBeforePaths();
 
             result.Should().Contain(new[]
             {
@@ -241,8 +241,8 @@ namespace SonarScanner.MSBuild.Common.Test
         public void GetGlobalTargetsPaths_WhenProgramFilesIsEmptyOrNull_Returns_Empty()
         {
             // Arrange
-            var testSubject1 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? null : "foo", IPlatformHelper.OS.Windows, DirectoryAlwaysExists));
-            var testSubject2 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? string.Empty : "foo", IPlatformHelper.OS.Windows, DirectoryAlwaysExists));
+            var testSubject1 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? null : "foo", PlatformOS.Windows, DirectoryAlwaysExists));
+            var testSubject2 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? string.Empty : "foo", PlatformOS.Windows, DirectoryAlwaysExists));
 
             // Act
             testSubject1.GetGlobalTargetsPaths().Should().BeEmpty();
@@ -258,7 +258,7 @@ namespace SonarScanner.MSBuild.Common.Test
             };
 
             // Arrange
-            var settings = MsBuildPathSettings(paths, IPlatformHelper.OS.Windows, DirectoryAlwaysExists);
+            var settings = MsBuildPathSettings(paths, PlatformOS.Windows, DirectoryAlwaysExists);
 
             // Act
             var result = settings.GetGlobalTargetsPaths().ToList();
@@ -271,7 +271,7 @@ namespace SonarScanner.MSBuild.Common.Test
 
         private MsBuildPathSettings MsBuildPathSettings(
             (Environment.SpecialFolder, string)[] paths,
-            IPlatformHelper.OS os,
+            PlatformOS os,
             Func<string, bool> directoryExistsFunc) =>
             new(new PlatformHelper((folder, option) =>
                 {
@@ -283,16 +283,16 @@ namespace SonarScanner.MSBuild.Common.Test
 
         private MsBuildPathSettings MsBuildPathSettings(
             string path,
-            IPlatformHelper.OS os,
+            PlatformOS os,
             Func<string, bool> directoryExistsFunc) =>
             new(new PlatformHelper((_, _) => path, os, directoryExistsFunc));
 
         private sealed class PlatformHelper(
             Func<Environment.SpecialFolder, Environment.SpecialFolderOption, string> pathFunc,
-            IPlatformHelper.OS os,
+            PlatformOS os,
             Func<string, bool> directoryExistsFunc) : IPlatformHelper
         {
-            public IPlatformHelper.OS OperatingSystem => os;
+            public PlatformOS OperatingSystem => os;
             public bool DirectoryExists(string path) => directoryExistsFunc(path);
             public string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option) => pathFunc(folder, option);
         }

--- a/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
@@ -29,15 +29,17 @@ namespace SonarScanner.MSBuild.Common.Test
     [TestClass]
     public class MsBuildPathSettingsTests
     {
+        private static readonly Func<string, bool> DirectoryAlwaysExists = _ => true;
+
         [TestMethod]
         public void GetImportBeforePaths_NonWindows_AppData_Is_NullOrEmpty()
         {
             Action action;
 
-            action = new Action(() => MsBuildPathSettings(string.Empty, OS.Linux, _ => true).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(string.Empty, OS.Linux, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
 
-            action = new Action(() => MsBuildPathSettings(null as string, OS.Linux, _ => true).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(path: null, OS.Linux, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
         }
 
@@ -50,7 +52,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.UserProfile, "c:\\user profile"),
             };
 
-            var result = MsBuildPathSettings(paths, OS.Linux, _ => true).GetImportBeforePaths();
+            var result = MsBuildPathSettings(paths, OS.Linux, DirectoryAlwaysExists).GetImportBeforePaths();
 
             result.Should().HaveCount(9);
             result.Should().Contain(
@@ -77,7 +79,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.UserProfile, string.Empty),
             };
 
-            var action = new Action(() => MsBuildPathSettings(paths, OS.Linux, _ => true).GetImportBeforePaths());
+            var action = new Action(() => MsBuildPathSettings(paths, OS.Linux, DirectoryAlwaysExists).GetImportBeforePaths());
 
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find user profile directory.");
         }
@@ -87,10 +89,10 @@ namespace SonarScanner.MSBuild.Common.Test
         {
             Action action;
 
-            action = new Action(() => MsBuildPathSettings(string.Empty, OS.Windows, _ => true).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(string.Empty, OS.Windows, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
 
-            action = new Action(() => MsBuildPathSettings(null as string, OS.Windows, _ => true).GetImportBeforePaths());
+            action = new Action(() => MsBuildPathSettings(path: null, OS.Windows, DirectoryAlwaysExists).GetImportBeforePaths());
             action.Should().ThrowExactly<IOException>().WithMessage("Cannot find local application data directory.");
         }
 
@@ -104,7 +106,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.SystemX86, "c:\\windows\\systemWOW64"),
             };
 
-            var settings = MsBuildPathSettings(paths, OS.Windows, _ => true);
+            var settings = MsBuildPathSettings(paths, OS.Windows, DirectoryAlwaysExists);
 
             var result = settings.GetImportBeforePaths();
 
@@ -132,7 +134,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.SystemX86, "c:\\windows\\sysWOW64"),
             };
 
-            var settings = MsBuildPathSettings(paths, OS.Windows, _ => true);
+            var settings = MsBuildPathSettings(paths, OS.Windows, DirectoryAlwaysExists);
 
             var result = settings.GetImportBeforePaths();
 
@@ -250,7 +252,7 @@ namespace SonarScanner.MSBuild.Common.Test
                 (Environment.SpecialFolder.UserProfile, "/Users/runner"),
             };
 
-            var result = MsBuildPathSettings(paths, OS.MacOSX, _ => true).GetImportBeforePaths();
+            var result = MsBuildPathSettings(paths, OS.MacOSX, DirectoryAlwaysExists).GetImportBeforePaths();
 
             result.Should().Contain(path => path.Contains(Path.Combine("local", "share")));
             result.Should().Contain(path => path.Contains(Path.Combine("Library", "Application Support")));
@@ -260,8 +262,8 @@ namespace SonarScanner.MSBuild.Common.Test
         public void GetGlobalTargetsPaths_WhenProgramFilesIsEmptyOrNull_Returns_Empty()
         {
             // Arrange
-            var testSubject1 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? null : "foo", OS.Windows, _ => true));
-            var testSubject2 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? string.Empty : "foo", OS.Windows, _ => true));
+            var testSubject1 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? null : "foo", OS.Windows, DirectoryAlwaysExists));
+            var testSubject2 = new MsBuildPathSettings(new PlatformHelper((x, y) => x == Environment.SpecialFolder.ProgramFiles ? string.Empty : "foo", OS.Windows, DirectoryAlwaysExists));
 
             // Act
             testSubject1.GetGlobalTargetsPaths().Should().BeEmpty();
@@ -277,7 +279,7 @@ namespace SonarScanner.MSBuild.Common.Test
             };
 
             // Arrange
-            var settings = MsBuildPathSettings(paths, OS.Windows, _ => true);
+            var settings = MsBuildPathSettings(paths, OS.Windows, DirectoryAlwaysExists);
 
             // Act
             var result = settings.GetGlobalTargetsPaths().ToList();

--- a/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
@@ -316,7 +316,7 @@ namespace SonarScanner.MSBuild.Common.Test
         {
             public bool DirectoryExists(string path) => directoryExistsFunc(path);
             public string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option) => pathFunc(folder, option);
-            public bool IsMacOSX() => os == OS.MacOSX;
+            public bool IsMacOs() => os == OS.MacOSX;
             public bool IsWindows() => os == OS.Windows;
         }
 

--- a/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
@@ -54,20 +54,16 @@ namespace SonarScanner.MSBuild.Common.Test
 
             var result = MsBuildPathSettings(paths, OS.Linux, DirectoryAlwaysExists).GetImportBeforePaths();
 
-            result.Should().HaveCount(9);
-            result.Should().Contain(
-                new[]
-                {
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\user profile", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\user profile", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore")
-                });
+            result.Should().BeEquivalentTo(
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\user profile", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\user profile", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"));
         }
 
         [TestMethod]
@@ -110,18 +106,14 @@ namespace SonarScanner.MSBuild.Common.Test
 
             var result = settings.GetImportBeforePaths();
 
-            result.Should().HaveCount(7);
-            result.Should().Contain(
-                new[]
-                {
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore")
-                });
+            result.Should().BeEquivalentTo(
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"));
         }
 
         [TestMethod]
@@ -138,34 +130,28 @@ namespace SonarScanner.MSBuild.Common.Test
 
             var result = settings.GetImportBeforePaths();
 
-            result.Should().HaveCount(21);
-            result.Should().Contain(
-                new[]
-                {
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"),
-
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"),
-
-                    Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore")
-                });
+            result.Should().BeEquivalentTo(
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"));
         }
 
         [TestMethod]
@@ -182,10 +168,7 @@ namespace SonarScanner.MSBuild.Common.Test
 
             var result = settings.GetImportBeforePaths();
 
-            result.Should().HaveCount(14);
-            result.Should().Contain(
-                new[]
-                {
+            result.Should().BeEquivalentTo(
                     Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
                     Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
                     Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
@@ -193,15 +176,13 @@ namespace SonarScanner.MSBuild.Common.Test
                     Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
                     Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
                     Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"),
-
                     Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
                     Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
                     Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
                     Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
                     Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
                     Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore")
-                });
+                    Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"));
         }
 
         [TestMethod]
@@ -218,31 +199,26 @@ namespace SonarScanner.MSBuild.Common.Test
 
             var result = settings.GetImportBeforePaths();
 
-            result.Should().HaveCount(14);
-            result.Should().Contain(
-                new[]
-                {
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"),
-
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
-                    Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore")
-                });
+            result.Should().BeEquivalentTo(
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\system32\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "4.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "10.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "11.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "12.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "14.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "15.0", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("c:\\windows\\sysWOW64\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"));
         }
 
         [DataTestMethod]
         [DataRow("/Users/runner/.local/share", DisplayName = "NET 7.0 and earlier")]
-        [DataRow("/Users/runner/Library/ApplicationSupport", DisplayName = "NET 8.0")]
+        [DataRow("/Users/runner/Library/Application Support", DisplayName = "NET 8.0")]
         [DataRow("/Users/runner/Something/Different", DisplayName = "Future value")]
         public void GetImportBeforePaths_MacOSX_ReturnsBothOldAndNewLocations(string localApplicationData)
         {
@@ -254,8 +230,11 @@ namespace SonarScanner.MSBuild.Common.Test
 
             var result = MsBuildPathSettings(paths, OS.MacOSX, DirectoryAlwaysExists).GetImportBeforePaths();
 
-            result.Should().Contain(path => path.Contains(Path.Combine("local", "share")));
-            result.Should().Contain(path => path.Contains(Path.Combine("Library", "Application Support")));
+            result.Should().Contain(new[]
+            {
+                Path.Combine("/Users/runner", ".local", "share", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"),
+                Path.Combine("/Users/runner", "Library", "Application Support", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore")
+            });
         }
 
         [TestMethod]
@@ -285,8 +264,7 @@ namespace SonarScanner.MSBuild.Common.Test
             var result = settings.GetGlobalTargetsPaths().ToList();
 
             // Assert
-            result.Should().HaveCount(2);
-            result.Should().ContainInOrder(
+            result.Should().BeEquivalentTo(
                 "C:\\Program\\MSBuild\\14.0\\Microsoft.Common.Targets\\ImportBefore",
                 "C:\\Program\\MSBuild\\15.0\\Microsoft.Common.Targets\\ImportBefore");
         }

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
@@ -294,7 +294,7 @@ namespace SonarScanner.MSBuild.Shim.Test
         {
             public string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option) => throw new NotImplementedException();
             public bool DirectoryExists(string path) => throw new NotImplementedException();
-            public bool IsMacOSX() => false;
+            public bool IsMacOs() => false;
             public bool IsWindows() => false;
         }
 

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
@@ -290,9 +290,9 @@ namespace SonarScanner.MSBuild.Shim.Test
             Path.GetExtension(scannerCliScriptPath).Should().BeNullOrEmpty();
         }
 
-        private class UnixTestPlatformHelper : IPlatformHelper
+        private sealed class UnixTestPlatformHelper : IPlatformHelper
         {
-            public IPlatformHelper.OS OperatingSystem => IPlatformHelper.OS.Unix;
+            public PlatformOS OperatingSystem => PlatformOS.Unix;
 
             public string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option) => throw new NotImplementedException();
             public bool DirectoryExists(string path) => throw new NotImplementedException();

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
@@ -284,18 +284,18 @@ namespace SonarScanner.MSBuild.Shim.Test
         public void FindScannerExe_WhenNonWindows_ReturnsNoExtension()
         {
             // Act
-            var scannerCliScriptPath = SonarScannerWrapper.FindScannerExe(new LinuxTestPlatformHelper());
+            var scannerCliScriptPath = SonarScannerWrapper.FindScannerExe(new UnixTestPlatformHelper());
 
             // Assert
             Path.GetExtension(scannerCliScriptPath).Should().BeNullOrEmpty();
         }
 
-        private class LinuxTestPlatformHelper : IPlatformHelper
+        private class UnixTestPlatformHelper : IPlatformHelper
         {
+            public IPlatformHelper.OS OperatingSystem => IPlatformHelper.OS.Unix;
+
             public string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option) => throw new NotImplementedException();
             public bool DirectoryExists(string path) => throw new NotImplementedException();
-            public bool IsMacOs() => false;
-            public bool IsWindows() => false;
         }
 
 #endregion Tests

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
@@ -32,8 +32,6 @@ namespace SonarScanner.MSBuild.Shim.Test
     [TestClass]
     public class SonarScannerWrapperTests
     {
-        private const string ExpectedConsoleMessagePrefix = "Args passed to dummy scanner: ";
-
         public TestContext TestContext { get; set; }
 
         #region Tests
@@ -280,6 +278,24 @@ namespace SonarScanner.MSBuild.Shim.Test
 
             // Assert
             scannerCliScriptPath.Should().EndWithEquivalentOf(@"\bin\sonar-scanner.bat");
+        }
+
+        [TestMethod]
+        public void FindScannerExe_WhenNonWindows_ReturnsNoExtension()
+        {
+            // Act
+            var scannerCliScriptPath = SonarScannerWrapper.FindScannerExe(new LinuxTestPlatformHelper());
+
+            // Assert
+            Path.GetExtension(scannerCliScriptPath).Should().BeNullOrEmpty();
+        }
+
+        private class LinuxTestPlatformHelper : IPlatformHelper
+        {
+            public string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option) => throw new NotImplementedException();
+            public bool DirectoryExists(string path) => throw new NotImplementedException();
+            public bool IsMacOSX() => false;
+            public bool IsWindows() => false;
         }
 
 #endregion Tests

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
@@ -375,7 +375,7 @@ namespace SonarScanner.MSBuild.Shim.Test
 
         private static void CheckEnvVarExists(string varName, string expectedValue, MockProcessRunner mockRunner)
         {
-            mockRunner.SuppliedArguments.EnvironmentVariables.ContainsKey(varName).Should().BeTrue();
+            mockRunner.SuppliedArguments.EnvironmentVariables.Should().ContainKey(varName);
             mockRunner.SuppliedArguments.EnvironmentVariables[varName].Should().Be(expectedValue);
         }
     }

--- a/src/SonarScanner.MSBuild.Common/EnvironmentBasedPlatformHelper.cs
+++ b/src/SonarScanner.MSBuild.Common/EnvironmentBasedPlatformHelper.cs
@@ -20,13 +20,18 @@
 
 using System;
 
-namespace SonarScanner.MSBuild.Common
+namespace SonarScanner.MSBuild.Common;
+
+public class EnvironmentBasedPlatformHelper : IPlatformHelper
 {
-    public static class PlatformHelper
+    public static IPlatformHelper Instance { get; } = new EnvironmentBasedPlatformHelper();
+
+    private EnvironmentBasedPlatformHelper()
     {
-        public static bool IsWindows()
-        {
-            return Environment.OSVersion.Platform == PlatformID.Win32NT;
-        }
     }
+
+    public string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option) => Environment.GetFolderPath(folder, option);
+    public bool DirectoryExists(string path) => System.IO.Directory.Exists(path);
+    public bool IsWindows() => Environment.OSVersion.Platform == PlatformID.Win32NT;
+    public bool IsMacOSX() => Environment.OSVersion.Platform == PlatformID.MacOSX;
 }

--- a/src/SonarScanner.MSBuild.Common/EnvironmentBasedPlatformHelper.cs
+++ b/src/SonarScanner.MSBuild.Common/EnvironmentBasedPlatformHelper.cs
@@ -19,11 +19,13 @@
  */
 
 using System;
+using System.IO;
 
 namespace SonarScanner.MSBuild.Common;
 
 public class EnvironmentBasedPlatformHelper : IPlatformHelper
 {
+    private bool? isMacOs;
     public static IPlatformHelper Instance { get; } = new EnvironmentBasedPlatformHelper();
 
     private EnvironmentBasedPlatformHelper()
@@ -31,7 +33,11 @@ public class EnvironmentBasedPlatformHelper : IPlatformHelper
     }
 
     public string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option) => Environment.GetFolderPath(folder, option);
-    public bool DirectoryExists(string path) => System.IO.Directory.Exists(path);
+    public bool DirectoryExists(string path) => Directory.Exists(path);
     public bool IsWindows() => Environment.OSVersion.Platform == PlatformID.Win32NT;
-    public bool IsMacOSX() => Environment.OSVersion.Platform == PlatformID.MacOSX;
+
+    // There's a more elegant way to obtain which operating system the app is running on. Unfortunately it's not suported in .NET Framework 4.6.2, only from 4.7.1
+    // SystemVersion.plist exists on Mac Os (and iOS) for a very long time (at least from 2002), so it's safe to check it, even though it's not a pretty solution.
+    // TODO: once we drop support for .NET Framework 4.6.2 replace this call with System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+    public bool IsMacOs() => isMacOs ??= File.Exists(@"/System/Library/CoreServices/SystemVersion.plist");
 }

--- a/src/SonarScanner.MSBuild.Common/Interfaces/IPlatformHelper.cs
+++ b/src/SonarScanner.MSBuild.Common/Interfaces/IPlatformHelper.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+
+namespace SonarScanner.MSBuild.Common;
+
+public interface IPlatformHelper
+{
+    string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option);
+    bool DirectoryExists(string path);
+    bool IsMacOSX();
+    bool IsWindows();
+}

--- a/src/SonarScanner.MSBuild.Common/Interfaces/IPlatformHelper.cs
+++ b/src/SonarScanner.MSBuild.Common/Interfaces/IPlatformHelper.cs
@@ -24,8 +24,15 @@ namespace SonarScanner.MSBuild.Common;
 
 public interface IPlatformHelper
 {
+    OS OperatingSystem { get; }
     string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option);
     bool DirectoryExists(string path);
-    bool IsMacOs();
-    bool IsWindows();
+
+    public enum OS
+    {
+        Unknown,
+        Windows,
+        Unix,
+        MacOSX,
+    }
 }

--- a/src/SonarScanner.MSBuild.Common/Interfaces/IPlatformHelper.cs
+++ b/src/SonarScanner.MSBuild.Common/Interfaces/IPlatformHelper.cs
@@ -22,17 +22,17 @@ using System;
 
 namespace SonarScanner.MSBuild.Common;
 
+public enum PlatformOS
+{
+    Unknown,
+    Windows,
+    Unix,
+    MacOSX,
+}
+
 public interface IPlatformHelper
 {
-    OS OperatingSystem { get; }
+    PlatformOS OperatingSystem { get; }
     string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option);
     bool DirectoryExists(string path);
-
-    public enum OS
-    {
-        Unknown,
-        Windows,
-        Unix,
-        MacOSX,
-    }
 }

--- a/src/SonarScanner.MSBuild.Common/Interfaces/IPlatformHelper.cs
+++ b/src/SonarScanner.MSBuild.Common/Interfaces/IPlatformHelper.cs
@@ -26,6 +26,6 @@ public interface IPlatformHelper
 {
     string GetFolderPath(Environment.SpecialFolder folder, Environment.SpecialFolderOption option);
     bool DirectoryExists(string path);
-    bool IsMacOSX();
+    bool IsMacOs();
     bool IsWindows();
 }

--- a/src/SonarScanner.MSBuild.Common/MsBuildPathSettings.cs
+++ b/src/SonarScanner.MSBuild.Common/MsBuildPathSettings.cs
@@ -123,7 +123,7 @@ namespace SonarScanner.MSBuild.Common
 
             yield return localAppData;
 
-            if (platformHelper.IsMacOSX())
+            if (platformHelper.IsMacOs())
             {
                 // Target files need to be placed under LocalApplicationData, to be picked up by MSBuild.
                 // Due to the breaking change of GetFolderPath on MacOSX in .NET8, we need to make sure we copy the targets file

--- a/src/SonarScanner.MSBuild.Common/MsBuildPathSettings.cs
+++ b/src/SonarScanner.MSBuild.Common/MsBuildPathSettings.cs
@@ -75,7 +75,7 @@ namespace SonarScanner.MSBuild.Common
 
         private IEnumerable<string> DotnetImportBeforePathsLinuxMac()
         {
-            if (platformHelper.OperatingSystem == IPlatformHelper.OS.Windows)
+            if (platformHelper.OperatingSystem == PlatformOS.Windows)
             {
                 return Enumerable.Empty<string>();
             }
@@ -123,7 +123,7 @@ namespace SonarScanner.MSBuild.Common
 
             yield return localAppData;
 
-            if (platformHelper.OperatingSystem == IPlatformHelper.OS.MacOSX)
+            if (platformHelper.OperatingSystem == PlatformOS.MacOSX)
             {
                 // Target files need to be placed under LocalApplicationData, to be picked up by MSBuild.
                 // Due to the breaking change of GetFolderPath on MacOSX in .NET8, we need to make sure we copy the targets file
@@ -134,7 +134,7 @@ namespace SonarScanner.MSBuild.Common
                 yield return Path.Combine(userProfile, ".local", "share");                // LocalApplicationData on .Net 7 and earlier
                 yield return Path.Combine(userProfile, "Library", "Application Support"); // LocalApplicationData on .Net 8 and later
             }
-            else if (platformHelper.OperatingSystem == IPlatformHelper.OS.Windows)
+            else if (platformHelper.OperatingSystem == PlatformOS.Windows)
             {
                 // The code below is Windows-specific, no need to be executed on non-Windows platforms.
                 // When running under Local System account on a 64bit OS, the local application data folder

--- a/src/SonarScanner.MSBuild.Common/MsBuildPathSettings.cs
+++ b/src/SonarScanner.MSBuild.Common/MsBuildPathSettings.cs
@@ -75,7 +75,7 @@ namespace SonarScanner.MSBuild.Common
 
         private IEnumerable<string> DotnetImportBeforePathsLinuxMac()
         {
-            if (platformHelper.IsWindows())
+            if (platformHelper.OperatingSystem == IPlatformHelper.OS.Windows)
             {
                 return Enumerable.Empty<string>();
             }
@@ -123,7 +123,7 @@ namespace SonarScanner.MSBuild.Common
 
             yield return localAppData;
 
-            if (platformHelper.IsMacOs())
+            if (platformHelper.OperatingSystem == IPlatformHelper.OS.MacOSX)
             {
                 // Target files need to be placed under LocalApplicationData, to be picked up by MSBuild.
                 // Due to the breaking change of GetFolderPath on MacOSX in .NET8, we need to make sure we copy the targets file
@@ -134,7 +134,7 @@ namespace SonarScanner.MSBuild.Common
                 yield return Path.Combine(userProfile, ".local", "share");                // LocalApplicationData on .Net 7 and earlier
                 yield return Path.Combine(userProfile, "Library", "Application Support"); // LocalApplicationData on .Net 8 and later
             }
-            else if (platformHelper.IsWindows())
+            else if (platformHelper.OperatingSystem == IPlatformHelper.OS.Windows)
             {
                 // The code below is Windows-specific, no need to be executed on non-Windows platforms.
                 // When running under Local System account on a 64bit OS, the local application data folder

--- a/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
@@ -97,7 +97,7 @@ namespace SonarScanner.MSBuild.Shim
         {
             platformHelper ??= EnvironmentBasedPlatformHelper.Instance;
             var binFolder = Path.GetDirectoryName(typeof(SonarScannerWrapper).Assembly.Location);
-            var fileExtension = platformHelper.OperatingSystem == IPlatformHelper.OS.Windows ? ".bat" : string.Empty;
+            var fileExtension = platformHelper.OperatingSystem == PlatformOS.Windows ? ".bat" : string.Empty;
             return Path.Combine(binFolder, $"sonar-scanner-{SonarScannerVersion}", "bin", $"sonar-scanner{fileExtension}");
         }
 
@@ -118,7 +118,7 @@ namespace SonarScanner.MSBuild.Shim
             Debug.Assert(!string.IsNullOrWhiteSpace(config.SonarScannerWorkingDirectory), "The working dir should have been set in the analysis config");
             Debug.Assert(Directory.Exists(config.SonarScannerWorkingDirectory), "The working dir should exist");
 
-            var scannerArgs = new ProcessRunnerArguments(exeFileName, EnvironmentBasedPlatformHelper.Instance.OperatingSystem == IPlatformHelper.OS.Windows)
+            var scannerArgs = new ProcessRunnerArguments(exeFileName, EnvironmentBasedPlatformHelper.Instance.OperatingSystem == PlatformOS.Windows)
             {
                 CmdLineArgs = allCmdLineArgs,
                 WorkingDirectory = config.SonarScannerWorkingDirectory,

--- a/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
@@ -93,10 +93,11 @@ namespace SonarScanner.MSBuild.Shim
             return ExecuteJavaRunner(config, userCmdLineArguments, logger, exeFileName, fullPropertiesFilePath, new ProcessRunner(logger));
         }
 
-        internal /* for testing */ static string FindScannerExe()
+        internal /* for testing */ static string FindScannerExe(IPlatformHelper platformHelper = null)
         {
+            platformHelper ??= EnvironmentBasedPlatformHelper.Instance;
             var binFolder = Path.GetDirectoryName(typeof(SonarScannerWrapper).Assembly.Location);
-            var fileExtension = EnvironmentBasedPlatformHelper.Instance.IsWindows() ? ".bat" : string.Empty;
+            var fileExtension = platformHelper.IsWindows() ? ".bat" : string.Empty;
             return Path.Combine(binFolder, $"sonar-scanner-{SonarScannerVersion}", "bin", $"sonar-scanner{fileExtension}");
         }
 

--- a/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
@@ -97,7 +97,7 @@ namespace SonarScanner.MSBuild.Shim
         {
             platformHelper ??= EnvironmentBasedPlatformHelper.Instance;
             var binFolder = Path.GetDirectoryName(typeof(SonarScannerWrapper).Assembly.Location);
-            var fileExtension = platformHelper.IsWindows() ? ".bat" : string.Empty;
+            var fileExtension = platformHelper.OperatingSystem == IPlatformHelper.OS.Windows ? ".bat" : string.Empty;
             return Path.Combine(binFolder, $"sonar-scanner-{SonarScannerVersion}", "bin", $"sonar-scanner{fileExtension}");
         }
 
@@ -118,7 +118,7 @@ namespace SonarScanner.MSBuild.Shim
             Debug.Assert(!string.IsNullOrWhiteSpace(config.SonarScannerWorkingDirectory), "The working dir should have been set in the analysis config");
             Debug.Assert(Directory.Exists(config.SonarScannerWorkingDirectory), "The working dir should exist");
 
-            var scannerArgs = new ProcessRunnerArguments(exeFileName, EnvironmentBasedPlatformHelper.Instance.IsWindows())
+            var scannerArgs = new ProcessRunnerArguments(exeFileName, EnvironmentBasedPlatformHelper.Instance.OperatingSystem == IPlatformHelper.OS.Windows)
             {
                 CmdLineArgs = allCmdLineArgs,
                 WorkingDirectory = config.SonarScannerWorkingDirectory,

--- a/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
@@ -96,7 +96,7 @@ namespace SonarScanner.MSBuild.Shim
         internal /* for testing */ static string FindScannerExe()
         {
             var binFolder = Path.GetDirectoryName(typeof(SonarScannerWrapper).Assembly.Location);
-            var fileExtension = PlatformHelper.IsWindows() ? ".bat" : "";
+            var fileExtension = EnvironmentBasedPlatformHelper.Instance.IsWindows() ? ".bat" : string.Empty;
             return Path.Combine(binFolder, $"sonar-scanner-{SonarScannerVersion}", "bin", $"sonar-scanner{fileExtension}");
         }
 
@@ -110,14 +110,14 @@ namespace SonarScanner.MSBuild.Shim
             var allCmdLineArgs = GetAllCmdLineArgs(propertiesFileName, userCmdLineArguments, config, logger);
 
             var envVarsDictionary = GetAdditionalEnvVariables(logger);
-            Debug.Assert(envVarsDictionary != null);
+            Debug.Assert(envVarsDictionary != null, "Unable to retrieve additional environment variables");
 
             logger.LogInfo(Resources.MSG_SonarScannerCalling);
 
             Debug.Assert(!string.IsNullOrWhiteSpace(config.SonarScannerWorkingDirectory), "The working dir should have been set in the analysis config");
             Debug.Assert(Directory.Exists(config.SonarScannerWorkingDirectory), "The working dir should exist");
 
-            var scannerArgs = new ProcessRunnerArguments(exeFileName, PlatformHelper.IsWindows())
+            var scannerArgs = new ProcessRunnerArguments(exeFileName, EnvironmentBasedPlatformHelper.Instance.IsWindows())
             {
                 CmdLineArgs = allCmdLineArgs,
                 WorkingDirectory = config.SonarScannerWorkingDirectory,

--- a/src/SonarScanner.MSBuild.Shim/TFSProcessor.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/TFSProcessor.Wrapper.cs
@@ -75,7 +75,7 @@ namespace SonarScanner.MSBuild.Shim
             Debug.Assert(!string.IsNullOrWhiteSpace(config.SonarScannerWorkingDirectory), "The working dir should have been set in the analysis config");
             Debug.Assert(Directory.Exists(config.SonarScannerWorkingDirectory), "The working dir should exist");
 
-            var converterArgs = new ProcessRunnerArguments(exeFileName, !PlatformHelper.IsWindows())
+            var converterArgs = new ProcessRunnerArguments(exeFileName, !EnvironmentBasedPlatformHelper.Instance.IsWindows())
             {
                 CmdLineArgs = userCmdLineArguments,
                 WorkingDirectory = config.SonarScannerWorkingDirectory,

--- a/src/SonarScanner.MSBuild.Shim/TFSProcessor.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/TFSProcessor.Wrapper.cs
@@ -75,7 +75,7 @@ namespace SonarScanner.MSBuild.Shim
             Debug.Assert(!string.IsNullOrWhiteSpace(config.SonarScannerWorkingDirectory), "The working dir should have been set in the analysis config");
             Debug.Assert(Directory.Exists(config.SonarScannerWorkingDirectory), "The working dir should exist");
 
-            var converterArgs = new ProcessRunnerArguments(exeFileName, EnvironmentBasedPlatformHelper.Instance.OperatingSystem != IPlatformHelper.OS.Windows)
+            var converterArgs = new ProcessRunnerArguments(exeFileName, EnvironmentBasedPlatformHelper.Instance.OperatingSystem != PlatformOS.Windows)
             {
                 CmdLineArgs = userCmdLineArguments,
                 WorkingDirectory = config.SonarScannerWorkingDirectory,

--- a/src/SonarScanner.MSBuild.Shim/TFSProcessor.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/TFSProcessor.Wrapper.cs
@@ -75,7 +75,7 @@ namespace SonarScanner.MSBuild.Shim
             Debug.Assert(!string.IsNullOrWhiteSpace(config.SonarScannerWorkingDirectory), "The working dir should have been set in the analysis config");
             Debug.Assert(Directory.Exists(config.SonarScannerWorkingDirectory), "The working dir should exist");
 
-            var converterArgs = new ProcessRunnerArguments(exeFileName, !EnvironmentBasedPlatformHelper.Instance.IsWindows())
+            var converterArgs = new ProcessRunnerArguments(exeFileName, EnvironmentBasedPlatformHelper.Instance.OperatingSystem != IPlatformHelper.OS.Windows)
             {
                 CmdLineArgs = userCmdLineArguments,
                 WorkingDirectory = config.SonarScannerWorkingDirectory,


### PR DESCRIPTION
Fixes #1862

The solution implemented is to place the `targets` file in both locations, specifically for MacOSX.
Because `GetFolderPath` may return either the new path or the old one, depending on the runtime, we do the following.
- First, retrieve the path via `GetFolderPath` with `UserProfile`. That will place us in the right user context.
- Then, include the old and the new locations, as relative paths to the user profile directory (hardcoded).
- We also include the `GetFolderPath` with `LocalApplicationData` to be future-proof (i.e. in case the path may change in the future).