### PR TITLE
Add support for JRE provisioning: Add sonar.scanner.apiBaseUrl parameter

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/CmdLineArgsPropertiesProviderTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/CmdLineArgsPropertiesProviderTests.cs
@@ -144,6 +144,7 @@ namespace SonarScanner.MSBuild.Common.Test
         [DataTestMethod]
         [DataRow("sonar.projectBaseDir=value1")]
         [DataRow($"{SonarProperties.SonarcloudUrl}=value1")]
+        [DataRow($"{SonarProperties.ApiBaseUrl}=value1")]
         [DataRow($"{SonarProperties.VsCoverageXmlReportsPaths}=value1")]
         public void SonarProperties_IsAllowed(string argument)
         {

--- a/Tests/SonarScanner.MSBuild.Common.Test/SonarPropertiesTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/SonarPropertiesTests.cs
@@ -36,6 +36,7 @@ namespace SonarScanner.MSBuild.Common.Test
             SonarProperties.ClientCertPath,
             SonarProperties.HostUrl,
             SonarProperties.SonarcloudUrl,
+            SonarProperties.ApiBaseUrl,
             SonarProperties.LogLevel,
             SonarProperties.Organization,
             SonarProperties.PluginCacheDirectory,

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -76,6 +76,33 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         [TestMethod]
+        public void PreArgProc_ApiBaseUrl_Set()
+        {
+            var args = CheckProcessingSucceeds("/k:key", "/d:sonar.scanner.apiBaseUrl=test");
+            args.ApiBaseUrl.Should().Be("test");
+        }
+
+        [TestMethod]
+        public void PreArgProc_ApiBaseUrl_NotSet_SonarCloudDefault()
+        {
+            var args = CheckProcessingSucceeds("/k:key", "/d:sonar.scanner.sonarcloudUrl=test");
+            args.ApiBaseUrl.Should().Be("https://api.sonarcloud.io");
+        }
+
+        [DataTestMethod]
+        [DataRow("http://host", "http://host/api/v2")]
+        [DataRow("http://host/", "http://host/api/v2")]
+        [DataRow("http://host ", "http://host /api/v2")]
+        [DataRow("http://host///", "http://host/api/v2")]
+        [DataRow(@"http://host\", @"http://host\/api/v2")]
+        [DataRow("/", "/api/v2")]
+        public void PreArgProc_ApiBaseUrl_NotSet_SonarQubeDefault(string hostUri, string expectedApiUri)
+        {
+            var args = CheckProcessingSucceeds("/k:key", $"/d:sonar.host.url={hostUri}");
+            args.ApiBaseUrl.Should().Be(expectedApiUri);
+        }
+
+        [TestMethod]
         [WorkItem(102)] // http://jira.sonarsource.com/browse/SONARMSBRU-102
         public void PreArgProc_ProjectKeyValidity()
         {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -82,11 +82,15 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             args.ApiBaseUrl.Should().Be("test");
         }
 
-        [TestMethod]
-        public void PreArgProc_ApiBaseUrl_NotSet_SonarCloudDefault()
+        [DataTestMethod]
+        [DataRow("test")]
+        [DataRow("https://sonarcloud.io")]
+        [DataRow("https://sonar-test.io")]
+        [DataRow("https://www.sonarcloud.io")]
+        public void PreArgProc_ApiBaseUrl_NotSet_SonarCloudDefault(string sonarcloudUrl)
         {
-            var args = CheckProcessingSucceeds("/k:key", "/d:sonar.scanner.sonarcloudUrl=test");
-            args.ApiBaseUrl.Should().Be("https://api.sonarcloud.io");
+            var args = CheckProcessingSucceeds("/k:key", $"/d:sonar.scanner.sonarcloudUrl={sonarcloudUrl}");
+            args.ApiBaseUrl.Should().Be("https://api.sonarcloud.io", because: "it is not so easy to transform the api url for a user specified sonarcloudUrl (Subdomain change).");
         }
 
         [DataTestMethod]

--- a/src/SonarScanner.MSBuild.Common/SonarProperties.cs
+++ b/src/SonarScanner.MSBuild.Common/SonarProperties.cs
@@ -38,6 +38,7 @@ namespace SonarScanner.MSBuild.Common
         public const string SonarPassword = "sonar.password"; // Deprecated by SonarQube
 
         public const string SonarcloudUrl = "sonar.scanner.sonarcloudUrl";
+        public const string ApiBaseUrl = "sonar.scanner.apiBaseUrl";
 
         // SonarQube project settings
         public const string ProjectKey = "sonar.projectKey";

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -133,7 +133,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                 ? apiBaseUrl.Value
                 : SonarServer switch
                 {
-                    SonarCloudServer => "https://api.sonarcloud.io", // SQ default
+                    SonarCloudServer => "https://api.sonarcloud.io", // SC default
                     SonarQubeServer { ServerUrl: { } baseUrl } => $"{baseUrl.TrimEnd('/')}/api/v2", // SQ default
                     _ => null,
                 };

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -131,12 +131,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             this.sonarServer = GetSonarServer(logger, isHostSet, sonarHostUrl, isSonarcloudSet, sonarcloudUrl);
             ApiBaseUrl = AggregateProperties.TryGetProperty(SonarProperties.ApiBaseUrl, out var apiBaseUrl)
                 ? apiBaseUrl.Value
-                : SonarServer switch
-                {
-                    SonarCloudServer => "https://api.sonarcloud.io", // SC default
-                    SonarQubeServer { ServerUrl: { } baseUrl } => $"{baseUrl.TrimEnd('/')}/api/v2", // SQ default
-                    _ => null,
-                };
+                : SonarServer?.DefaultApiBaseUrl;
             HttpTimeout = TimeoutProvider.HttpTimeout(AggregateProperties, logger);
         }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -135,8 +135,6 @@ namespace SonarScanner.MSBuild.PreProcessor
             HttpTimeout = TimeoutProvider.HttpTimeout(AggregateProperties, logger);
         }
 
-        protected /* for testing */ ProcessedArgs() { }
-
         /// <summary>
         /// Returns the value for the specified setting.
         /// Throws if the setting does not exist.

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -135,6 +135,8 @@ namespace SonarScanner.MSBuild.PreProcessor
             HttpTimeout = TimeoutProvider.HttpTimeout(AggregateProperties, logger);
         }
 
+        protected /* for testing */ ProcessedArgs() { }
+
         /// <summary>
         /// Returns the value for the specified setting.
         /// Throws if the setting does not exist.

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarServer.cs
@@ -35,7 +35,7 @@ public abstract record SonarServer(string ServerUrl)
 public sealed record SonarQubeServer(string ServerUrl) : SonarServer(ServerUrl)
 {
     /// <inheritdoc/>
-    public override string DefaultApiBaseUrl => $"{ServerUrl}.TrimEnd('/')/api/v2";
+    public override string DefaultApiBaseUrl => $"{ServerUrl?.TrimEnd('/')}/api/v2";
 }
 
 public sealed record SonarCloudServer(string ServerUrl) : SonarServer(ServerUrl)

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarServer.cs
@@ -22,12 +22,11 @@ namespace SonarScanner.MSBuild.PreProcessor;
 
 public abstract record SonarServer(string ServerUrl)
 {
-    public string ServerUrl { get; } = ServerUrl;
-
-    /// <summary>
+/// <summary>
     /// Base Url for the V2 endpoint
     /// </summary>
     public abstract string DefaultApiBaseUrl { get; }
+    public string ServerUrl { get; } = ServerUrl;
 }
 
 public sealed record SonarQubeServer(string ServerUrl) : SonarServer(ServerUrl)

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarServer.cs
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using static System.Net.WebRequestMethods;
-
 namespace SonarScanner.MSBuild.PreProcessor;
 
 public abstract record SonarServer(string ServerUrl)

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarServer.cs
@@ -35,7 +35,7 @@ public abstract record SonarServer(string ServerUrl)
 public sealed record SonarQubeServer(string ServerUrl) : SonarServer(ServerUrl)
 {
     /// <inheritdoc/>
-    public override string DefaultApiBaseUrl => $"{ServerUrl?.TrimEnd('/')}/api/v2";
+    public override string DefaultApiBaseUrl => $"{ServerUrl.TrimEnd('/')}/api/v2";
 }
 
 public sealed record SonarCloudServer(string ServerUrl) : SonarServer(ServerUrl)

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarServer.cs
@@ -18,13 +18,28 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using static System.Net.WebRequestMethods;
+
 namespace SonarScanner.MSBuild.PreProcessor;
 
 public abstract record SonarServer(string ServerUrl)
 {
     public string ServerUrl { get; } = ServerUrl;
+
+    /// <summary>
+    /// Base Url for the V2 endpoint
+    /// </summary>
+    public abstract string DefaultApiBaseUrl { get; }
 }
 
-public sealed record SonarQubeServer(string ServerUrl) : SonarServer(ServerUrl);
+public sealed record SonarQubeServer(string ServerUrl) : SonarServer(ServerUrl)
+{
+    /// <inheritdoc/>
+    public override string DefaultApiBaseUrl => $"{ServerUrl}.TrimEnd('/')/api/v2";
+}
 
-public sealed record SonarCloudServer(string ServerUrl) : SonarServer(ServerUrl);
+public sealed record SonarCloudServer(string ServerUrl) : SonarServer(ServerUrl)
+{
+    /// <inheritdoc/>
+    public override string DefaultApiBaseUrl => "https://api.sonarcloud.io";
+}


### PR DESCRIPTION
Contributes to https://github.com/SonarSource/sonar-scanner-msbuild/issues/1960
Based on #1967