### PR TITLE
Add support for JRE provisioning: JreResolver

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreCaching/JreResolverTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreCaching/JreResolverTests.cs
@@ -1,0 +1,200 @@
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using SonarScanner.MSBuild.Common;
+using SonarScanner.MSBuild.PreProcessor.JreCaching;
+using TestUtilities;
+
+namespace SonarScanner.MSBuild.PreProcessor.Test.JreCaching;
+
+[TestClass]
+public class JreResolverTests
+{
+    private readonly string sonarUserHome = "sonarUserHome";
+    private readonly TestLogger logger = new TestLogger();
+    // For ProcessedArgs
+    private readonly IFileWrapper fileWrapper = Substitute.For<IFileWrapper>();
+    private readonly ListPropertiesProvider provider = new ListPropertiesProvider();
+    // For JreResolver
+    private readonly ISonarWebServer server = Substitute.For<ISonarWebServer>();
+    private readonly IJreCache cache = Substitute.For<IJreCache>();
+    private readonly JreMetadata metadata = new JreMetadata(null, null, null, null, null);
+
+    private IJreResolver sut;
+
+    private ProcessedArgs Args =>
+        new("valid.key",
+            "valid.name",
+            "1.0",
+            "organization",
+            false,
+            provider,
+            EmptyPropertyProvider.Instance,
+            EmptyPropertyProvider.Instance,
+            fileWrapper,
+            Substitute.For<IOperatingSystemProvider>(),
+            logger);
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        sut = new JreResolver(server, cache, logger);
+        server
+            .DownloadJreMetadataAsync(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.FromResult(metadata));
+    }
+
+    [TestMethod]
+    public async Task ResolveJrePath_JavaExePathSet()
+    {
+        provider.AddProperty("sonar.scanner.javaExePath", "path");
+        fileWrapper.Exists("path").Returns(true);
+
+        var res = await sut.ResolveJrePath(Args, sonarUserHome);
+
+        res.Should().BeNull();
+        logger.AssertDebugLogged("JreResolver: Resolving JRE path.");
+        logger.AssertDebugLogged("JreResolver: JavaExePath is set, skipping JRE provisioning.");
+    }
+
+    [TestMethod]
+    public async Task ResolveJrePath_SkipProvisioningSet()
+    {
+        provider.AddProperty("sonar.scanner.skipJreProvisioning", "True");
+
+        var res = await sut.ResolveJrePath(Args, sonarUserHome);
+
+        res.Should().BeNull();
+        logger.AssertDebugLogged("JreResolver: Resolving JRE path.");
+        logger.AssertDebugLogged("JreResolver: SkipJreProvisioning is set, skipping JRE provisioning.");
+    }
+
+    [TestMethod]
+    public async Task ResolveJrePath_ArchitectureEmpty()
+    {
+        provider.AddProperty("sonar.scanner.arch", string.Empty);
+
+        var res = await sut.ResolveJrePath(Args, sonarUserHome);
+
+        res.Should().BeNull();
+        logger.AssertDebugLogged("JreResolver: Resolving JRE path.");
+        logger.AssertDebugLogged("JreResolver: Architecture is not set or detected, skipping JRE provisioning.");
+    }
+
+    [TestMethod]
+    public async Task ResolveJrePath_OperatingSystemEmpty()
+    {
+        provider.AddProperty("sonar.scanner.os", string.Empty);
+
+        var res = await sut.ResolveJrePath(Args, sonarUserHome);
+
+        res.Should().BeNull();
+        logger.AssertDebugLogged("JreResolver: Resolving JRE path.");
+        logger.AssertDebugLogged("JreResolver: Operating System is not set or detected, skipping JRE provisioning.");
+    }
+
+    [TestMethod]
+    public async Task ResolveJrePath_MetadataNotFound()
+    {
+        server
+            .DownloadJreMetadataAsync(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.FromResult<JreMetadata>(null));
+
+        var res = await sut.ResolveJrePath(Args, sonarUserHome);
+
+        res.Should().BeNull();
+        logger.AssertDebugLogged("JreResolver: Resolving JRE path.");
+        logger.AssertDebugLogged("JreResolver: Metadata could not be retrieved.");
+    }
+
+    [TestMethod]
+    public async Task ResolveJrePath_IsJreCached_CacheFailure()
+    {
+        cache
+            .IsJreCached(sonarUserHome, Arg.Any<JreDescriptor>())
+            .Returns(new JreCacheFailure("failure"));
+
+        var res = await sut.ResolveJrePath(Args, sonarUserHome);
+
+        res.Should().BeNull();
+        logger.AssertDebugLogged("JreResolver: Resolving JRE path.");
+        logger.AssertDebugLogged("JreResolver: Exiting early due to cache failure.");
+    }
+
+    [TestMethod]
+    public async Task ResolveJrePath_IsJreCached_CacheHit()
+    {
+        cache
+            .IsJreCached(sonarUserHome, Arg.Any<JreDescriptor>())
+            .Returns(new JreCacheHit("path"));
+
+        var res = await sut.ResolveJrePath(Args, sonarUserHome);
+
+        res.Should().Be("path");
+        logger.AssertDebugLogged("JreResolver: Resolving JRE path.");
+        logger.AssertDebugLogged("JreResolver: Cache hit 'path'.");
+    }
+
+    [TestMethod]
+    public async Task ResolveJrePath_IsJreCached_CacheMiss_DownloadSuccess()
+    {
+        cache
+            .IsJreCached(sonarUserHome, Arg.Any<JreDescriptor>())
+            .Returns(new JreCacheMiss());
+
+        cache
+            .DownloadJreAsync(sonarUserHome, Arg.Any<JreDescriptor>(), Arg.Any<Func<Task<Stream>>>())
+            .Returns(new JreCacheHit("path"));
+
+        var res = await sut.ResolveJrePath(Args, sonarUserHome);
+
+        res.Should().Be("path");
+        logger.AssertDebugLogged("JreResolver: Resolving JRE path.");
+        logger.AssertDebugLogged("JreResolver: Cache miss.");
+        logger.AssertDebugLogged("JreResolver: Attempting to download JRE.");
+        logger.AssertDebugLogged("JreResolver: Download successful. JRE can be found at 'path'.");
+    }
+
+    [TestMethod]
+    public async Task ResolveJrePath_IsJreCached_CacheMiss_DownloadFailure()
+    {
+        cache
+            .IsJreCached(sonarUserHome, Arg.Any<JreDescriptor>())
+            .Returns(new JreCacheMiss());
+
+        cache
+            .DownloadJreAsync(sonarUserHome, Arg.Any<JreDescriptor>(), Arg.Any<Func<Task<Stream>>>())
+            .Returns(new JreCacheMiss());
+
+        var res = await sut.ResolveJrePath(Args, sonarUserHome);
+
+        res.Should().BeNull();
+        logger.AssertDebugLogged("JreResolver: Resolving JRE path.");
+        logger.AssertDebugLogged("JreResolver: Cache miss.");
+        logger.AssertDebugLogged("JreResolver: Attempting to download JRE.");
+        logger.AssertDebugLogged("JreResolver: Attempting to download JRE. Retrying...");
+    }
+}

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreCaching/JreResolverTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreCaching/JreResolverTests.cs
@@ -35,12 +35,12 @@ public class JreResolverTests
 {
     private const string SonarUserHome = "sonarUserHome";
 
-    private readonly TestLogger logger = new();
     private readonly IFileWrapper fileWrapper = Substitute.For<IFileWrapper>();
     private readonly JreMetadata metadata = new(null, null, null, null, null);
 
     private ListPropertiesProvider provider;
     private IJreCache cache;
+    private TestLogger logger;
     private ISonarWebServer server;
     private IJreResolver sut;
 
@@ -61,7 +61,9 @@ public class JreResolverTests
     public void Initialize()
     {
         provider = new();
+        provider.AddProperty("sonar.scanner.os", "linux");
         cache = Substitute.For<IJreCache>();
+        logger = new TestLogger();
         server = Substitute.For<ISonarWebServer>();
         server
             .DownloadJreMetadataAsync(Arg.Any<string>(), Arg.Any<string>())
@@ -116,6 +118,7 @@ public class JreResolverTests
     [TestMethod]
     public async Task ResolveJrePath_OperatingSystemEmpty()
     {
+        provider = new();
         provider.AddProperty("sonar.scanner.os", string.Empty);
 
         var res = await sut.ResolveJrePath(Args, SonarUserHome);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
@@ -357,7 +357,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
         [DataRow(PlatformOS.MacOSX, "macos")]
         [DataRow(PlatformOS.Alpine, "alpine")]
         [DataRow(PlatformOS.Linux, "linux")]
-        [DataRow(PlatformOS.Unknown, "unknown")]
+        [DataRow(PlatformOS.Unknown, null)]
         public void ProcArgs_OperatingSystem_AutoDetection(PlatformOS platformOS, string expectedOperatingSystem)
         {
             var operatingSystemProvider = Substitute.For<IOperatingSystemProvider>();

--- a/src/SonarScanner.MSBuild.PreProcessor/JreCaching/IJreResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreCaching/IJreResolver.cs
@@ -18,18 +18,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarScanner.MSBuild.PreProcessor.JreCaching;
+using System.Threading.Tasks;
 
-namespace SonarScanner.MSBuild.PreProcessor;
+namespace SonarScanner.MSBuild.PreProcessor.JreCaching;
 
-public sealed class JreMetadata(string Id, string Filename, string JavaPath, string DownloadUrl, string Sha256)
+internal interface IJreResolver
 {
-    public string Id { get; } = Id;                     // Optional, only exists for SonarQube
-    public string Filename { get; } = Filename;
-    public string Sha256 { get; } = Sha256;
-    public string JavaPath { get; } = JavaPath;
-    public string DownloadUrl { get; } = DownloadUrl;   // Optional, only exists for SonarCloud
-
-    public JreDescriptor ToDescriptor() =>
-        new(Filename, Sha256, JavaPath);
+    Task<string> ResolveJrePath(ProcessedArgs args, string sonarUserHome);
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/JreCaching/JreResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreCaching/JreResolver.cs
@@ -27,10 +27,6 @@ namespace SonarScanner.MSBuild.PreProcessor.JreCaching;
 // https://xtranet-sonarsource.atlassian.net/wiki/spaces/LANG/pages/3155001372/Scanner+Bootstrapping
 internal class JreResolver(ISonarWebServer server, IJreCache cache, ILogger logger) : IJreResolver
 {
-    private readonly ISonarWebServer server = server;
-    private readonly IJreCache cache = cache;
-    private readonly ILogger logger = logger;
-
     public async Task<string> ResolveJrePath(ProcessedArgs args, string sonarUserHome)
     {
         logger.LogDebug(Resources.MSG_JreResolver_Resolving, string.Empty);

--- a/src/SonarScanner.MSBuild.PreProcessor/JreCaching/JreResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreCaching/JreResolver.cs
@@ -1,0 +1,116 @@
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using System.Threading.Tasks;
+using SonarScanner.MSBuild.Common;
+
+namespace SonarScanner.MSBuild.PreProcessor.JreCaching;
+
+// https://xtranet-sonarsource.atlassian.net/wiki/spaces/LANG/pages/3155001372/Scanner+Bootstrapping
+internal class JreResolver : IJreResolver
+{
+    private readonly ISonarWebServer server;
+    private readonly IJreCache cache;
+    private readonly ILogger logger;
+
+    public JreResolver(ISonarWebServer server, IJreCache cache, ILogger logger)
+    {
+        this.server = server;
+        this.cache = cache;
+        this.logger = logger;
+    }
+
+    public async Task<string> ResolveJrePath(ProcessedArgs args, string sonarUserHome)
+    {
+        logger.LogDebug(Resources.MSG_JreResolver_Starting);
+        if (!IsValid(args))
+        {
+            return null;
+        }
+
+        var metadata = await server.DownloadJreMetadataAsync(args.OperatingSystem, args.Architecture);
+        if (metadata is null)
+        {
+            logger.LogDebug(Resources.MSG_JreResolver_MetadataFailure);
+            return null;
+        }
+
+        var descriptor = metadata.ToDescriptor();
+        var isCachedResult = cache.IsJreCached(sonarUserHome, descriptor);
+        switch (isCachedResult)
+        {
+            case JreCacheHit hit:
+                logger.LogDebug(Resources.MSG_JreResolver_CacheHit, hit.JavaExe);
+                return hit.JavaExe;
+            case JreCacheMiss:
+                logger.LogDebug(Resources.MSG_JreResolver_CacheMiss);
+                return await DownloadJre(sonarUserHome, metadata, descriptor);
+            case JreCacheFailure:
+                logger.LogDebug(Resources.MSG_JreResolver_CacheFailure);
+                return null;
+        }
+
+        return null;
+    }
+
+    private async Task<string> DownloadJre(string sonarUserHome, JreMetadata metadata, JreDescriptor descriptor, bool retry = true)
+    {
+        var retrying = retry ? string.Empty : " Retrying...";
+        logger.LogDebug(Resources.MSG_JreResolver_DownloadAttempt, retrying);
+        var result = await cache.DownloadJreAsync(sonarUserHome, descriptor, () => server.DownloadJreAsync(metadata));
+        switch (result)
+        {
+            case JreCacheHit hit:
+                logger.LogDebug(Resources.MSG_JreResolver_DownloadSuccess, hit.JavaExe);
+                return hit.JavaExe;
+            default:
+                return retry
+                ? await DownloadJre(sonarUserHome, metadata, descriptor, false)
+                : null;
+        }
+    }
+
+    private bool IsValid(ProcessedArgs args)
+    {
+        if (!string.IsNullOrWhiteSpace(args.JavaExePath))
+        {
+            logger.LogDebug(Resources.MSG_JreResolver_JavaExePathSet);
+            return false;
+        }
+        if (args.SkipJreProvisioning)
+        {
+            logger.LogDebug(Resources.MSG_JreResolver_SkipJreProvisioningSet);
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(args.OperatingSystem))
+        {
+            logger.LogDebug(Resources.MSG_JreResolver_OperatingSystemMissing);
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(args.Architecture))
+        {
+            logger.LogDebug(Resources.MSG_JreResolver_ArchitectureMissing);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -54,7 +54,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             }
             webDownloader ??= CreateDownloader(args.ServerInfo.ServerUrl);
             apiDownloader ??= CreateDownloader(args.ServerInfo.ApiBaseUrl);
-            var jreCache = new JreCache(logger, DirectoryWrapper.Instance, FileWrapper.Instance);
+            var jreCache = new JreCache(logger, DirectoryWrapper.Instance, FileWrapper.Instance, ChecksumSha256.Instance);
 
             var serverVersion = await QueryServerVersion(apiDownloader, webDownloader);
             if (!ValidateServerVersion(args.ServerInfo, serverVersion))

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -21,7 +21,6 @@
 using System;
 using System.Threading.Tasks;
 using SonarScanner.MSBuild.Common;
-using SonarScanner.MSBuild.PreProcessor.JreCaching;
 using SonarScanner.MSBuild.PreProcessor.Roslyn;
 using SonarScanner.MSBuild.PreProcessor.WebServer;
 
@@ -54,7 +53,6 @@ namespace SonarScanner.MSBuild.PreProcessor
             }
             webDownloader ??= CreateDownloader(args.ServerInfo.ServerUrl);
             apiDownloader ??= CreateDownloader(args.ServerInfo.ApiBaseUrl);
-            var jreCache = new JreCache(logger, DirectoryWrapper.Instance, FileWrapper.Instance, ChecksumSha256.Instance);
 
             var serverVersion = await QueryServerVersion(apiDownloader, webDownloader);
             if (!ValidateServerVersion(args.ServerInfo, serverVersion))
@@ -68,9 +66,9 @@ namespace SonarScanner.MSBuild.PreProcessor
                     logger.LogError(Resources.ERR_MissingOrganization);
                     return null;
                 }
-                return new SonarCloudWebServer(webDownloader, apiDownloader, jreCache, serverVersion, logger, args.Organization, args.HttpTimeout);
+                return new SonarCloudWebServer(webDownloader, apiDownloader, serverVersion, logger, args.Organization, args.HttpTimeout);
             }
-            return new SonarQubeWebServer(webDownloader, apiDownloader, jreCache, serverVersion, logger, args.Organization);
+            return new SonarQubeWebServer(webDownloader, apiDownloader, serverVersion, logger, args.Organization);
 
             IDownloader CreateDownloader(string baseUrl) =>
                 new WebClientDownloaderBuilder(baseUrl, args.HttpTimeout, logger)

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Threading.Tasks;
 using SonarScanner.MSBuild.Common;
+using SonarScanner.MSBuild.PreProcessor.JreCaching;
 using SonarScanner.MSBuild.PreProcessor.Roslyn;
 using SonarScanner.MSBuild.PreProcessor.WebServer;
 
@@ -53,6 +54,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             }
             webDownloader ??= CreateDownloader(args.ServerInfo.ServerUrl);
             apiDownloader ??= CreateDownloader(args.ServerInfo.ApiBaseUrl);
+            var jreCache = new JreCache(logger, DirectoryWrapper.Instance, FileWrapper.Instance);
 
             var serverVersion = await QueryServerVersion(apiDownloader, webDownloader);
             if (!ValidateServerVersion(args.ServerInfo, serverVersion))
@@ -66,9 +68,9 @@ namespace SonarScanner.MSBuild.PreProcessor
                     logger.LogError(Resources.ERR_MissingOrganization);
                     return null;
                 }
-                return new SonarCloudWebServer(webDownloader, apiDownloader, serverVersion, logger, args.Organization, args.HttpTimeout);
+                return new SonarCloudWebServer(webDownloader, apiDownloader, jreCache, serverVersion, logger, args.Organization, args.HttpTimeout);
             }
-            return new SonarQubeWebServer(webDownloader, apiDownloader, serverVersion, logger, args.Organization);
+            return new SonarQubeWebServer(webDownloader, apiDownloader, jreCache, serverVersion, logger, args.Organization);
 
             IDownloader CreateDownloader(string baseUrl) =>
                 new WebClientDownloaderBuilder(baseUrl, args.HttpTimeout, logger)

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -222,7 +222,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                       PlatformOS.MacOSX => "macos",
                       PlatformOS.Alpine => "alpine",
                       PlatformOS.Linux => "linux",
-                      _ => "unknown"
+                      _ => null
                   };
 
         private bool CheckOrganizationValidity(ILogger logger)

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -595,7 +595,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to JreResolver: Architecture is not set or detected, skipping JRE provisioning..
+        ///   Looks up a localized string similar to JreResolver: sonar.scanner.arch is not set or detected, skipping JRE provisioning..
         /// </summary>
         internal static string MSG_JreResolver_ArchitectureMissing {
             get {
@@ -649,7 +649,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to JreResolver: JavaExePath is set, skipping JRE provisioning..
+        ///   Looks up a localized string similar to JreResolver: sonar.scanner.javaExePath is set, skipping JRE provisioning..
         /// </summary>
         internal static string MSG_JreResolver_JavaExePathSet {
             get {
@@ -667,7 +667,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to JreResolver: Operating System is not set or detected, skipping JRE provisioning..
+        ///   Looks up a localized string similar to JreResolver: sonar.scanner.os is not set or detected, skipping JRE provisioning..
         /// </summary>
         internal static string MSG_JreResolver_OperatingSystemMissing {
             get {
@@ -685,7 +685,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to JreResolver: SkipJreProvisioning is set, skipping JRE provisioning..
+        ///   Looks up a localized string similar to JreResolver: sonar.scanner.skipJreProvisioning is set, skipping JRE provisioning..
         /// </summary>
         internal static string MSG_JreResolver_SkipJreProvisioningSet {
             get {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -604,7 +604,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to JreResolver: Exiting early due to cache failure..
+        ///   Looks up a localized string similar to JreResolver: Cache failure. {0}.
         /// </summary>
         internal static string MSG_JreResolver_CacheFailure {
             get {
@@ -622,7 +622,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to JreResolver: Cache miss..
+        ///   Looks up a localized string similar to JreResolver: Cache miss. Attempting to download JRE..
         /// </summary>
         internal static string MSG_JreResolver_CacheMiss {
             get {
@@ -631,16 +631,16 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to JreResolver: Attempting to download JRE.{0}.
+        ///   Looks up a localized string similar to JreResolver: Download failure. {0}.
         /// </summary>
-        internal static string MSG_JreResolver_DownloadAttempt {
+        internal static string MSG_JreResolver_DownloadFailure {
             get {
-                return ResourceManager.GetString("MSG_JreResolver_DownloadAttempt", resourceCulture);
+                return ResourceManager.GetString("MSG_JreResolver_DownloadFailure", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to JreResolver: Download successful. JRE can be found at &apos;{0}&apos;..
+        ///   Looks up a localized string similar to JreResolver: Download success. JRE can be found at &apos;{0}&apos;..
         /// </summary>
         internal static string MSG_JreResolver_DownloadSuccess {
             get {
@@ -676,20 +676,20 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to JreResolver: Resolving JRE path.{0}.
+        /// </summary>
+        internal static string MSG_JreResolver_Resolving {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_Resolving", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to JreResolver: SkipJreProvisioning is set, skipping JRE provisioning..
         /// </summary>
         internal static string MSG_JreResolver_SkipJreProvisioningSet {
             get {
                 return ResourceManager.GetString("MSG_JreResolver_SkipJreProvisioningSet", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to JreResolver: Resolving JRE path..
-        /// </summary>
-        internal static string MSG_JreResolver_Starting {
-            get {
-                return ResourceManager.GetString("MSG_JreResolver_Starting", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -595,6 +595,105 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to JreResolver: Architecture is not set or detected, skipping JRE provisioning..
+        /// </summary>
+        internal static string MSG_JreResolver_ArchitectureMissing {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_ArchitectureMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JreResolver: Exiting early due to cache failure..
+        /// </summary>
+        internal static string MSG_JreResolver_CacheFailure {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_CacheFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JreResolver: Cache hit &apos;{0}&apos;..
+        /// </summary>
+        internal static string MSG_JreResolver_CacheHit {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_CacheHit", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JreResolver: Cache miss..
+        /// </summary>
+        internal static string MSG_JreResolver_CacheMiss {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_CacheMiss", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JreResolver: Attempting to download JRE.{0}.
+        /// </summary>
+        internal static string MSG_JreResolver_DownloadAttempt {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_DownloadAttempt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JreResolver: Download successful. JRE can be found at &apos;{0}&apos;..
+        /// </summary>
+        internal static string MSG_JreResolver_DownloadSuccess {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_DownloadSuccess", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JreResolver: JavaExePath is set, skipping JRE provisioning..
+        /// </summary>
+        internal static string MSG_JreResolver_JavaExePathSet {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_JavaExePathSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JreResolver: Metadata could not be retrieved..
+        /// </summary>
+        internal static string MSG_JreResolver_MetadataFailure {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_MetadataFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JreResolver: Operating System is not set or detected, skipping JRE provisioning..
+        /// </summary>
+        internal static string MSG_JreResolver_OperatingSystemMissing {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_OperatingSystemMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JreResolver: SkipJreProvisioning is set, skipping JRE provisioning..
+        /// </summary>
+        internal static string MSG_JreResolver_SkipJreProvisioningSet {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_SkipJreProvisioningSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to JreResolver: Resolving JRE path..
+        /// </summary>
+        internal static string MSG_JreResolver_Starting {
+            get {
+                return ResourceManager.GetString("MSG_JreResolver_Starting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cache data is empty. A full analysis will be performed..
         /// </summary>
         internal static string MSG_NoCacheData {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -421,16 +421,13 @@ Use '/?' or '/h' to see the help message.</value>
     <value>JreResolver: Architecture is not set or detected, skipping JRE provisioning.</value>
   </data>
   <data name="MSG_JreResolver_CacheFailure" xml:space="preserve">
-    <value>JreResolver: Exiting early due to cache failure.</value>
+    <value>JreResolver: Cache failure. {0}</value>
   </data>
   <data name="MSG_JreResolver_CacheHit" xml:space="preserve">
     <value>JreResolver: Cache hit '{0}'.</value>
   </data>
   <data name="MSG_JreResolver_CacheMiss" xml:space="preserve">
-    <value>JreResolver: Cache miss.</value>
-  </data>
-  <data name="MSG_JreResolver_DownloadAttempt" xml:space="preserve">
-    <value>JreResolver: Attempting to download JRE.{0}</value>
+    <value>JreResolver: Cache miss. Attempting to download JRE.</value>
   </data>
   <data name="MSG_JreResolver_JavaExePathSet" xml:space="preserve">
     <value>JreResolver: JavaExePath is set, skipping JRE provisioning.</value>
@@ -444,10 +441,13 @@ Use '/?' or '/h' to see the help message.</value>
   <data name="MSG_JreResolver_SkipJreProvisioningSet" xml:space="preserve">
     <value>JreResolver: SkipJreProvisioning is set, skipping JRE provisioning.</value>
   </data>
-  <data name="MSG_JreResolver_Starting" xml:space="preserve">
-    <value>JreResolver: Resolving JRE path.</value>
+  <data name="MSG_JreResolver_Resolving" xml:space="preserve">
+    <value>JreResolver: Resolving JRE path.{0}</value>
   </data>
   <data name="MSG_JreResolver_DownloadSuccess" xml:space="preserve">
-    <value>JreResolver: Download successful. JRE can be found at '{0}'.</value>
+    <value>JreResolver: Download success. JRE can be found at '{0}'.</value>
+  </data>
+  <data name="MSG_JreResolver_DownloadFailure" xml:space="preserve">
+    <value>JreResolver: Download failure. {0}</value>
   </data>
 </root>

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -418,7 +418,7 @@ Use '/?' or '/h' to see the help message.</value>
     <value>Downloading Java JRE from {0}.</value>
   </data>
   <data name="MSG_JreResolver_ArchitectureMissing" xml:space="preserve">
-    <value>JreResolver: Architecture is not set or detected, skipping JRE provisioning.</value>
+    <value>JreResolver: sonar.scanner.arch is not set or detected, skipping JRE provisioning.</value>
   </data>
   <data name="MSG_JreResolver_CacheFailure" xml:space="preserve">
     <value>JreResolver: Cache failure. {0}</value>
@@ -430,16 +430,16 @@ Use '/?' or '/h' to see the help message.</value>
     <value>JreResolver: Cache miss. Attempting to download JRE.</value>
   </data>
   <data name="MSG_JreResolver_JavaExePathSet" xml:space="preserve">
-    <value>JreResolver: JavaExePath is set, skipping JRE provisioning.</value>
+    <value>JreResolver: sonar.scanner.javaExePath is set, skipping JRE provisioning.</value>
   </data>
   <data name="MSG_JreResolver_MetadataFailure" xml:space="preserve">
     <value>JreResolver: Metadata could not be retrieved.</value>
   </data>
   <data name="MSG_JreResolver_OperatingSystemMissing" xml:space="preserve">
-    <value>JreResolver: Operating System is not set or detected, skipping JRE provisioning.</value>
+    <value>JreResolver: sonar.scanner.os is not set or detected, skipping JRE provisioning.</value>
   </data>
   <data name="MSG_JreResolver_SkipJreProvisioningSet" xml:space="preserve">
-    <value>JreResolver: SkipJreProvisioning is set, skipping JRE provisioning.</value>
+    <value>JreResolver: sonar.scanner.skipJreProvisioning is set, skipping JRE provisioning.</value>
   </data>
   <data name="MSG_JreResolver_Resolving" xml:space="preserve">
     <value>JreResolver: Resolving JRE path.{0}</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -417,4 +417,37 @@ Use '/?' or '/h' to see the help message.</value>
   <data name="MSG_JreDownloadUri" xml:space="preserve">
     <value>Downloading Java JRE from {0}.</value>
   </data>
+  <data name="MSG_JreResolver_ArchitectureMissing" xml:space="preserve">
+    <value>JreResolver: Architecture is not set or detected, skipping JRE provisioning.</value>
+  </data>
+  <data name="MSG_JreResolver_CacheFailure" xml:space="preserve">
+    <value>JreResolver: Exiting early due to cache failure.</value>
+  </data>
+  <data name="MSG_JreResolver_CacheHit" xml:space="preserve">
+    <value>JreResolver: Cache hit '{0}'.</value>
+  </data>
+  <data name="MSG_JreResolver_CacheMiss" xml:space="preserve">
+    <value>JreResolver: Cache miss.</value>
+  </data>
+  <data name="MSG_JreResolver_DownloadAttempt" xml:space="preserve">
+    <value>JreResolver: Attempting to download JRE.{0}</value>
+  </data>
+  <data name="MSG_JreResolver_JavaExePathSet" xml:space="preserve">
+    <value>JreResolver: JavaExePath is set, skipping JRE provisioning.</value>
+  </data>
+  <data name="MSG_JreResolver_MetadataFailure" xml:space="preserve">
+    <value>JreResolver: Metadata could not be retrieved.</value>
+  </data>
+  <data name="MSG_JreResolver_OperatingSystemMissing" xml:space="preserve">
+    <value>JreResolver: Operating System is not set or detected, skipping JRE provisioning.</value>
+  </data>
+  <data name="MSG_JreResolver_SkipJreProvisioningSet" xml:space="preserve">
+    <value>JreResolver: SkipJreProvisioning is set, skipping JRE provisioning.</value>
+  </data>
+  <data name="MSG_JreResolver_Starting" xml:space="preserve">
+    <value>JreResolver: Resolving JRE path.</value>
+  </data>
+  <data name="MSG_JreResolver_DownloadSuccess" xml:space="preserve">
+    <value>JreResolver: Download successful. JRE can be found at '{0}'.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #2027

Next PR will make use of the resolver in the `Preprocessor.Execute`