### PR TITLE
UTs: Add .runsettings to run UTs in parallel

### DIFF
--- a/.runsettings
+++ b/.runsettings
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- 0 will run all Test DLL in parallel locally -->
+    <MaxCpuCount>0</MaxCpuCount>
+  </RunConfiguration>
+</RunSettings>


### PR DESCRIPTION
This reduces UT runtime from 1m12s to 47s locally.

This will instruct the test adapter to run all test DLLs in parallel when running UTs via Test Explorer.

