### PR TITLE
Remove IsTestAnalysisSupported

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTest/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTest/GetAnalyzerSettingsTests.cs
@@ -330,18 +330,11 @@ namespace SonarScanner.MSBuild.Tasks.UnitTest
         }
 
         [DataTestMethod]
-        [DataRow("7.3", "cs", /* not set */ null, DisplayName = "Legacy CS")]
-        [DataRow("7.4", "cs", /* not set */ null, DisplayName = "SQ 7.4 - test projects are not analyzed CS")]
-        [DataRow("8.0.0.29455", "cs", /* not set */ null, DisplayName = "SonarQube 8.0 build version CS")]
         [DataRow("8.0.0.18955", "cs", "true", DisplayName = "SonarCloud build version - needs exclusion parameter CS")]
-        [DataRow("8.8", "cs", /* not set */ null, DisplayName = "SQ 8.8 - test projects are not analyzed CS")]
         [DataRow("8.9", "cs", "true", DisplayName = "SQ 8.9 - needs exclusion parameter CS")]
         [DataRow("9.0", "cs", "TRUE", DisplayName = "SQ 9.0 - needs exclusion parameter CS")]
         [DataRow("10.0", "cs", "tRUE", DisplayName = "SQ 10.0 - needs exclusion parameter CS")]
-        [DataRow("7.3", "vbnet", /* not set */ null, DisplayName = "Legacy VB")]
-        [DataRow("7.4", "vbnet", /* not set */ null, DisplayName = "SQ 7.4 - test projects are not analyzed VB")]
         [DataRow("8.0.0.18955", "vbnet", "true", DisplayName = "SonarCloud build version - needs exclusion parameter CS")]
-        [DataRow("8.8", "vbnet", /* not set */ null, DisplayName = "SQ 8.8 - test projects are not analyzed VB")]
         [DataRow("8.9", "vbnet", "true", DisplayName = "SQ 8.9 - needs exclusion parameter VB")]
         public void ConfigExists_ForTestProject_WhenExcluded_DeactivatedSonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string excludeTestProject)
         {

--- a/src/SonarScanner.MSBuild.Tasks/GetAnalyzerSettings.cs
+++ b/src/SonarScanner.MSBuild.Tasks/GetAnalyzerSettings.cs
@@ -129,8 +129,7 @@ namespace SonarScanner.MSBuild.Tasks
             }
 
             TaskOutputs outputs;
-            // We analyze test projects since MMF-2297 / SQ 8.9. C#/VB.NET plugin <= 8.20 bundled with SQ <= 8.8 would ignore results on test projects anyway.
-            if (IsTestProject && (ExcludeTestProjects() || !IsTestAnalysisSupported()))
+            if (IsTestProject && ExcludeTestProjects())
             {
                 // Special case: to provide colorization etc for code in test projects, we need to run only the SonarC#/VB analyzers, with all of the non-utility rules turned off
                 // See [MMF-486]: https://jira.sonarsource.com/browse/MMF-486
@@ -158,12 +157,6 @@ namespace SonarScanner.MSBuild.Tasks
             bool ExcludeTestProjects() =>
                 config.GetAnalysisSettings(false, logger).TryGetValue(ExcludeTestProjectsSettingId, out var excludeTestProjects)
                 && excludeTestProjects.Equals("true", StringComparison.OrdinalIgnoreCase);
-
-            bool IsTestAnalysisSupported()
-            {
-                var version = config.FindServerVersion();
-                return SonarProduct.IsSonarCloud(config.SonarQubeHostUrl, version) || version >= new Version(8, 9);
-            }
         }
 
         #endregion Overrides


### PR DESCRIPTION
The check is always true for SonarCloud, as well as SonarQube >= 8.9

*(The earliest supported version of SQ at the time of writing is 9.9)*