### PR TITLE
Add support for JRE provisioning: sonar.scanner.javaExePath + sonar.scanner.skipJreProvisioning

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/CmdLineArgsPropertiesProviderTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/CmdLineArgsPropertiesProviderTests.cs
@@ -139,6 +139,7 @@ namespace SonarScanner.MSBuild.Common.Test
         [DataTestMethod]
         [DataRow("sonar.projectBaseDir=value1")]
         [DataRow($"{SonarProperties.SonarcloudUrl}=value1")]
+        [DataRow($"{SonarProperties.JavaExePath}=value1")]
         [DataRow($"{SonarProperties.ApiBaseUrl}=value1")]
         [DataRow($"{SonarProperties.ConnectTimeout }=value1")]
         [DataRow($"{SonarProperties.SocketTimeout }=value1")]

--- a/Tests/SonarScanner.MSBuild.Common.Test/SonarPropertiesTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/SonarPropertiesTests.cs
@@ -34,6 +34,8 @@ namespace SonarScanner.MSBuild.Common.Test
         private static readonly IEnumerable<string> NonSensitivePropertyKeys = new[]
         {
             SonarProperties.ClientCertPath,
+            SonarProperties.JavaExePath,
+            SonarProperties.SkipJreProvisioning,
             SonarProperties.HostUrl,
             SonarProperties.SonarcloudUrl,
             SonarProperties.ApiBaseUrl,

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigGeneratorTests.cs
@@ -289,5 +289,5 @@ public class AnalysisConfigGeneratorTests
         CreateProcessedArgs(EmptyPropertyProvider.Instance, EmptyPropertyProvider.Instance, Substitute.For<ILogger>());
 
     private static ProcessedArgs CreateProcessedArgs(IAnalysisPropertyProvider cmdLineProperties, IAnalysisPropertyProvider globalFileProperties, ILogger logger) =>
-        new("valid.key", "valid.name", "1.0", "organization", false, cmdLineProperties, globalFileProperties, EmptyPropertyProvider.Instance, logger);
+        new("valid.key", "valid.name", "1.0", "organization", false, cmdLineProperties, globalFileProperties, EmptyPropertyProvider.Instance, Substitute.For<IFileWrapper>(), logger);
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -518,6 +518,34 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             }
         }
 
+        [DataTestMethod]
+        [DataRow("C:\\Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe", "C:\\Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe")]
+        [DataRow("C:Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe", "C:Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe")]
+        [DataRow("\\jdk1.6.0_30\\bin\\javac.exe", "\\jdk1.6.0_30\\bin\\javac.exe")]
+        [DataRow("jdk1.6.0_30\\bin\\javac.exe", null)]
+        [DataRow("not a path", null)]
+        [DataRow(" ", null)]
+        public void PreArgProc_JavaExePath_Set(string javaExePath, string result) =>
+            CheckProcessingSucceeds("/k:key", $"/d:sonar.scanner.javaExePath={javaExePath}").JavaExePath.Should().Be(result);
+
+        [TestMethod]
+        public void PreArgProc_JavaExePath_NotSet() =>
+            CheckProcessingSucceeds("/k:key").JavaExePath.Should().Be(null);
+
+        [DataTestMethod]
+        [DataRow("true", true)]
+        [DataRow("True", true)]
+        [DataRow("false", false)]
+        [DataRow("False", false)]
+        [DataRow("gibberish", false)]
+        [DataRow(" ", false)]
+        public void PreArgProc_SkipJreProvisioning_Set(string skipJreProvisioning, bool result) =>
+            CheckProcessingSucceeds("/k:key", $"/d:sonar.scanner.skipJreProvisioning={skipJreProvisioning}").SkipJreProvisioning.Should().Be(result);
+
+        [TestMethod]
+        public void PreArgProc_SkipJreProvisioning_NotSet() =>
+            CheckProcessingSucceeds("/k:key").SkipJreProvisioning.Should().BeFalse();
+
         #endregion Tests
 
         #region Checks

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -527,6 +527,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
         [DataTestMethod]
         [DataRow("jdk1.6.0_30\\bin\\javac.exe")]
+        [DataRow("C:Program Files\\Java\\jdk1.6.0_30\\bin\\javac")]
         [DataRow("not a path")]
         [DataRow(" ")]
         public void PreArgProc_JavaExePath_SetInvalid(string javaExePath)

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -519,14 +519,21 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         [DataTestMethod]
-        [DataRow("C:\\Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe", "C:\\Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe")]
-        [DataRow("C:Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe", "C:Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe")]
-        [DataRow("\\jdk1.6.0_30\\bin\\javac.exe", "\\jdk1.6.0_30\\bin\\javac.exe")]
-        [DataRow("jdk1.6.0_30\\bin\\javac.exe", null)]
-        [DataRow("not a path", null)]
-        [DataRow(" ", null)]
-        public void PreArgProc_JavaExePath_Set(string javaExePath, string result) =>
-            CheckProcessingSucceeds("/k:key", $"/d:sonar.scanner.javaExePath={javaExePath}").JavaExePath.Should().Be(result);
+        [DataRow("C:\\Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe")]
+        [DataRow("C:Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe")]
+        [DataRow("\\jdk1.6.0_30\\bin\\javac.exe")]
+        public void PreArgProc_JavaExePath_SetValid(string javaExePath) =>
+            CheckProcessingSucceeds("/k:key", $"/d:sonar.scanner.javaExePath={javaExePath}").JavaExePath.Should().Be(javaExePath);
+
+        [DataTestMethod]
+        [DataRow("jdk1.6.0_30\\bin\\javac.exe")]
+        [DataRow("not a path")]
+        [DataRow(" ")]
+        public void PreArgProc_JavaExePath_SetInvalid(string javaExePath)
+        {
+            var logger = CheckProcessingFails("/k:key", $"/d:sonar.scanner.javaExePath={javaExePath}");
+            logger.AssertErrorLogged("The argument 'sonar.scanner.javaExePath' contains an invalid path. Please make sure the path is correctly pointing to the javac.exe.");
+        }
 
         [TestMethod]
         public void PreArgProc_JavaExePath_NotSet() =>
@@ -537,10 +544,17 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [DataRow("True", true)]
         [DataRow("false", false)]
         [DataRow("False", false)]
-        [DataRow("gibberish", false)]
-        [DataRow(" ", false)]
-        public void PreArgProc_SkipJreProvisioning_Set(string skipJreProvisioning, bool result) =>
+        public void PreArgProc_SkipJreProvisioning_SetValid(string skipJreProvisioning, bool result) =>
             CheckProcessingSucceeds("/k:key", $"/d:sonar.scanner.skipJreProvisioning={skipJreProvisioning}").SkipJreProvisioning.Should().Be(result);
+
+        [DataTestMethod]
+        [DataRow("gibberish")]
+        [DataRow(" ")]
+        public void PreArgProc_SkipJreProvisioning_SetInvalid(string skipJreProvisioning)
+        {
+            var logger = CheckProcessingFails("/k:key", $"/d:sonar.scanner.skipJreProvisioning={skipJreProvisioning}");
+            logger.AssertErrorLogged("The argument 'sonar.scanner.skipJreProvisioning' has an invalid value. Please ensure it is set to either 'true' or 'false'.");
+        }
 
         [TestMethod]
         public void PreArgProc_SkipJreProvisioning_NotSet() =>

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -519,21 +519,21 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         }
 
         [DataTestMethod]
-        [DataRow("C:\\Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe")]
-        [DataRow("C:Program Files\\Java\\jdk1.6.0_30\\bin\\javac.exe")]
-        [DataRow("\\jdk1.6.0_30\\bin\\javac.exe")]
+        [DataRow(@"C:\Program Files\Java\jdk1.6.0_30\bin\java.exe")]
+        [DataRow(@"C:Program Files\Java\jdk1.6.0_30\bin\java.exe")]
+        [DataRow(@"\jdk1.6.0_30\bin\java.exe")]
         public void PreArgProc_JavaExePath_SetValid(string javaExePath) =>
             CheckProcessingSucceeds("/k:key", $"/d:sonar.scanner.javaExePath={javaExePath}").JavaExePath.Should().Be(javaExePath);
 
         [DataTestMethod]
-        [DataRow("jdk1.6.0_30\\bin\\javac.exe")]
-        [DataRow("C:Program Files\\Java\\jdk1.6.0_30\\bin\\javac")]
-        [DataRow("not a path")]
-        [DataRow(" ")]
+        [DataRow(@"jdk1.6.0_30\bin\java.exe")]
+        [DataRow(@"C:Program Files\Java\jdk1.6.0_30\bin\java")]
+        [DataRow(@"not a path")]
+        [DataRow(@" ")]
         public void PreArgProc_JavaExePath_SetInvalid(string javaExePath)
         {
             var logger = CheckProcessingFails("/k:key", $"/d:sonar.scanner.javaExePath={javaExePath}");
-            logger.AssertErrorLogged("The argument 'sonar.scanner.javaExePath' contains an invalid path. Please make sure the path is correctly pointing to the javac.exe.");
+            logger.AssertErrorLogged("The argument 'sonar.scanner.javaExePath' contains an invalid path. Please make sure the path is correctly pointing to the java executable.");
         }
 
         [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -530,7 +530,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
         [TestMethod]
         public void PreArgProc_JavaExePath_NotSet() =>
-            CheckProcessingSucceeds("/k:key").JavaExePath.Should().Be(null);
+            CheckProcessingSucceeds("/k:key").JavaExePath.Should().BeNull();
 
         [DataTestMethod]
         [DataRow("true", true)]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -142,7 +142,7 @@ public class PreprocessorObjectFactoryTests
 
     private ProcessedArgs CreateValidArguments(string hostUrl = "http://myhost:222", string organization = "organization")
     {
-        var cmdLineArgs = new ListPropertiesProvider(new[] { new Property(SonarProperties.HostUrl, hostUrl) });
-        return new ProcessedArgs("key", "name", "version", organization, false, cmdLineArgs, new ListPropertiesProvider(), EmptyPropertyProvider.Instance, logger);
+        var cmdLineArgs = new ListPropertiesProvider([new Property(SonarProperties.HostUrl, hostUrl)]);
+        return new ProcessedArgs("key", "name", "version", organization, false, cmdLineArgs, new ListPropertiesProvider(), EmptyPropertyProvider.Instance, Substitute.For<IFileWrapper>(), logger);
     }
 }

--- a/src/SonarScanner.MSBuild.Common/SonarProperties.cs
+++ b/src/SonarScanner.MSBuild.Common/SonarProperties.cs
@@ -33,6 +33,8 @@ namespace SonarScanner.MSBuild.Common
         // SonarQube server settings
         public const string HostUrl = "sonar.host.url";
 
+        public const string JavaExePath = "sonar.scanner.javaExePath";
+        public const string SkipJreProvisioning = "sonar.scanner.skipJreProvisioning";
         public const string SonarToken = "sonar.token";
         public const string SonarUserName = "sonar.login"; // Deprecated by SonarQube
         public const string SonarPassword = "sonar.password"; // Deprecated by SonarQube

--- a/src/SonarScanner.MSBuild.PreProcessor/ArgumentProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ArgumentProcessor.cs
@@ -62,7 +62,10 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// reports any errors using the logger.
         /// Returns null unless all of the properties are valid.
         /// </summary>
-        public static ProcessedArgs TryProcessArgs(IEnumerable<string> commandLineArgs, ILogger logger)
+        public static ProcessedArgs TryProcessArgs(IEnumerable<string> commandLineArgs, ILogger logger) =>
+            TryProcessArgs(commandLineArgs, FileWrapper.Instance, logger);
+
+        internal /* for testing */ static ProcessedArgs TryProcessArgs(IEnumerable<string> commandLineArgs, IFileWrapper fileWrapper, ILogger logger)
         {
             if (logger == null)
             {
@@ -104,6 +107,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                     cmdLineProperties,
                     globalFileProperties,
                     scannerEnvProperties,
+                    fileWrapper,
                     logger);
 
                 if (!processed.IsValid)

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -239,7 +239,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             }
         }
 
-        private bool TryParseBool(string value) =>
+        private static bool TryParseBool(string value) =>
             bool.TryParse(value, out var result) && result;
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -22,7 +22,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
-using System.IO;
 using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild.PreProcessor

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using System.IO;
 using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild.PreProcessor
@@ -145,15 +146,12 @@ namespace SonarScanner.MSBuild.PreProcessor
             ApiBaseUrl = AggregateProperties.TryGetProperty(SonarProperties.ApiBaseUrl, out var apiBaseUrl)
                 ? apiBaseUrl.Value
                 : SonarServer?.DefaultApiBaseUrl;
-            JavaExePath = AggregateProperties.TryGetProperty(SonarProperties.JavaExePath, out var javaExePath)
-                && !string.IsNullOrWhiteSpace(javaExePath.Value)
-                && System.IO.Path.IsPathRooted(javaExePath.Value)
-                ? javaExePath.Value
-                : null;
 
-            if (AggregateProperties.TryGetProperty(SonarProperties.JavaExePath, out javaExePath))
+            if (AggregateProperties.TryGetProperty(SonarProperties.JavaExePath, out var javaExePath))
             {
-                if (string.IsNullOrWhiteSpace(javaExePath.Value) || !System.IO.Path.IsPathRooted(javaExePath.Value))
+                if (string.IsNullOrWhiteSpace(javaExePath.Value)
+                    || Path.GetExtension(javaExePath.Value).ToLower() is not ".exe"
+                    || !Path.IsPathRooted(javaExePath.Value))
                 {
                     IsJavaConfigurationValid = false;
                     logger.LogError(Resources.ERROR_InvalidJavaExePath);

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -117,6 +117,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             IAnalysisPropertyProvider cmdLineProperties,
             IAnalysisPropertyProvider globalFileProperties,
             IAnalysisPropertyProvider scannerEnvProperties,
+            IFileWrapper fileWrapper,
             ILogger logger)
         {
             IsValid = true;
@@ -149,9 +150,7 @@ namespace SonarScanner.MSBuild.PreProcessor
 
             if (AggregateProperties.TryGetProperty(SonarProperties.JavaExePath, out var javaExePath))
             {
-                if (string.IsNullOrWhiteSpace(javaExePath.Value)
-                    || Path.GetExtension(javaExePath.Value).ToLower() is not ".exe"
-                    || !Path.IsPathRooted(javaExePath.Value))
+                if (!fileWrapper.Exists(javaExePath.Value))
                 {
                     IsValid = false;
                     logger.LogError(Resources.ERROR_InvalidJavaExePath);

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -153,7 +153,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                     || Path.GetExtension(javaExePath.Value).ToLower() is not ".exe"
                     || !Path.IsPathRooted(javaExePath.Value))
                 {
-                    IsJavaConfigurationValid = false;
+                    IsValid = false;
                     logger.LogError(Resources.ERROR_InvalidJavaExePath);
                 }
                 JavaExePath = javaExePath.Value;
@@ -162,7 +162,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             {
                 if (!bool.TryParse(skipJreProvisioningString.Value, out var result))
                 {
-                    IsJavaConfigurationValid = false;
+                    IsValid = false;
                     logger.LogError(Resources.ERROR_InvalidSkipJreProvisioning);
                 }
                 SkipJreProvisioning = result;

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -253,7 +253,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The argument &apos;sonar.scanner.javaExePath&apos; contains an invalid path. Please make sure the path is correctly pointing to the javac.exe..
+        ///   Looks up a localized string similar to The argument &apos;sonar.scanner.javaExePath&apos; contains an invalid path. Please make sure the path is correctly pointing to the java executable..
         /// </summary>
         internal static string ERROR_InvalidJavaExePath {
             get {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -253,11 +253,29 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;sonar.scanner.javaExePath&apos; contains an invalid path. Please make sure the path is correctly pointing to the javac.exe..
+        /// </summary>
+        internal static string ERROR_InvalidJavaExePath {
+            get {
+                return ResourceManager.GetString("ERROR_InvalidJavaExePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid project key. Allowed characters are alphanumeric, &apos;-&apos;, &apos;_&apos;, &apos;.&apos; and &apos;:&apos;, with at least one non-digit..
         /// </summary>
         internal static string ERROR_InvalidProjectKeyArg {
             get {
                 return ResourceManager.GetString("ERROR_InvalidProjectKeyArg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;sonar.scanner.skipJreProvisioning&apos; has an invalid value. Please ensure it is set to either &apos;true&apos; or &apos;false&apos;..
+        /// </summary>
+        internal static string ERROR_InvalidSkipJreProvisioning {
+            get {
+                return ResourceManager.GetString("ERROR_InvalidSkipJreProvisioning", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -370,7 +370,7 @@ Use '/?' or '/h' to see the help message.</value>
     <value>The arguments 'sonar.host.url' and 'sonar.scanner.sonarcloudUrl' are both set. Please set only 'sonar.scanner.sonarcloudUrl'.</value>
   </data>
   <data name="ERROR_InvalidJavaExePath" xml:space="preserve">
-    <value>The argument 'sonar.scanner.javaExePath' contains an invalid path. Please make sure the path is correctly pointing to the javac.exe.</value>
+    <value>The argument 'sonar.scanner.javaExePath' contains an invalid path. Please make sure the path is correctly pointing to the java executable.</value>
   </data>
   <data name="ERROR_InvalidSkipJreProvisioning" xml:space="preserve">
     <value>The argument 'sonar.scanner.skipJreProvisioning' has an invalid value. Please ensure it is set to either 'true' or 'false'.</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -369,4 +369,10 @@ Use '/?' or '/h' to see the help message.</value>
   <data name="WARN_HostUrlAndSonarcloudUrlSet" xml:space="preserve">
     <value>The arguments 'sonar.host.url' and 'sonar.scanner.sonarcloudUrl' are both set. Please set only 'sonar.scanner.sonarcloudUrl'.</value>
   </data>
+  <data name="ERROR_InvalidJavaExePath" xml:space="preserve">
+    <value>The argument 'sonar.scanner.javaExePath' contains an invalid path. Please make sure the path is correctly pointing to the javac.exe.</value>
+  </data>
+  <data name="ERROR_InvalidSkipJreProvisioning" xml:space="preserve">
+    <value>The argument 'sonar.scanner.skipJreProvisioning' has an invalid value. Please ensure it is set to either 'true' or 'false'.</value>
+  </data>
 </root>


### PR DESCRIPTION
Contributes to https://github.com/SonarSource/sonar-scanner-msbuild/issues/1960