### PR TITLE
CI: Use build tools paths instead of visual studio

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -479,51 +479,51 @@ stages:
           displayName: 'Run ITs'
           strategy:
             matrix:
-              vs2017_latest89:
+              msbuild15_latest89:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE[8.9]"
                 SONAR_DOTNET_VERSION: '9.7.0.75501' # sonar-dotnet 9.8 will mention SQ 9.9 as minimum supported version
                 SONAR_CFAMILYPLUGIN_VERSION: "6.20.5.49286"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
                 MSBUILD_PATH: $(MSBUILD_15_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
-              vs2022_latest89:
+              msbuild17_latest89:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE[8.9]"
                 SONAR_DOTNET_VERSION: '9.7.0.75501' # sonar-dotnet 9.8 will mention SQ 9.9 as minimum supported version
                 SONAR_CFAMILYPLUGIN_VERSION: "6.20.5.49286"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
                 MSBUILD_PATH: $(MSBUILD_17_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
-              vs2017_latest99:
+              msbuild15_latest99:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE[9.9]"
                 SONAR_CFAMILYPLUGIN_VERSION: "6.41.0.60884"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
                 MSBUILD_PATH: $(MSBUILD_15_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
-              vs2019_latest99:
+              msbuild16_latest99:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE[9.9]"
                 SONAR_CFAMILYPLUGIN_VERSION: "6.41.0.60884"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
                 MSBUILD_PATH: $(MSBUILD_16_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
-              vs2022_latest99:
+              msbuild17_latest99:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE[9.9]"
                 SONAR_CFAMILYPLUGIN_VERSION: "6.41.0.60884" # LATEST_RELEASE of CFAMILY is not compatible with old SQ
                 MSBUILD_PATH: $(MSBUILD_17_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
-              vs2022_latest:
+              msbuild17_latest:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE"
                 SONAR_CFAMILYPLUGIN_VERSION: "LATEST_RELEASE"
                 MSBUILD_PATH: $(MSBUILD_17_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
-              vs2022_dev:
+              msbuild17_dev:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "DEV"
                 SONAR_CFAMILYPLUGIN_VERSION: "LATEST_RELEASE"
                 MSBUILD_PATH: $(MSBUILD_17_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
-              vs2022_sonar_cloud:
+              msbuild17_sonar_cloud:
                 PRODUCT: "SonarCloud"
                 SQ_VERSION: ""
                 MSBUILD_PATH: $(MSBUILD_17_PATH)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,8 +38,12 @@ variables:
     value: $[variables.ARTIFACTORY_PROMOTER_ACCESS_TOKEN]
   - name: IS_RELEASE_BRANCH
     value: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/branch-')) }}
-  - name: MSBUILD_2022_PATH
-    value: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe"
+  - name: MSBUILD_15_PATH
+    value: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\BuildTools\\MSBuild\\15.0\\Bin\\MSBuild.exe"
+  - name: MSBUILD_16_PATH
+    value: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\MSBuild\\Current\\Bin\\MSBuild.exe"
+  - name: MSBUILD_17_PATH
+    value: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools\\MSBuild\\Current\\Bin\\MSBuild.exe"
 
 resources:
   repositories:
@@ -480,49 +484,49 @@ stages:
                 SQ_VERSION: "LATEST_RELEASE[8.9]"
                 SONAR_DOTNET_VERSION: '9.7.0.75501' # sonar-dotnet 9.8 will mention SQ 9.9 as minimum supported version
                 SONAR_CFAMILYPLUGIN_VERSION: "6.20.5.49286"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
-                MSBUILD_PATH: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe"
+                MSBUILD_PATH: $(MSBUILD_15_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
               vs2022_latest89:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE[8.9]"
                 SONAR_DOTNET_VERSION: '9.7.0.75501' # sonar-dotnet 9.8 will mention SQ 9.9 as minimum supported version
                 SONAR_CFAMILYPLUGIN_VERSION: "6.20.5.49286"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
-                MSBUILD_PATH: $(MSBUILD_2022_PATH)
+                MSBUILD_PATH: $(MSBUILD_17_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
               vs2017_latest99:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE[9.9]"
                 SONAR_CFAMILYPLUGIN_VERSION: "6.41.0.60884"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
-                MSBUILD_PATH: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe"
+                MSBUILD_PATH: $(MSBUILD_15_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
               vs2019_latest99:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE[9.9]"
                 SONAR_CFAMILYPLUGIN_VERSION: "6.41.0.60884"  # LATEST_RELEASE of CFAMILY is not compatible with old SQ
-                MSBUILD_PATH: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe"
+                MSBUILD_PATH: $(MSBUILD_16_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
               vs2022_latest99:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE[9.9]"
                 SONAR_CFAMILYPLUGIN_VERSION: "6.41.0.60884" # LATEST_RELEASE of CFAMILY is not compatible with old SQ
-                MSBUILD_PATH: $(MSBUILD_2022_PATH)
+                MSBUILD_PATH: $(MSBUILD_17_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
               vs2022_latest:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "LATEST_RELEASE"
                 SONAR_CFAMILYPLUGIN_VERSION: "LATEST_RELEASE"
-                MSBUILD_PATH: $(MSBUILD_2022_PATH)
+                MSBUILD_PATH: $(MSBUILD_17_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
               vs2022_dev:
                 PRODUCT: "SonarQube"
                 SQ_VERSION: "DEV"
                 SONAR_CFAMILYPLUGIN_VERSION: "LATEST_RELEASE"
-                MSBUILD_PATH: $(MSBUILD_2022_PATH)
+                MSBUILD_PATH: $(MSBUILD_17_PATH)
                 TEST_INCLUDE: "**/sonarqube/*"
               vs2022_sonar_cloud:
                 PRODUCT: "SonarCloud"
                 SQ_VERSION: ""
-                MSBUILD_PATH: $(MSBUILD_2022_PATH)
+                MSBUILD_PATH: $(MSBUILD_17_PATH)
                 TEST_INCLUDE: "**/sonarcloud/*"
           variables:
             SONAR_DOTNET_VERSION: 'DEV'


### PR DESCRIPTION
This prepares the branch for using the new VMs that do not have Visual Studio installed.
Additionally, the IT task ids have been renamed to specify msbuild version instead of visual studio version.
