### PR TITLE
BUILD-5236 Rename VSTS to AzDO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,7 +164,7 @@ $RECYCLE.BIN/
 
 /PackagingProjects/CSharpPluginPayload/TempJarDir
 
-# VSTS
+# AzDO
 *.vsix
 
 # IntelliJ

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The SonarScanner for .NET is the recommended way to launch a SonarQube or SonarC
 SonarScanner for .NET is distributed as a
 
 * [Standalone tool](https://github.com/SonarSource/sonar-scanner-msbuild)
-* [Azure DevOps extension](https://github.com/SonarSource/sonar-scanner-vsts)
+* [Azure DevOps extension](https://github.com/SonarSource/sonar-scanner-azdo)
 * [Jenkins plugin](https://github.com/SonarSource/sonar-scanner-jenkins)
 
 For more info please look at our documentation page

--- a/Tests/SonarScanner.MSBuild.Common.Test/AnalysisConfig/AnalysisConfigExtensionsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/AnalysisConfig/AnalysisConfigExtensionsTests.cs
@@ -478,7 +478,7 @@ namespace SonarScanner.MSBuild.Common.Test
         {
             var testLogger = new TestLogger();
             // Make sure the test isn't affected by the hosting environment
-            // The SonarCloud VSTS extension sets additional properties in an environment variable that
+            // The SonarCloud AzDO extension sets additional properties in an environment variable that
             // would affect the test
             using var scope = new EnvironmentVariableScope().SetVariable(EnvScannerPropertiesProvider.ENV_VAR_KEY, null);
             return config.GetAnalysisSettings(includeServerSettings, testLogger);

--- a/Tests/SonarScanner.MSBuild.Common.Test/EnvScannerPropertiesProviderTest.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/EnvScannerPropertiesProviderTest.cs
@@ -55,7 +55,7 @@ namespace SonarScanner.MSBuild.Common.Test
 
             // Make sure the test isn't affected by the hosting environment and
             // does not affect the hosting environment
-            // The SonarCloud VSTS extension sets additional properties in an environment variable that
+            // The SonarCloud AzDO extension sets additional properties in an environment variable that
             // would affect the test.
             using var scope = new EnvironmentVariableScope().SetVariable("SONARQUBE_SCANNER_PARAMS", "trash");
             var result = EnvScannerPropertiesProvider.TryCreateProvider(logger, out _);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -530,7 +530,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         private static ProcessedArgs TryProcessArgsIsolatedFromEnvironment(string[] commandLineArgs, ILogger logger)
         {
             // Make sure the test isn't affected by the hosting environment
-            // The SonarCloud VSTS extension sets additional properties in an environment variable that
+            // The SonarCloud AzDO extension sets additional properties in an environment variable that
             // would be picked up by the argument processor
             using var scope = new EnvironmentVariableScope().SetVariable(EnvScannerPropertiesProvider.ENV_VAR_KEY, null);
             return ArgumentProcessor.TryProcessArgs(commandLineArgs, logger);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/PreprocessTestUtils.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/PreprocessTestUtils.cs
@@ -36,6 +36,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
                 .SetVariable(BuildSettings.EnvironmentVariables.TfsCollectionUri_TFS2015, null)
                 .SetVariable(BuildSettings.EnvironmentVariables.BuildUri_Legacy, null)
                 .SetVariable(BuildSettings.EnvironmentVariables.BuildUri_TFS2015, null)
-                .SetVariable(EnvScannerPropertiesProvider.ENV_VAR_KEY, null); // The Sonar VSTS tasks set and use this environment variable
+                .SetVariable(EnvScannerPropertiesProvider.ENV_VAR_KEY, null); // The Sonar AzDO tasks set and use this environment variable
     }
 }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/IncrementalPRAnalysisSonarCloudTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/IncrementalPRAnalysisSonarCloudTest.java
@@ -20,7 +20,6 @@
 package com.sonar.it.scanner.msbuild.sonarcloud;
 
 import com.sonar.it.scanner.msbuild.utils.TestUtils;
-import com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils;
 import com.sonar.orchestrator.http.HttpException;
 import com.sonar.orchestrator.util.Command;
 import com.sonar.orchestrator.util.CommandExecutor;
@@ -45,6 +44,8 @@ import java.time.Duration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils.getEnvBuildDirectory;
+import static com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils.isRunningUnderAzureDevOps;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -147,7 +148,7 @@ class IncrementalPRAnalysisSonarCloudTest {
   }
 
   private static Path getUnchangedFilesPath(Path projectDir) {
-    Path buildDirectory = AzureDevOpsUtils.isRunningUnderAzureDevOps() ? Path.of(AzureDevOpsUtils.getEnvBuildDirectory()) : projectDir;
+    Path buildDirectory = isRunningUnderAzureDevOps() ? Path.of(getEnvBuildDirectory()) : projectDir;
     return buildDirectory.resolve(".sonarqube\\conf\\UnchangedFiles.txt").toAbsolutePath();
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/IncrementalPRAnalysisSonarCloudTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/IncrementalPRAnalysisSonarCloudTest.java
@@ -20,7 +20,7 @@
 package com.sonar.it.scanner.msbuild.sonarcloud;
 
 import com.sonar.it.scanner.msbuild.utils.TestUtils;
-import com.sonar.it.scanner.msbuild.utils.VstsUtils;
+import com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils;
 import com.sonar.orchestrator.http.HttpException;
 import com.sonar.orchestrator.util.Command;
 import com.sonar.orchestrator.util.CommandExecutor;
@@ -147,7 +147,7 @@ class IncrementalPRAnalysisSonarCloudTest {
   }
 
   private static Path getUnchangedFilesPath(Path projectDir) {
-    Path buildDirectory = VstsUtils.isRunningUnderVsts() ? Path.of(VstsUtils.getEnvBuildDirectory()) : projectDir;
+    Path buildDirectory = AzureDevOpsUtils.isRunningUnderAzureDevOps() ? Path.of(AzureDevOpsUtils.getEnvBuildDirectory()) : projectDir;
     return buildDirectory.resolve(".sonarqube\\conf\\UnchangedFiles.txt").toAbsolutePath();
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
@@ -21,7 +21,7 @@ package com.sonar.it.scanner.msbuild.sonarqube;
 
 import com.sonar.it.scanner.msbuild.utils.EnvironmentVariable;
 import com.sonar.it.scanner.msbuild.utils.TestUtils;
-import com.sonar.it.scanner.msbuild.utils.VstsUtils;
+import com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils;
 import com.sonar.orchestrator.build.BuildResult;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +57,7 @@ class CodeCoverageTest {
   void whenRunningOutsideAzureDevops_coverageIsNotImported() throws Exception {
     // When running in AzureDevOps some of the environment variables are set and cannot be overwritten.
     // Because of this, the coverage is always enabled.
-    assumeFalse(VstsUtils.isRunningUnderVsts());
+    assumeFalse(AzureDevOpsUtils.isRunningUnderAzureDevOps());
 
     var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
     var token = TestUtils.getNewToken(ORCHESTRATOR);
@@ -74,7 +74,7 @@ class CodeCoverageTest {
     var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
     var token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    List<EnvironmentVariable> environmentVariables = VstsUtils.isRunningUnderVsts()
+    List<EnvironmentVariable> environmentVariables = AzureDevOpsUtils.isRunningUnderAzureDevOps()
       ? Collections.emptyList()
       : // In order to simulate Azure-DevOps environment, the following variables are needed:
         // TF_Build -> Must be set to true.
@@ -114,7 +114,7 @@ class CodeCoverageTest {
   private static void runTestsWithCoverage(Path projectDir) {
     // On AzureDevops the build directory is already set, and it's different from the "projectDir"
     // In order to simulate the behavior, we need to generate the test results in the location specified by %AGENT_BUILDDIRECTORY%
-    var buildDirectory = VstsUtils.getEnvBuildDirectory() == null ? projectDir.toString() : VstsUtils.getEnvBuildDirectory();
+    var buildDirectory = AzureDevOpsUtils.getEnvBuildDirectory() == null ? projectDir.toString() : AzureDevOpsUtils.getEnvBuildDirectory();
     // --collect "Code Coverage" parameter produces a binary coverage file ".coverage" that needs to be converted to an XML ".coveragexml" file by the end step
     var testResult = TestUtils.runDotnetCommand(projectDir, "test", "--collect", "Code Coverage", "--logger", "trx", "--results-directory", buildDirectory + "\\TestResults");
     assertTrue(testResult.isSuccess());

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
@@ -36,6 +36,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.sonar.it.scanner.msbuild.sonarqube.Tests.ORCHESTRATOR;
+import static com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils.getEnvBuildDirectory;
+import static com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils.isRunningUnderAzureDevOps;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -57,7 +59,7 @@ class CodeCoverageTest {
   void whenRunningOutsideAzureDevops_coverageIsNotImported() throws Exception {
     // When running in AzureDevOps some of the environment variables are set and cannot be overwritten.
     // Because of this, the coverage is always enabled.
-    assumeFalse(AzureDevOpsUtils.isRunningUnderAzureDevOps());
+    assumeFalse(isRunningUnderAzureDevOps());
 
     var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
     var token = TestUtils.getNewToken(ORCHESTRATOR);
@@ -74,7 +76,7 @@ class CodeCoverageTest {
     var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
     var token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    List<EnvironmentVariable> environmentVariables = AzureDevOpsUtils.isRunningUnderAzureDevOps()
+    List<EnvironmentVariable> environmentVariables = isRunningUnderAzureDevOps()
       ? Collections.emptyList()
       : // In order to simulate Azure-DevOps environment, the following variables are needed:
         // TF_Build -> Must be set to true.
@@ -114,7 +116,7 @@ class CodeCoverageTest {
   private static void runTestsWithCoverage(Path projectDir) {
     // On AzureDevops the build directory is already set, and it's different from the "projectDir"
     // In order to simulate the behavior, we need to generate the test results in the location specified by %AGENT_BUILDDIRECTORY%
-    var buildDirectory = AzureDevOpsUtils.getEnvBuildDirectory() == null ? projectDir.toString() : AzureDevOpsUtils.getEnvBuildDirectory();
+    var buildDirectory = getEnvBuildDirectory() == null ? projectDir.toString() : getEnvBuildDirectory();
     // --collect "Code Coverage" parameter produces a binary coverage file ".coverage" that needs to be converted to an XML ".coveragexml" file by the end step
     var testResult = TestUtils.runDotnetCommand(projectDir, "test", "--collect", "Code Coverage", "--logger", "trx", "--results-directory", buildDirectory + "\\TestResults");
     assertTrue(testResult.isSuccess());

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -23,7 +23,7 @@ import com.sonar.it.scanner.msbuild.utils.EnvironmentVariable;
 import com.sonar.it.scanner.msbuild.utils.ProxyAuthenticator;
 import com.sonar.it.scanner.msbuild.utils.ScannerClassifier;
 import com.sonar.it.scanner.msbuild.utils.TestUtils;
-import com.sonar.it.scanner.msbuild.utils.VstsUtils;
+import com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.ScannerForMSBuild;
 import com.sonar.orchestrator.http.HttpException;
@@ -892,8 +892,8 @@ class ScannerMSBuildTest {
   void testAzureFunctions_WithWrongBaseDirectory_AnalysisSucceeds() throws IOException {
     // If the test is being run under AzDO then the Scanner will
     // expect the project to be under the AzDO sources directory
-    if (VstsUtils.isRunningUnderVsts()) {
-      String azdoSourcePath = VstsUtils.getSourcesDirectory();
+    if (AzureDevOpsUtils.isRunningUnderAzureDevOps()) {
+      String azdoSourcePath = AzureDevOpsUtils.getSourcesDirectory();
       LOG.info("TEST SETUP: Tests are running under AzDO. Build dir:  " + azdoSourcePath);
       basePath = Path.of(azdoSourcePath);
     } else {
@@ -906,7 +906,7 @@ class ScannerMSBuildTest {
     assertThat(buildResult.isSuccess()).isTrue();
     // ToDo this will be fixed by https://github.com/SonarSource/sonar-scanner-msbuild/issues/1309
     // Expected: projectDir should be the base directory
-    if (VstsUtils.isRunningUnderVsts()) {
+    if (AzureDevOpsUtils.isRunningUnderAzureDevOps()) {
       // this might fail if Azure changes the drive
       assertThat(buildResult.getLogs()).contains("Using longest common projects path as a base directory: 'C:\\'");
     } else {
@@ -979,7 +979,7 @@ class ScannerMSBuildTest {
     assertThat(result.getLogs()).contains("Processing analysis cache");
     assertThat(result.getLogs()).contains("Downloading cache. Project key: IncrementalPRAnalysis, branch: " + baseBranch + ".");
 
-    Path buildDirectory = VstsUtils.isRunningUnderVsts() ? Path.of(VstsUtils.getEnvBuildDirectory()) : projectDir;
+    Path buildDirectory = AzureDevOpsUtils.isRunningUnderAzureDevOps() ? Path.of(AzureDevOpsUtils.getEnvBuildDirectory()) : projectDir;
     Path expectedUnchangedFiles = buildDirectory.resolve(".sonarqube\\conf\\UnchangedFiles.txt");
 
     LOG.info("UnchangedFiles: " + expectedUnchangedFiles.toAbsolutePath());
@@ -1102,7 +1102,7 @@ class ScannerMSBuildTest {
       .setProjectVersion("1.0")
       // do NOT set "sonar.projectBaseDir" for this test
       .setScannerVersion(TestUtils.developmentScannerVersion())
-      .setEnvironmentVariable(VstsUtils.ENV_SOURCES_DIRECTORY, "")
+      .setEnvironmentVariable(AzureDevOpsUtils.ENV_SOURCES_DIRECTORY, "")
       .setProperty("sonar.verbose", "true")
       .setProperty("sonar.sourceEncoding", "UTF-8");
 
@@ -1116,7 +1116,7 @@ class ScannerMSBuildTest {
     return ORCHESTRATOR.executeBuildQuietly(TestUtils.newScanner(ORCHESTRATOR, projectDir, ScannerClassifier.NET, token)
       .addArgument("end")
       // simulate it's not on Azure Pipelines (otherwise, it will take the projectBaseDir from there)
-      .setEnvironmentVariable(VstsUtils.ENV_SOURCES_DIRECTORY, "")
+      .setEnvironmentVariable(AzureDevOpsUtils.ENV_SOURCES_DIRECTORY, "")
       .setScannerVersion(TestUtils.developmentScannerVersion()));
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -890,14 +890,14 @@ class ScannerMSBuildTest {
 
   @Test
   void testAzureFunctions_WithWrongBaseDirectory_AnalysisSucceeds() throws IOException {
-    // If the test is being run under VSTS then the Scanner will
-    // expect the project to be under the VSTS sources directory
+    // If the test is being run under AzDO then the Scanner will
+    // expect the project to be under the AzDO sources directory
     if (VstsUtils.isRunningUnderVsts()) {
-      String vstsSourcePath = VstsUtils.getSourcesDirectory();
-      LOG.info("TEST SETUP: Tests are running under VSTS. Build dir:  " + vstsSourcePath);
-      basePath = Path.of(vstsSourcePath);
+      String azdoSourcePath = VstsUtils.getSourcesDirectory();
+      LOG.info("TEST SETUP: Tests are running under AzDO. Build dir:  " + azdoSourcePath);
+      basePath = Path.of(azdoSourcePath);
     } else {
-      LOG.info("TEST SETUP: Tests are not running under VSTS");
+      LOG.info("TEST SETUP: Tests are not running under AzDO");
     }
 
     Path projectDir = TestUtils.projectDir(basePath, "ReproAzureFunctions");
@@ -1175,7 +1175,7 @@ class ScannerMSBuildTest {
       .setProperty("sonar.sourceEncoding", "UTF-8");
 
     if (setProjectBaseDirExplicitly) {
-      // When running under VSTS the scanner calculates the projectBaseDir differently.
+      // When running under AzDO the scanner calculates the projectBaseDir differently.
       // This can be a problem when using shared files as the keys for the shared files
       // are calculated relative to the projectBaseDir.
       // For tests that need to check a specific shared project key, one way to work round

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -19,11 +19,11 @@
  */
 package com.sonar.it.scanner.msbuild.sonarqube;
 
+import com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils;
 import com.sonar.it.scanner.msbuild.utils.EnvironmentVariable;
 import com.sonar.it.scanner.msbuild.utils.ProxyAuthenticator;
 import com.sonar.it.scanner.msbuild.utils.ScannerClassifier;
 import com.sonar.it.scanner.msbuild.utils.TestUtils;
-import com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.ScannerForMSBuild;
 import com.sonar.orchestrator.http.HttpException;
@@ -84,6 +84,9 @@ import org.sonarqube.ws.client.WsClient;
 import org.sonarqube.ws.client.components.ShowRequest;
 
 import static com.sonar.it.scanner.msbuild.sonarqube.Tests.ORCHESTRATOR;
+import static com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils.getEnvBuildDirectory;
+import static com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils.getSourcesDirectory;
+import static com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils.isRunningUnderAzureDevOps;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
@@ -890,14 +893,14 @@ class ScannerMSBuildTest {
 
   @Test
   void testAzureFunctions_WithWrongBaseDirectory_AnalysisSucceeds() throws IOException {
-    // If the test is being run under AzDO then the Scanner will
-    // expect the project to be under the AzDO sources directory
-    if (AzureDevOpsUtils.isRunningUnderAzureDevOps()) {
-      String azdoSourcePath = AzureDevOpsUtils.getSourcesDirectory();
-      LOG.info("TEST SETUP: Tests are running under AzDO. Build dir:  " + azdoSourcePath);
-      basePath = Path.of(azdoSourcePath);
+    // If the test is being run under Azure DevOps then the Scanner will
+    // expect the project to be under the Azure DevOps sources directory
+    if (isRunningUnderAzureDevOps()) {
+      String sourcesDirectory = getSourcesDirectory();
+      LOG.info("TEST SETUP: Tests are running under Azure DevOps. Build dir:  " + sourcesDirectory);
+      basePath = Path.of(sourcesDirectory);
     } else {
-      LOG.info("TEST SETUP: Tests are not running under AzDO");
+      LOG.info("TEST SETUP: Tests are not running under Azure DevOps");
     }
 
     Path projectDir = TestUtils.projectDir(basePath, "ReproAzureFunctions");
@@ -906,7 +909,7 @@ class ScannerMSBuildTest {
     assertThat(buildResult.isSuccess()).isTrue();
     // ToDo this will be fixed by https://github.com/SonarSource/sonar-scanner-msbuild/issues/1309
     // Expected: projectDir should be the base directory
-    if (AzureDevOpsUtils.isRunningUnderAzureDevOps()) {
+    if (isRunningUnderAzureDevOps()) {
       // this might fail if Azure changes the drive
       assertThat(buildResult.getLogs()).contains("Using longest common projects path as a base directory: 'C:\\'");
     } else {
@@ -979,7 +982,7 @@ class ScannerMSBuildTest {
     assertThat(result.getLogs()).contains("Processing analysis cache");
     assertThat(result.getLogs()).contains("Downloading cache. Project key: IncrementalPRAnalysis, branch: " + baseBranch + ".");
 
-    Path buildDirectory = AzureDevOpsUtils.isRunningUnderAzureDevOps() ? Path.of(AzureDevOpsUtils.getEnvBuildDirectory()) : projectDir;
+    Path buildDirectory = isRunningUnderAzureDevOps() ? Path.of(getEnvBuildDirectory()) : projectDir;
     Path expectedUnchangedFiles = buildDirectory.resolve(".sonarqube\\conf\\UnchangedFiles.txt");
 
     LOG.info("UnchangedFiles: " + expectedUnchangedFiles.toAbsolutePath());
@@ -1175,7 +1178,7 @@ class ScannerMSBuildTest {
       .setProperty("sonar.sourceEncoding", "UTF-8");
 
     if (setProjectBaseDirExplicitly) {
-      // When running under AzDO the scanner calculates the projectBaseDir differently.
+      // When running under Azure DevOps the scanner calculates the projectBaseDir differently.
       // This can be a problem when using shared files as the keys for the shared files
       // are calculated relative to the projectBaseDir.
       // For tests that need to check a specific shared project key, one way to work round

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/AzureDevOpsUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/AzureDevOpsUtils.java
@@ -19,28 +19,24 @@
  */
 package com.sonar.it.scanner.msbuild.utils;
 
-public class VstsUtils {
+public class AzureDevOpsUtils {
 
   public final static String ENV_BUILD_DIRECTORY = "AGENT_BUILDDIRECTORY";
   public final static String ENV_SOURCES_DIRECTORY = "BUILD_SOURCESDIRECTORY";
 
-  public static Boolean isRunningUnderVsts(){
+  public static Boolean isRunningUnderAzureDevOps(){
     return System.getenv(ENV_BUILD_DIRECTORY) != null;
   }
 
   public static String getSourcesDirectory(){
-    return GetVstsEnvironmentVariable(ENV_SOURCES_DIRECTORY);
+    return getAzureDevOpsEnvironmentVariable(ENV_SOURCES_DIRECTORY);
   }
 
   public static String getEnvBuildDirectory(){
-    return GetVstsEnvironmentVariable(ENV_BUILD_DIRECTORY);
+    return getAzureDevOpsEnvironmentVariable(ENV_BUILD_DIRECTORY);
   }
 
-  private static String GetVstsEnvironmentVariable(String name){
-    String value = System.getenv(name);
-    if (name == null){
-      throw new IllegalStateException("Unable to find AzDO environment variable: " + name);
-    }
-    return value;
+  private static String getAzureDevOpsEnvironmentVariable(String name){
+    return System.getenv(name);
   }
 }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/VstsUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/VstsUtils.java
@@ -39,7 +39,7 @@ public class VstsUtils {
   private static String GetVstsEnvironmentVariable(String name){
     String value = System.getenv(name);
     if (name == null){
-      throw new IllegalStateException("Unable to find VSTS environment variable: " + name);
+      throw new IllegalStateException("Unable to find AzDO environment variable: " + name);
     }
     return value;
   }

--- a/scripts/build-utils.ps1
+++ b/scripts/build-utils.ps1
@@ -56,7 +56,7 @@ function Restore-Packages (
 
     $msbuildBinDir = Split-Path -Parent (Get-MsBuildPath $msbuildVersion)
 
-    # see https://github.com/Microsoft/vsts-tasks/issues/3762
+    # see https://github.com/microsoft/azure-pipelines-tasks/issues/3762
     # it seems for mixed .net standard and .net framework, we need both dotnet restore and nuget restore...
     if (Test-Debug) {
         Exec { & (Get-NuGetPath) restore $solutionPath -MSBuildPath $msbuildBinDir -Verbosity detailed `

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -47,7 +47,7 @@ namespace SonarScanner.MSBuild.TFS
         {
             binaryFilePaths = new TrxFileReader(Logger).FindCodeCoverageFiles(settings.BuildDirectory);
 
-            // Fallback to workround VSTS-179: if the standard searches for .trx/.converage failed
+            // Fallback to workround SONARAZDO-179: if the standard searches for .trx/.converage failed
             // then try the fallback method to find coverage files
             if (!TrxFilesLocated && (binaryFilePaths == null || !binaryFilePaths.Any()))
             {

--- a/src/SonarScanner.MSBuild.TFS/IBuildVNextCoverageSearchFallback.cs
+++ b/src/SonarScanner.MSBuild.TFS/IBuildVNextCoverageSearchFallback.cs
@@ -25,7 +25,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using SonarScanner.MSBuild.Common;
 
-// HACK: Workaround for VSTS-179
+// HACK: Workaround for SONARAZDO-179
 
 // v2 of the AzureDevOps VSTest task may delete the .trx files from disc after it has uploaded them
 // (it does this when using the distributed task runner (?) e.g. when running tests in parallel).


### PR DESCRIPTION
The repository was recently renamed to sonar-scanner-azdo, and the Jira project SONARAZDO, this PR reflects this change to this repository

Comments are also updated to use the new name for VSTS (AzDO).

See [ticket](https://sonarsource.atlassian.net/browse/BUILD-5236) for context