### PR TITLE
Move args validation to a single place

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/RegexExtensionsTest.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/RegexExtensionsTest.cs
@@ -1,0 +1,84 @@
+﻿/*
+* SonarAnalyzer for .NET
+* Copyright (C) 2015-2024 SonarSource SA
+* mailto: contact AT sonarsource DOT com
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+using System;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarScanner.MSBuild.Common;
+
+namespace SonarAnalyzer.Test.Extensions;
+
+[TestClass]
+public class RegexExtensionsTest
+{
+    // https://stackoverflow.com/questions/3403512/regex-match-take-a-very-long-time-to-execute
+    // Regular expression with catastrophic backtracking to ensure timeout exception when a small timeout is set
+    private const string TimeoutPattern =
+        @"^((?<DRIVE>[a-zA-Z]):\\)*((?<DIR>[a-zA-Z0-9_]+(([a-zA-Z0-9_\s_\-\.]*[a-zA-Z0-9_]+)|([a-zA-Z0-9_]+)))\\)*(?<FILE>([a-zA-Z0-9_]+(([a-zA-Z0-9_\s_\-\.]*[a-zA-Z0-9_]+)|([a-zA-Z0-9_]+))\.(?<EXTENSION>[a-zA-Z0-9]{1,6})$))";
+
+    [DataTestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void SafeIsMatch_Timeout_Fallback(bool timeoutFallback)
+    {
+        var regex = new Regex(TimeoutPattern, RegexOptions.None, TimeSpan.FromTicks(1));
+        regex.SafeIsMatch(@"C:\Users\username\AppData\Local\Temp\00af5451-626f-40db-af1d-89d376dc5ef6\SomeFile.csproj", timeoutFallback).Should().Be(timeoutFallback);
+    }
+
+    [DataTestMethod]
+    [DataRow(@"C:\Users\username\AppData\Local\Temp\00af5451-626f-40db-af1d-89d376dc5ef6\SomeFile.csproj", 1, false)]
+    [DataRow(@"C:\Users\username\AppData\Local\Temp\00af5451-626f-40db-af1d-89d376dc5ef6\SomeFile.csproj", 1_000_000, true)]
+    [DataRow(@"äöü", 1, false)]
+    [DataRow(@"äöü", 1_000_000, false)]
+    public void SafeMatch_Timeout(string input, long timeoutTicks, bool matchSucceed)
+    {
+        var regex = new Regex(TimeoutPattern, RegexOptions.None, TimeSpan.FromTicks(timeoutTicks));
+        regex.SafeMatch(input).Success.Should().Be(matchSucceed);
+    }
+
+    [DataTestMethod]
+    [DataRow(@"C:\Users\username\AppData\Local\Temp\00af5451-626f-40db-af1d-89d376dc5ef6\SomeFile.csproj", 1, 0)]
+    [DataRow(@"C:\Users\username\AppData\Local\Temp\00af5451-626f-40db-af1d-89d376dc5ef6\SomeFile.csproj", 1_000_000, 1)]
+    [DataRow(@"äöü", 1, 0)]
+    [DataRow(@"äöü", 1_000_000, 0)]
+    public void SafeMatches_Timeout(string input, long timeoutTicks, int matchCount)
+    {
+        var regex = new Regex(TimeoutPattern, RegexOptions.None, TimeSpan.FromTicks(timeoutTicks));
+        var actual = regex.SafeMatches(input);
+        actual.Count.Should().Be(matchCount);
+        if (matchCount > 0)
+        {
+            var access = () => actual[0];
+            access.Should().NotThrow().Which.Index.Should().Be(0);
+        }
+    }
+
+    [DataTestMethod]
+    [DataRow(@"C:\Users\username\AppData\Local\Temp\00af5451-626f-40db-af1d-89d376dc5ef6\SomeFile.csproj", 1, false)]
+    [DataRow(@"C:\Users\username\AppData\Local\Temp\00af5451-626f-40db-af1d-89d376dc5ef6\SomeFile.csproj", 1_000_000, true)]
+    [DataRow(@"äöü", 1, false)]
+    [DataRow(@"äöü", 1_000_000, false)]
+    public void SafeRegex_IsMatch_Timeout(string input, long timeoutTicks, bool isMatch)
+    {
+        var actual = SafeRegex.IsMatch(input, TimeoutPattern, RegexOptions.None, TimeSpan.FromTicks(timeoutTicks));
+        actual.Should().Be(isMatch);
+    }
+}

--- a/Tests/SonarScanner.MSBuild.Common.Test/RegexExtensionsTest.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/RegexExtensionsTest.cs
@@ -43,6 +43,13 @@ public class RegexExtensionsTest
         regex.SafeIsMatch(@"C:\Users\username\AppData\Local\Temp\00af5451-626f-40db-af1d-89d376dc5ef6\SomeFile.csproj", timeoutFallback).Should().Be(timeoutFallback);
     }
 
+    [TestMethod]
+    public void SafeIsMatch_Overloads()
+    {
+        var regex = new Regex("pattern", RegexOptions.None, TimeSpan.FromTicks(100));
+        regex.SafeIsMatch("input").Should().BeFalse();
+    }
+
     [DataTestMethod]
     [DataRow(@"C:\Users\username\AppData\Local\Temp\00af5451-626f-40db-af1d-89d376dc5ef6\SomeFile.csproj", 1, false)]
     [DataRow(@"C:\Users\username\AppData\Local\Temp\00af5451-626f-40db-af1d-89d376dc5ef6\SomeFile.csproj", 1_000_000, true)]
@@ -80,5 +87,12 @@ public class RegexExtensionsTest
     {
         var actual = SafeRegex.IsMatch(input, TimeoutPattern, RegexOptions.None, TimeSpan.FromTicks(timeoutTicks));
         actual.Should().Be(isMatch);
+    }
+
+    [TestMethod]
+    public void SafeRegex_IsMatch_Overloads()
+    {
+        SafeRegex.IsMatch("input", "pattern").Should().BeFalse();
+        SafeRegex.IsMatch("input", "pattern", RegexOptions.None).Should().BeFalse();
     }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
@@ -178,6 +178,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             AssertExpectedValue("xxx", "cmd line value XXX - lower case", processedArgs);
             AssertExpectedValue("XXX", "file line value XXX - upper case", processedArgs);
             AssertExpectedValue(SonarProperties.HostUrl, "http://host", processedArgs);
+            processedArgs.IsValid.Should().BeTrue();
         }
 
         [TestMethod]
@@ -189,6 +190,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             sut.SonarServer.Should().BeOfType<SonarQubeServer>().Which.ServerUrl.Should().Be("http://host");
             logger.Warnings.Should().BeEmpty();
             logger.Errors.Should().BeEmpty();
+            sut.IsValid.Should().BeTrue();
         }
 
         [TestMethod]
@@ -200,6 +202,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             sut.SonarServer.Should().BeOfType<SonarCloudServer>().Which.ServerUrl.Should().Be("https://sonarcloud.proxy");
             logger.Warnings.Should().BeEmpty();
             logger.Errors.Should().BeEmpty();
+            sut.IsValid.Should().BeTrue();
         }
 
         [TestMethod]
@@ -212,6 +215,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             sut.SonarServer.Should().BeOfType<SonarCloudServer>().Which.ServerUrl.Should().Be("https://sonarcloud.proxy");
             logger.AssertWarningLogged("The arguments 'sonar.host.url' and 'sonar.scanner.sonarcloudUrl' are both set. Please set only 'sonar.scanner.sonarcloudUrl'.");
             logger.Errors.Should().BeEmpty();
+            sut.IsValid.Should().BeTrue();
         }
 
         [TestMethod]
@@ -225,6 +229,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             logger.Warnings.Should().BeEmpty();
             logger.AssertErrorLogged("The arguments 'sonar.host.url' and 'sonar.scanner.sonarcloudUrl' are both set and are different. " +
                 "Please set either 'sonar.host.url' for SonarQube or 'sonar.scanner.sonarcloudUrl' for SonarCloud.");
+            sut.IsValid.Should().BeFalse();
         }
 
         [DataTestMethod]
@@ -240,6 +245,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             sut.SonarServer.Should().BeNull();
             logger.Warnings.Should().BeEmpty();
             logger.AssertErrorLogged("The arguments 'sonar.host.url' and 'sonar.scanner.sonarcloudUrl' are both set to an invalid value.");
+            sut.IsValid.Should().BeFalse();
         }
 
         [TestMethod]
@@ -249,6 +255,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             sut.SonarServer.Should().BeOfType<SonarCloudServer>().Which.ServerUrl.Should().Be("https://sonarcloud.io");
             logger.Warnings.Should().BeEmpty();
             logger.Errors.Should().BeEmpty();
+            sut.IsValid.Should().BeTrue();
         }
 
         [TestMethod]
@@ -260,6 +267,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             sut.SonarServer.Should().BeOfType<SonarCloudServer>().Which.ServerUrl.Should().Be("https://sonarcloud.io");
             logger.Warnings.Should().BeEmpty();
             logger.Errors.Should().BeEmpty();
+            sut.IsValid.Should().BeTrue();
         }
 
         [TestMethod]
@@ -273,6 +281,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
             logger.Warnings.Should().BeEmpty();
             logger.AssertErrorLogged("The arguments 'sonar.host.url' and 'sonar.scanner.sonarcloudUrl' are both set and are different. " +
                 "Please set either 'sonar.host.url' for SonarQube or 'sonar.scanner.sonarcloudUrl' for SonarCloud.");
+            sut.IsValid.Should().BeFalse();
         }
         #endregion Tests
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
@@ -57,6 +57,34 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         #region Tests
 
         [TestMethod]
+        public void ProcArgs_ParameterThrow_Key()
+        {
+            var action = () => new ProcessedArgs(key: null, "name", "version", "org", true, EmptyPropertyProvider.Instance, EmptyPropertyProvider.Instance, EmptyPropertyProvider.Instance, logger);
+            action.Should().Throw<ArgumentNullException>().WithParameterName("key");
+        }
+
+        [TestMethod]
+        public void ProcArgs_ParameterThrow_CmdLineProperties()
+        {
+            var action = () => new ProcessedArgs("key", "name", "version", "org", true, cmdLineProperties: null, EmptyPropertyProvider.Instance, EmptyPropertyProvider.Instance, logger);
+            action.Should().Throw<ArgumentNullException>().WithParameterName("cmdLineProperties");
+        }
+
+        [TestMethod]
+        public void ProcArgs_ParameterThrow_GlobalFileProperties()
+        {
+            var action = () => new ProcessedArgs("key", "name", "version", "org", true, EmptyPropertyProvider.Instance, globalFileProperties: null, EmptyPropertyProvider.Instance, logger);
+            action.Should().Throw<ArgumentNullException>().WithParameterName("globalFileProperties");
+        }
+
+        [TestMethod]
+        public void ProcArgs_ParameterThrow_ScannerEnvProperties()
+        {
+            var action = () => new ProcessedArgs("key", "name", "version", "org", true, EmptyPropertyProvider.Instance, EmptyPropertyProvider.Instance, scannerEnvProperties: null, logger);
+            action.Should().Throw<ArgumentNullException>().WithParameterName("scannerEnvProperties");
+        }
+
+        [TestMethod]
         public void ProcArgs_Organization()
         {
             this.args.Organization.Should().BeNull();

--- a/src/SonarScanner.MSBuild.Common/RegexExtensions.cs
+++ b/src/SonarScanner.MSBuild.Common/RegexExtensions.cs
@@ -25,7 +25,9 @@ namespace SonarScanner.MSBuild.Common;
 
 public static class RegexExtensions
 {
+#pragma warning disable T0004 // T0004 Use 'SafeRegex.Matches' instead.
     private static readonly MatchCollection EmptyMatchCollection = Regex.Matches(string.Empty, "a", RegexOptions.None, RegexConstants.DefaultTimeout);
+#pragma warning restore T0004
 
     /// <summary>
     /// Matches the input to the regex. Returns <see cref="Match.Empty" /> in case of an <see cref="RegexMatchTimeoutException" />.
@@ -34,7 +36,9 @@ public static class RegexExtensions
     {
         try
         {
+#pragma warning disable T0004 // T0004 Use 'SafeRegex.Matches' instead.
             return regex.Match(input);
+#pragma warning restore T0004
         }
         catch (RegexMatchTimeoutException)
         {
@@ -55,7 +59,9 @@ public static class RegexExtensions
     {
         try
         {
+#pragma warning disable T0004 // T0004 Use 'SafeRegex.Matches' instead.
             return regex.IsMatch(input);
+#pragma warning restore T0004
         }
         catch (RegexMatchTimeoutException)
         {
@@ -70,7 +76,9 @@ public static class RegexExtensions
     {
         try
         {
+#pragma warning disable T0004 // T0004 Use 'SafeRegex.Matches' instead.
             var res = regex.Matches(input);
+#pragma warning restore T0004
             _ = res.Count; // MatchCollection is lazy. Accessing "Count" executes the regex and caches the result
             return res;
         }
@@ -98,7 +106,9 @@ public static class SafeRegex
     {
         try
         {
+#pragma warning disable T0004 // T0004 Use 'SafeRegex.Matches' instead.
             return Regex.IsMatch(input, pattern, options, matchTimeout);
+#pragma warning restore T0004
         }
         catch (RegexMatchTimeoutException)
         {

--- a/src/SonarScanner.MSBuild.Common/RegexExtensions.cs
+++ b/src/SonarScanner.MSBuild.Common/RegexExtensions.cs
@@ -25,9 +25,7 @@ namespace SonarScanner.MSBuild.Common;
 
 public static class RegexExtensions
 {
-#pragma warning disable T0004 // T0004 Use 'SafeRegex.Matches' instead.
     private static readonly MatchCollection EmptyMatchCollection = Regex.Matches(string.Empty, "a", RegexOptions.None, RegexConstants.DefaultTimeout);
-#pragma warning restore T0004
 
     /// <summary>
     /// Matches the input to the regex. Returns <see cref="Match.Empty" /> in case of an <see cref="RegexMatchTimeoutException" />.
@@ -36,9 +34,7 @@ public static class RegexExtensions
     {
         try
         {
-#pragma warning disable T0004 // T0004 Use 'SafeRegex.Matches' instead.
             return regex.Match(input);
-#pragma warning restore T0004
         }
         catch (RegexMatchTimeoutException)
         {
@@ -59,9 +55,7 @@ public static class RegexExtensions
     {
         try
         {
-#pragma warning disable T0004 // T0004 Use 'SafeRegex.Matches' instead.
             return regex.IsMatch(input);
-#pragma warning restore T0004
         }
         catch (RegexMatchTimeoutException)
         {
@@ -76,9 +70,7 @@ public static class RegexExtensions
     {
         try
         {
-#pragma warning disable T0004 // T0004 Use 'SafeRegex.Matches' instead.
             var res = regex.Matches(input);
-#pragma warning restore T0004
             _ = res.Count; // MatchCollection is lazy. Accessing "Count" executes the regex and caches the result
             return res;
         }
@@ -106,9 +98,7 @@ public static class SafeRegex
     {
         try
         {
-#pragma warning disable T0004 // T0004 Use 'SafeRegex.Matches' instead.
             return Regex.IsMatch(input, pattern, options, matchTimeout);
-#pragma warning restore T0004
         }
         catch (RegexMatchTimeoutException)
         {

--- a/src/SonarScanner.MSBuild.Common/RegexExtensions.cs
+++ b/src/SonarScanner.MSBuild.Common/RegexExtensions.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Text.RegularExpressions;
+
+namespace SonarScanner.MSBuild.Common;
+
+public static class RegexExtensions
+{
+    /// <summary>
+    /// Matches the input to the regex. Returns <see langword="false" /> in case of an <see cref="RegexMatchTimeoutException" />.
+    /// </summary>
+    public static bool SafeIsMatch(this Regex regex, string input) =>
+        regex.SafeIsMatch(input, false);
+
+    /// <summary>
+    /// Matches the input to the regex. Returns <paramref name="timeoutFallback"/> in case of an <see cref="RegexMatchTimeoutException" />.
+    /// </summary>
+    public static bool SafeIsMatch(this Regex regex, string input, bool timeoutFallback)
+    {
+        try
+        {
+            return regex.IsMatch(input);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return timeoutFallback;
+        }
+    }
+}

--- a/src/SonarScanner.MSBuild.PreProcessor/ArgumentProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ArgumentProcessor.cs
@@ -23,7 +23,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using SonarScanner.MSBuild.Common;
 using static SonarScanner.MSBuild.Common.CommandLine.CommandLineFlagPrefix;
 

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -42,8 +42,6 @@ namespace SonarScanner.MSBuild.PreProcessor
 
         private readonly IAnalysisPropertyProvider globalFileProperties;
 
-        internal bool IsValid { get; set; }
-
         public /* for testing */ virtual string ProjectKey { get; }
 
         public string ProjectName { get; }
@@ -96,6 +94,8 @@ namespace SonarScanner.MSBuild.PreProcessor
                 return null;
             }
         }
+
+        internal bool IsValid { get; set; }
 
         public ProcessedArgs(
             string key,

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -40,8 +40,6 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// </remarks>
         private static readonly Regex ProjectKeyRegEx = new(@"^[a-zA-Z0-9:\-_\.]*[a-zA-Z:\-_\.]+[a-zA-Z0-9:\-_\.]*$", RegexOptions.Compiled | RegexOptions.Singleline, RegexConstants.DefaultTimeout);
 
-        private readonly SonarServer sonarServer;
-
         private readonly IAnalysisPropertyProvider globalFileProperties;
 
         public bool IsValid { get; set; }
@@ -60,7 +58,7 @@ namespace SonarScanner.MSBuild.PreProcessor
         /// Returns either a <see cref="SonarQubeServer"/>, <see cref="SonarCloudServer"/>, or <see langword="null"/> depending on
         /// the sonar.host and sonar.scanner.sonarcloudUrl settings.
         /// </summary>
-        public SonarServer SonarServer => this.sonarServer;
+        public SonarServer SonarServer { get; }
 
         /// <summary>
         /// Api v2 endpoint. Either https://api.sonarcloud.io for SonarCloud or http://host/api/v2 for SonarQube.
@@ -132,7 +130,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             AggregateProperties = new AggregatePropertiesProvider(cmdLineProperties, globalFileProperties, ScannerEnvProperties);
             var isHostSet = AggregateProperties.TryGetValue(SonarProperties.HostUrl, out var sonarHostUrl); // Used for SQ and may also be set to https://SonarCloud.io
             var isSonarcloudSet = AggregateProperties.TryGetValue(SonarProperties.SonarcloudUrl, out var sonarcloudUrl);
-            sonarServer = GetAndCheckSonarServer(logger, isHostSet, sonarHostUrl, isSonarcloudSet, sonarcloudUrl);
+            SonarServer = GetAndCheckSonarServer(logger, isHostSet, sonarHostUrl, isSonarcloudSet, sonarcloudUrl);
             ApiBaseUrl = AggregateProperties.TryGetProperty(SonarProperties.ApiBaseUrl, out var apiBaseUrl)
                 ? apiBaseUrl.Value
                 : SonarServer?.DefaultApiBaseUrl;

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -42,7 +42,7 @@ namespace SonarScanner.MSBuild.PreProcessor
 
         private readonly IAnalysisPropertyProvider globalFileProperties;
 
-        public bool IsValid { get; set; }
+        internal bool IsValid { get; set; }
 
         public /* for testing */ virtual string ProjectKey { get; }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -184,7 +184,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             return true;
         }
 
-        private bool CheckProjectKeyValidity(string key, ILogger logger)
+        private static bool CheckProjectKeyValidity(string key, ILogger logger)
         {
             if (!ProjectKeyRegEx.SafeIsMatch(key, timeoutFallback: true))
             {


### PR DESCRIPTION
Currently, the argument validation is split between two classes. This change moves all validation into a single class.

This change is required to simplify the validation for the properties added in
https://github.com/SonarSource/sonar-scanner-msbuild/pull/1981
https://github.com/SonarSource/sonar-scanner-msbuild/pull/1977

