### PR TITLE
Bump MSBuild.StructuredLogger

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -15,10 +15,12 @@
   </config>
   <trustedSigners>
     <repository name="nuget.org" serviceIndex="https://api.nuget.org/v3/index.json">
-      <!-- Subject Name: CN=NuGet.org Repository by Microsoft, valid from 10/04/2018 -->
+      <!-- Subject Name: CN=NuGet.org Repository by Microsoft, valid from 2018-04-10 -->
       <certificate fingerprint="0E5F38F57DC1BCC806D8494F4F90FBCEDD988B46760709CBEEC6F4219AA6157D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
-      <!-- Subject Name: CN=NuGet.org Repository by Microsoft, valid from 16/02/2021 -->
+      <!-- Subject Name: CN=NuGet.org Repository by Microsoft, valid from 2021-02-16 -->
       <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <!-- Subject Name: CN=NuGet.org Repository by Microsoft, valid from 2024-02-23 -->
+      <certificate fingerprint="1F4B311D9ACC115C8DC8018B5A49E00FCE6DA8E2855F9F014CA6F34570BC482D" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
       <!-- sharwell = author of StyleCop.Analyzers -->
       <!-- test dependencies: -->
       <!-- meirb = Meir Blachman, author of FluentAssertions.Analyzers -->
@@ -31,8 +33,15 @@
       <!-- protobuf-packages = Google.Protobuf -->
       <owners>Microsoft;sharwell;meirb;kzu;dotnetfoundation;castleproject;jonorossi;onovotny;fluentassertions;jamesnk;CycloneDX;grpc-packages;protobuf-packages</owners>
     </repository>
+    <author name="Microsoft">
+      <!-- Subject Name: CN=Microsoft Corporation, valid from 2023-07-27 -->
+      <certificate fingerprint="566A31882BE208BE4422F7CFD66ED09F5D4524A5994F50CCC8B05EC0528C1353" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <!-- Subject Name: CN=Microsoft Corporation, valid from: 2020-09-30 -->
+      <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+    </author>
     <author name="SonarSource">
-      <certificate fingerprint="FC4D3F3F815C1B56A656F1A5D9456AF04B469267D945786057175049B15A62A0" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
+      <!-- Subject Name: CN=SonarSource SA, valid from 2023-10-17 -->
+      <certificate fingerprint="A943C46DBA193D99C1135FFE33D3337524E9B3F05B416B9314E168CD206EF427" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
     </author>
     <author name="James Newton-King">
       <certificate fingerprint="A3AF7AF11EBB8EF729D2D91548509717E7E0FF55A129ABC3AEAA8A6940267641" hashAlgorithm="SHA256" allowUntrustedRoot="false" />

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/SonarScanner.MSBuild.Tasks.IntegrationTest.csproj
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/SonarScanner.MSBuild.Tasks.IntegrationTest.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net48</TargetFrameworks>
   </PropertyGroup>
@@ -18,7 +18,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Framework" Version="17.7.2" />
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.7.2175" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.858" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.243" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />


### PR DESCRIPTION
To fix the following issue:
```
System.NotSupportedException: Unsupported log file format. Latest supported version is 17, the log file has version 18.
```
