### PR TITLE
Fix ScannerMSBuildTest after S6966 was merged

### DIFF
--- a/its/projects/VueWithAspBackend/AspBackend/Program.cs
+++ b/its/projects/VueWithAspBackend/AspBackend/Program.cs
@@ -22,4 +22,8 @@ app.UseAuthorization();
 
 app.MapControllers();
 
+// This method's Async version is supported for >= .NET 6
+// https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.webapplication.runasync?view=aspnetcore-8.0
+#pragma warning disable S6966 // Awaitable method should be used
 app.Run();
+#pragma warning disable S6966 // Awaitable method should be used

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -624,7 +624,7 @@ class ScannerMSBuildTest {
       "javascript:S2703",
       "typescript:S3626");
 
-    assertThat(TestUtils.getMeasureAsInteger(localProjectKey, "lines", ORCHESTRATOR)).isEqualTo(266);
+    assertThat(TestUtils.getMeasureAsInteger(localProjectKey, "lines", ORCHESTRATOR)).isEqualTo(270);
     assertThat(TestUtils.getMeasureAsInteger(localProjectKey, "ncloc", ORCHESTRATOR)).isEqualTo(170);
     assertThat(TestUtils.getMeasureAsInteger(localProjectKey, "files", ORCHESTRATOR)).isEqualTo(9);
   }


### PR DESCRIPTION
Fixes failing IT after S6966 was merged to sonar-dotnet master.
