### PR TITLE
Run on our infrastructure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,8 @@ variables:
     value: "Any CPU"
   - name: SOLUTION
     value: "SonarScanner.MSBuild.sln"
+  - name: NUGET_VERSION
+    value: "6.10.0"
 
 resources:
   repositories:
@@ -66,6 +68,12 @@ stages:
           commonMavenArguments: -B -Pdeploy-sonarsource -Dmaven.test.skip=true
         steps:
           - checkout: self
+
+          - task: NuGetToolInstaller@1
+            displayName: "Install NuGet"
+            inputs:
+              versionSpec: $(NUGET_VERSION)
+
           - task: Cache@2
             displayName: Cache Maven local repo
             inputs:
@@ -138,13 +146,34 @@ stages:
               verbosityRestore: 'normal'  # Default is noisy 'Detailed'
 
           - task: DotNetCoreCLI@2
-            displayName: Dotnet generate SBOM
-            # https://sonarsource.atlassian.net/browse/BUILD-1303
+            displayName: Install CycloneDX
+            env:
+              ARTIFACTORY_USER: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
+              ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
             inputs:
               command: custom
-              custom: CycloneDX
-              projects: '$(SOLUTION)'
-              arguments: '-t -j -o build'
+              custom: tool
+              feedsToUse: 'select'
+              includeNuGetOrg: true
+              arguments: 'install --global CycloneDX'
+
+          - powershell: |
+              # It's not possible to use the tool using only its name (dotnet CycloneDX [args]), because of this message in the pipeline:
+              # "Since you just installed the .NET Core SDK, you will need to reopen the Command Prompt window before running the tool you installed."
+              # Instead, we need to find the installed tool and execute it directly using its absolute path.
+
+              # Find the latest tool version with the latest .NET runtime version
+              $toolVersionRegex = "^\d+(\.\d+)+$"
+              $netVersionRegex = "^net\d+(\.\d+)*$"
+
+              $latestToolVersionPath = Get-ChildItem -Path "$env:userprofile\.dotnet\tools\.store\cyclonedx" -Directory | Where-Object { $_.Name -match $toolVersionRegex } | Sort-Object Name -Descending | Select-Object -First 1
+              $netVersionsDirectory = [IO.Path]::Combine($latestToolVersionPath.FullName, "cyclonedx", $latestToolVersionPath.Name, "tools")
+              $latestNetVersionPath = Get-ChildItem -Path $netVersionsDirectory -Directory | Where-Object { $_.Name -match $netVersionRegex } | Sort-Object Name -Descending | Select-Object -First 1
+              $toolFullPath = Join-Path $latestNetVersionPath.FullName "any\CycloneDX.dll"
+
+              # Execute CycloneDX tool to generate the SBOM
+              dotnet $toolFullPath "$(SOLUTION)" -t -j -o build
+            displayName: Dotnet generate SBOM
 
           - task: DotNetCoreCLI@2
             env:
@@ -429,6 +458,10 @@ stages:
               buildType: 'current'
               targetPath: '$(Build.SourcesDirectory)\build'
               artifactName: build
+
+          - task: NuGetToolInstaller@1
+            inputs:
+              versionSpec: $(NUGET_VERSION)
 
           - powershell: |
               $projectVersion = Get-Content "$(Build.SourcesDirectory)\build\version.txt"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,7 @@ trigger:
   - master
   - branch-*
 
-pool:
-  vmImage: 'windows-latest'
+pool: .net-bubble-aws-re-team-prod
 
 variables:
   - group: sonarsource-build-variables
@@ -67,8 +66,6 @@ stages:
           commonMavenArguments: -B -Pdeploy-sonarsource -Dmaven.test.skip=true
         steps:
           - checkout: self
-          - task: NuGetToolInstaller@1
-            displayName: "Install NuGet"
           - task: Cache@2
             displayName: Cache Maven local repo
             inputs:
@@ -139,18 +136,6 @@ stages:
               feedsToUse: 'config'
               nugetConfigPath: 'NuGet.Config'
               verbosityRestore: 'normal'  # Default is noisy 'Detailed'
-
-          - task: DotNetCoreCLI@2
-            displayName: Install CycloneDX
-            env:
-              ARTIFACTORY_USER: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
-              ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
-            inputs:
-              command: custom
-              custom: tool
-              feedsToUse: 'select'
-              includeNuGetOrg: true
-              arguments: 'install --global CycloneDX'
 
           - task: DotNetCoreCLI@2
             displayName: Dotnet generate SBOM
@@ -427,7 +412,6 @@ stages:
           WINDOWSSDKTARGET: '10.0.17763.0'
           MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
           MAVEN_OPTS: '-Xmx3072m -Dmaven.repo.local=$(MAVEN_CACHE_FOLDER)'
-        pool: .net-bubble-aws-re-team-prod
         steps:
           - checkout: self
             fetchDepth: 1
@@ -449,10 +433,6 @@ stages:
               buildType: 'current'
               targetPath: '$(Build.SourcesDirectory)\build'
               artifactName: build
-
-          - task: NuGetToolInstaller@1
-            inputs:
-              versionSpec: '5.8.0'
 
           - powershell: |
               $projectVersion = Get-Content "$(Build.SourcesDirectory)\build\version.txt"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,13 +185,10 @@ stages:
                 Package-NetFrameworkScanner -SignAssemblies $signAssemblies
                 Package-NetScanner -SignAssemblies $signAssemblies
 
-          - task: NuGetCommand@2
+            - powershell: |
+                nuget help | Select-String "NuGet Version"
+                nuget pack 'nuspec\netcoreglobaltool\dotnet-sonarscanner.nuspec' -NonInteractive -OutputDirectory build -Verbosity Detailed
             displayName: 'Package dotnet global tool'
-            inputs:
-              command: 'pack'
-              packagesToPack: 'nuspec\netcoreglobaltool\dotnet-sonarscanner.nuspec'
-              packDestination: 'build'
-              versioningScheme: 'off'
 
           - powershell: |
               nuget sign "$env:PACKAGES_PATH" -Overwrite -HashAlgorithm SHA256 -CertificateFingerprint $(SM_CERT_FP) -Timestamper http://timestamp.digicert.com -TimestampHashAlgorithm SHA256

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,14 +100,6 @@ stages:
             inputs:
               secureFile: cert_525594307.crt
 
-          - task: SSMClientToolsSetup@1
-            displayName: Client Tools Setup
-            condition: eq(variables.IS_RELEASE_BRANCH, 'true')
-
-          - task: SSMSigningToolsSetup@1
-            displayName: Signing Tools Setup
-            condition: eq(variables.IS_RELEASE_BRANCH, 'true')
-
           # Initialize the DigiCert Private Key Provider.
           # What we think it does: The smctl tool authenticates with a client certificate (SM_CLIENT_CERT_FILE) and a client password (SM_CLIENT_CERT_PASSWORD).
           # It uses an API Key (SM_API_KEY) and the ID of the certificate (SM_CERT) to check if the authenticated client is authorized to use the

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -184,7 +184,6 @@ stages:
                 $signAssemblies = [System.Convert]::ToBoolean("$(IS_RELEASE_BRANCH)") # the variable is a string, we need a boolean
                 Package-NetFrameworkScanner -SignAssemblies $signAssemblies
                 Package-NetScanner -SignAssemblies $signAssemblies
-              pwsh: true
 
           - task: NuGetCommand@2
             displayName: 'Package dotnet global tool'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -215,10 +215,13 @@ stages:
                 Package-NetFrameworkScanner -SignAssemblies $signAssemblies
                 Package-NetScanner -SignAssemblies $signAssemblies
 
-          - powershell: |
-                nuget help | Select-String "NuGet Version"
-                nuget pack 'nuspec\netcoreglobaltool\dotnet-sonarscanner.nuspec' -NonInteractive -OutputDirectory build -Verbosity Detailed
+          - task: NuGetCommand@2
             displayName: 'Package dotnet global tool'
+            inputs:
+              command: 'pack'
+              packagesToPack: 'nuspec\netcoreglobaltool\dotnet-sonarscanner.nuspec'
+              packDestination: 'build'
+              versioningScheme: 'off'
 
           - powershell: |
               nuget sign "$env:PACKAGES_PATH" -Overwrite -HashAlgorithm SHA256 -CertificateFingerprint $(SM_CERT_FP) -Timestamper http://timestamp.digicert.com -TimestampHashAlgorithm SHA256

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,14 +166,15 @@ stages:
               $toolVersionRegex = "^\d+(\.\d+)+$"
               $netVersionRegex = "^net\d+(\.\d+)*$"
 
-              $latestToolVersionPath = Get-ChildItem -Path "$env:userprofile\.dotnet\tools\.store\cyclonedx" -Directory | Where-Object { $_.Name -match $toolVersionRegex } | Sort-Object Name -Descending | Select-Object -First 1
+              $latestToolVersionPath = Get-ChildItem -Path "$env:userprofile\.dotnet\tools\.store\cyclonedx" -Directory | Select-Object -First 1
               $netVersionsDirectory = [IO.Path]::Combine($latestToolVersionPath.FullName, "cyclonedx", $latestToolVersionPath.Name, "tools")
-              $latestNetVersionPath = Get-ChildItem -Path $netVersionsDirectory -Directory | Where-Object { $_.Name -match $netVersionRegex } | Sort-Object Name -Descending | Select-Object -First 1
+              $latestNetVersionPath = Get-ChildItem -Path $netVersionsDirectory -Directory | Where-Object { $_.Name -match $netVersionRegex } | Sort-Object { (($_ -replace '-.+$') -replace 'net') -as [version] } -Descending | Select-Object -First 1
               $toolFullPath = Join-Path $latestNetVersionPath.FullName "any\CycloneDX.dll"
 
               # Execute CycloneDX tool to generate the SBOM
               dotnet $toolFullPath "$(SOLUTION)" -t -j -o build
             displayName: Dotnet generate SBOM
+            # https://sonarsource.atlassian.net/browse/BUILD-1303
 
           - task: DotNetCoreCLI@2
             env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -185,7 +185,7 @@ stages:
                 Package-NetFrameworkScanner -SignAssemblies $signAssemblies
                 Package-NetScanner -SignAssemblies $signAssemblies
 
-            - powershell: |
+          - powershell: |
                 nuget help | Select-String "NuGet Version"
                 nuget pack 'nuspec\netcoreglobaltool\dotnet-sonarscanner.nuspec' -NonInteractive -OutputDirectory build -Verbosity Detailed
             displayName: 'Package dotnet global tool'

--- a/scripts/run-unit-tests.ps1
+++ b/scripts/run-unit-tests.ps1
@@ -1,7 +1,13 @@
 ﻿param ($sourcesDirectory, $buildConfiguration)
 
 . .\scripts\utils.ps1
-mkdir $sourcesDirectory\coverage\
+
+$path = "$sourcesDirectory\coverage\"
+If(!(test-path -PathType container $path))
+{
+      New-Item -ItemType Directory -Path $path
+}
+
 function Run-Tests-With-Coverage {
     param (
     $projectPath


### PR DESCRIPTION
Fixes #1934 

---

I have done some tests and was able to have a green CI for the Build stage.
To do so, I had to disable/comment on any task related to the SBOM file:
- `Dotnet generate SBOM` task
- `Generate packages` task: I commented two lines in the script
- `Stage to repox` task which needs the file to continue

Once the build of the dotnet-ci AMI is working, I do not expect to see any other issues, except maybe in the `Stage to repox`.

**Update (from Zsolt):** I re-enabled the tasks and modified the SBOM generation to make it work with the new image.