### PR TITLE
CI: Add `branch-` prefix to predefined triggers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,10 +8,12 @@ schedules:
     branches:
       include:
         - master
+        - branch-*
     always: true
 
 trigger:
   - master
+  - branch-*
 
 pool:
   vmImage: 'windows-latest'


### PR DESCRIPTION
According to the following example: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?tabs=yaml&view=azure-devops#examples, wildcards are supported.
