### PR TITLE
CI: Fix the cfamily plugin version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -410,13 +410,13 @@ stages:
             msbuild17_latest:
               PRODUCT: "SonarQube"
               SQ_VERSION: "LATEST_RELEASE"
-              SONAR_CFAMILYPLUGIN_VERSION: "LATEST_RELEASE"
+              SONAR_CFAMILYPLUGIN_VERSION: "6.56.0.72172" # This should have been LATEST_RELEASE but the download fails
               MSBUILD_PATH: $(MSBUILD_17_PATH)
               TEST_INCLUDE: "**/sonarqube/*"
             msbuild17_dev:
               PRODUCT: "SonarQube"
               SQ_VERSION: "DEV"
-              SONAR_CFAMILYPLUGIN_VERSION: "LATEST_RELEASE"
+              SONAR_CFAMILYPLUGIN_VERSION: "6.56.0.72172" # This should have been LATEST_RELEASE but the download fails
               MSBUILD_PATH: $(MSBUILD_17_PATH)
               TEST_INCLUDE: "**/sonarqube/*"
             msbuild17_sonar_cloud:


### PR DESCRIPTION
The ITs are failing with the following error:

```
java.lang.IllegalStateException: Can not find the plugin [com.sonarsource.cpp:sonar-cfamily-plugin:LATEST_RELEASE:jar]
	at com.sonar.orchestrator.server.ServerInstaller.installPluginIntoDir(ServerInstaller.java:211)
	at com.sonar.orchestrator.server.ServerInstaller.copyPlugins(ServerInstaller.java:204)
	at com.sonar.orchestrator.server.ServerInstaller.copyExternalPlugins(ServerInstaller.java:188)
	at com.sonar.orchestrator.server.ServerInstaller.preparePlugins(ServerInstaller.java:113)
	at com.sonar.orchestrator.server.ServerInstaller.install(ServerInstaller.java:94)
	at com.sonar.orchestrator.Orchestrator.install(Orchestrator.java:98)
	at com.sonar.orchestrator.Orchestrator.start(Orchestrator.java:118)
	at com.sonar.it.scanner.msbuild.sonarqube.Tests.beforeAll(Tests.java:53)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```
This will unblock us until the infrastructure problem is solved.

More details can be found here: https://sonarsource.slack.com/archives/C04CVEU7734/p1720517768955869

Reversion of the PR is tracked by #2035