### PR TITLE
Add support for JRE provisioning: Add logging for the Jre download cache

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreCaching/JreCacheTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreCaching/JreCacheTests.cs
@@ -28,12 +28,15 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.PreProcessor.JreCaching;
+using TestUtilities;
 
 namespace SonarScanner.MSBuild.PreProcessor.Test.JreCaching;
 
 [TestClass]
 public class JreCacheTests
 {
+    private readonly TestLogger testLogger = new TestLogger();
+
     // https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.createdirectory
     // https://learn.microsoft.com/en-us/dotnet/api/system.io.file.create
     // https://learn.microsoft.com/en-us/dotnet/api/system.io.file.move
@@ -60,7 +63,7 @@ public class JreCacheTests
         directoryWrapper.Exists(cache).Returns(false);
         var fileWrapper = Substitute.For<IFileWrapper>();
 
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = sut.IsJreCached(home, new("jre", "sha", "java"));
         result.Should().Be(new JreCacheMiss());
         directoryWrapper.Received().CreateDirectory(cache);
@@ -76,7 +79,7 @@ public class JreCacheTests
         directoryWrapper.When(x => x.CreateDirectory(cache)).Throw((Exception)Activator.CreateInstance(exceptionType));
         var fileWrapper = Substitute.For<IFileWrapper>();
 
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = sut.IsJreCached(home, new("jre", "sha", "java"));
         result.Should().Be(new JreCacheFailure(@"The JRE cache directory in 'C:\Users\user\.sonar\cache' could not be created."));
         directoryWrapper.Received().Exists(cache);
@@ -94,7 +97,7 @@ public class JreCacheTests
         directoryWrapper.Exists(expectedExtractedPath).Returns(false);
         var fileWrapper = Substitute.For<IFileWrapper>();
 
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = sut.IsJreCached(home, new("filename.tar.gz", "sha", "jdk/bin/java"));
         result.Should().Be(new JreCacheMiss());
         directoryWrapper.DidNotReceive().CreateDirectory(Arg.Any<string>());
@@ -113,7 +116,7 @@ public class JreCacheTests
         var fileWrapper = Substitute.For<IFileWrapper>();
         fileWrapper.Exists(expectedExtractedJavaExe).Returns(false);
 
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = sut.IsJreCached(home, new("filename.tar.gz", "sha", "jdk/bin/java"));
         result.Should().Be(new JreCacheFailure(
             @"The java executable in the JRE cache could not be found at the expected location 'C:\Users\user\.sonar\cache\sha\filename.tar.gz_extracted\jdk/bin/java'."));
@@ -133,7 +136,7 @@ public class JreCacheTests
         var fileWrapper = Substitute.For<IFileWrapper>();
         fileWrapper.Exists(expectedExtractedJavaExe).Returns(true);
 
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = sut.IsJreCached(home, new("filename.tar.gz", "sha", "jdk/bin/java"));
         result.Should().Be(new JreCacheHit(expectedExtractedJavaExe));
         directoryWrapper.DidNotReceive().CreateDirectory(Arg.Any<string>());
@@ -149,7 +152,7 @@ public class JreCacheTests
         directoryWrapper.Exists(cache).Returns(false);
         directoryWrapper.When(x => x.CreateDirectory(cache)).Throw((Exception)Activator.CreateInstance(exception));
         var fileWrapper = Substitute.For<IFileWrapper>();
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", "sha256", "javaPath"), () => throw new NotSupportedException("Unreachable"));
         result.Should().BeOfType<JreCacheFailure>().Which.Message.Should().Be(@"The JRE cache directory in 'C:\Users\user\.sonar\cache\sha256' could not be created.");
     }
@@ -165,7 +168,7 @@ public class JreCacheTests
         directoryWrapper.Exists(cache).Returns(true);
         directoryWrapper.When(x => x.CreateDirectory(sha)).Throw((Exception)Activator.CreateInstance(exception));
         var fileWrapper = Substitute.For<IFileWrapper>();
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", "sha256", "javaPath"), () => throw new NotSupportedException("Unreachable"));
         result.Should().BeOfType<JreCacheFailure>().Which.Message.Should().Be(@"The JRE cache directory in 'C:\Users\user\.sonar\cache\sha256' could not be created.");
     }
@@ -181,9 +184,10 @@ public class JreCacheTests
         directoryWrapper.Exists(sha).Returns(true);
         var fileWrapper = Substitute.For<IFileWrapper>();
         fileWrapper.Exists($@"{sha}\filename.tar.gz").Returns(true);
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", "sha256", "javaPath"), () => throw new NotSupportedException("Unreachable"));
         result.Should().BeOfType<JreCacheFailure>().Which.Message.Should().Be(@"NotImplemented. The JRE is downloaded, but we still need to check, unpack, and set permissions.");
+        testLogger.AssertDebugLogged(@"The Java Runtime Environment was already downloaded from the server and stored at 'C:\Users\user\.sonar\cache\sha256\filename.tar.gz'.");
     }
 
     [TestMethod]
@@ -202,7 +206,7 @@ public class JreCacheTests
         var fileContentStream = new MemoryStream(fileContentArray, writable: true);
         string tempFileName = null;
         fileWrapper.Create(Arg.Do<string>(x => tempFileName = x)).Returns(fileContentStream);
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", "sha256", "javaPath"), () => Task.FromResult<Stream>(new MemoryStream(downloadContentArray)));
         result.Should().BeOfType<JreCacheFailure>().Which.Message.Should().Be(@"NotImplemented. The JRE is downloaded, but we still need to check, unpack, and set permissions.");
         fileWrapper.Received().Create(tempFileName);
@@ -210,6 +214,7 @@ public class JreCacheTests
         fileContentArray.Should().BeEquivalentTo(downloadContentArray);
         var streamAccess = () => fileContentStream.Position;
         streamAccess.Should().Throw<ObjectDisposedException>("FileStream should be closed after success.");
+        testLogger.AssertDebugLogged(@"Starting the Java Runtime Environment download.");
     }
 
     [TestMethod]
@@ -223,7 +228,7 @@ public class JreCacheTests
         var directoryWrapper = DirectoryWrapper.Instance; // Do real I/O operations in this test and only fake the download.
         var fileWrapper = FileWrapper.Instance;
         var downloadContentArray = new byte[] { 1, 2, 3 };
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         try
         {
             var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", sha, "javaPath"), () => Task.FromResult<Stream>(new MemoryStream(downloadContentArray)));
@@ -294,7 +299,7 @@ public class JreCacheTests
         string tempFileName = null;
         var exception = (Exception)Activator.CreateInstance(exceptionType);
         fileWrapper.Create(Arg.Do<string>(x => tempFileName = x)).Throws(exception);
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", "sha256", "javaPath"), () => throw new NotSupportedException("Unreachable"));
         result.Should().BeOfType<JreCacheFailure>().Which.Message.Should().Be(
             $"The download of the Java runtime environment from the server failed with the exception '{exception.Message}'.");
@@ -318,7 +323,7 @@ public class JreCacheTests
         string tempFileName = null;
         fileWrapper.Create(Arg.Do<string>(x => tempFileName = x)).Returns(new MemoryStream());
         fileWrapper.When(x => x.Delete(Arg.Is<string>(x => x == tempFileName))).Do(x => throw ((Exception)Activator.CreateInstance(exceptionType)));
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", "sha256", "javaPath"), () => throw new InvalidOperationException("Download failure simulation."));
         result.Should().BeOfType<JreCacheFailure>().Which.Message.Should().Be("The download of the Java runtime environment from the server failed with the " +
             "exception 'Download failure simulation.'."); // The exception from the failed temp file delete is not visible to the user.
@@ -342,7 +347,7 @@ public class JreCacheTests
         fileStream.When(x => x.Close()).Throw(x => new ObjectDisposedException("stream"));
         string tempFileName = null;
         fileWrapper.Create(Arg.Do<string>(x => tempFileName = x)).Returns(fileStream);
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", "sha256", "javaPath"), () => throw new InvalidOperationException("Download failure simulation."));
         result.Should().BeOfType<JreCacheFailure>().Which.Message.Should().Be("The download of the Java runtime environment from the server failed with the exception " +
             "'Cannot access a disposed object.\r\nObject name: 'stream'.'."); // This should actually read "Download failure simulation." because the ObjectDisposedException is actually swallowed.
@@ -370,7 +375,7 @@ public class JreCacheTests
         var fileContentStream = new MemoryStream();
         string tempFileName = null;
         fileWrapper.Create(Arg.Do<string>(x => tempFileName = x)).Returns(fileContentStream);
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", "sha256", "javaPath"), () => throw new InvalidOperationException("Download failure simulation."));
         result.Should().BeOfType<JreCacheFailure>().Which.Message.Should().Be("The download of the Java runtime environment from the server failed with the exception 'Download failure simulation.'.");
         fileWrapper.Received().Create(tempFileName);
@@ -399,7 +404,7 @@ public class JreCacheTests
         fileWrapper.Create(Arg.Do<string>(x => tempFileName = x)).Returns(fileContentStream);
         var exception = (Exception)Activator.CreateInstance(exceptionType);
         fileWrapper.When(x => x.Move(Arg.Is<string>(x => x == tempFileName), file)).Throw(exception);
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", "sha256", "javaPath"), () => Task.FromResult<Stream>(new MemoryStream([1, 2, 3])));
         result.Should().BeOfType<JreCacheFailure>().Which.Message.Should().Be($"The download of the Java runtime environment from the server failed with the exception '{exception.Message}'.");
         fileWrapper.Received().Create(tempFileName);
@@ -426,9 +431,12 @@ public class JreCacheTests
         // The second call to fileWrapper.Exists returns true and therefore and we want to continue with provisioning.
         fileWrapper.Exists(file).Returns(false, true);
         fileWrapper.When(x => x.Create(Arg.Any<string>())).Throw<IOException>(); // Fail the download somehow.
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", "sha256", "javaPath"), () => throw new NotSupportedException("Unreachable"));
         // The download failed, but we still progress with the provisioning because somehow magically the file is there anyway.
         result.Should().BeOfType<JreCacheFailure>().Which.Message.Should().Be("NotImplemented. The JRE is downloaded, but we still need to check, unpack, and set permissions.");
+        testLogger.AssertDebugLogged(@"Starting the Java Runtime Environment download.");
+        testLogger.AssertDebugLogged(@"The download of the Java runtime environment from the server failed with the exception 'I/O error occurred.'.");
+        testLogger.AssertDebugLogged(@"The Java Runtime Environment archive was found after the download failed. Another scanner did the download in the parallel.");
     }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreCaching/JreCacheTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreCaching/JreCacheTests.cs
@@ -261,7 +261,7 @@ public class JreCacheTests
         var file = $@"{jre}\filename.tar.gz";
         var directoryWrapper = DirectoryWrapper.Instance; // Do real I/O operations in this test and only fake the download.
         var fileWrapper = FileWrapper.Instance;
-        var sut = new JreCache(directoryWrapper, fileWrapper);
+        var sut = new JreCache(testLogger, directoryWrapper, fileWrapper);
         try
         {
             var result = await sut.DownloadJreAsync(home, new("filename.tar.gz", sha, "javaPath"), () => throw new InvalidOperationException("Download failure simulation."));

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -523,6 +523,24 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Java Runtime Environment was already downloaded from the server and stored at &apos;{0}&apos;..
+        /// </summary>
+        internal static string MSG_JreAlreadyDownloaded {
+            get {
+                return ResourceManager.GetString("MSG_JreAlreadyDownloaded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The Java Runtime Environment archive was found after the download failed. Another scanner did the download in the parallel..
+        /// </summary>
+        internal static string MSG_JreFoundAfterFailedDownload {
+            get {
+                return ResourceManager.GetString("MSG_JreFoundAfterFailedDownload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cache data is empty. A full analysis will be performed..
         /// </summary>
         internal static string MSG_NoCacheData {
@@ -636,6 +654,15 @@ namespace SonarScanner.MSBuild.PreProcessor {
         internal static string MSG_SonarCloudDetected_SkipVersionCheck {
             get {
                 return ResourceManager.GetString("MSG_SonarCloudDetected_SkipVersionCheck", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Starting the Java Runtime Environment download..
+        /// </summary>
+        internal static string MSG_StartingJreDownload {
+            get {
+                return ResourceManager.GetString("MSG_StartingJreDownload", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -378,4 +378,13 @@ Use '/?' or '/h' to see the help message.</value>
   <data name="ERR_JreDownloadFailed" xml:space="preserve">
     <value>The download of the Java runtime environment from the server failed with the exception '{0}'.</value>
   </data>
+  <data name="MSG_JreAlreadyDownloaded" xml:space="preserve">
+    <value>The Java Runtime Environment was already downloaded from the server and stored at '{0}'.</value>
+  </data>
+  <data name="MSG_JreFoundAfterFailedDownload" xml:space="preserve">
+    <value>The Java Runtime Environment archive was found after the download failed. Another scanner did the download in the parallel.</value>
+  </data>
+  <data name="MSG_StartingJreDownload" xml:space="preserve">
+    <value>Starting the Java Runtime Environment download.</value>
+  </data>
 </root>


### PR DESCRIPTION
Adds logging to JreCache.
Based on #2011