### PR TITLE
Small Architecture fix: Convert to lowercase

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -158,7 +158,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
         [TestMethod]
         public void PreArgProc_Architecture_NotSet() =>
-            CheckProcessingSucceeds("/k:key").Architecture.Should().Be(RuntimeInformation.OSArchitecture.ToString());
+            CheckProcessingSucceeds("/k:key").Architecture.Should().Be(RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant());
 
         [TestMethod]
         [WorkItem(102)] // http://jira.sonarsource.com/browse/SONARMSBRU-102

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
@@ -804,11 +804,11 @@ public class SonarWebServerTest
     public async Task DownloadJreMetadataAsync_Throws_Warning()
     {
         downloader
-            .When(x => x.Download("analysis/jres?os=what>&arch=ever"))
+            .When(x => x.Download("analysis/jres?os=what&arch=ever"))
             .Throw(new Exception());
 
         (await sut.DownloadJreMetadataAsync("what", "ever")).Should().BeNull();
-        logger.AssertWarningLogged("JRE Metadata could not be retrieved from analysis/jres?os=what>&arch=ever.");
+        logger.AssertWarningLogged("JRE Metadata could not be retrieved from analysis/jres?os=what&arch=ever.");
     }
 
     [DataTestMethod]
@@ -819,18 +819,18 @@ public class SonarWebServerTest
     public async Task DownloadJreMetadataAsync_ReturnsInvalid_Warning(string jresResponse)
     {
         downloader
-            .Download("analysis/jres?os=what>&arch=ever")
+            .Download("analysis/jres?os=what&arch=ever")
             .Returns(jresResponse);
 
         (await sut.DownloadJreMetadataAsync("what", "ever")).Should().BeNull();
-        logger.AssertWarningLogged("JRE Metadata could not be retrieved from analysis/jres?os=what>&arch=ever.");
+        logger.AssertWarningLogged("JRE Metadata could not be retrieved from analysis/jres?os=what&arch=ever.");
     }
 
     [TestMethod]
     public async Task DownloadJreMetadataAsync_ReturnsSingle_Success()
     {
         downloader
-            .Download("analysis/jres?os=what>&arch=ever")
+            .Download("analysis/jres?os=what&arch=ever")
             .Returns("""
             [{
                 "id": "someId",
@@ -857,7 +857,7 @@ public class SonarWebServerTest
     public async Task DownloadJreMetadataAsync_ReturnsMultiple_Success_ReturnsFirst()
     {
         downloader
-            .Download("analysis/jres?os=what>&arch=ever")
+            .Download("analysis/jres?os=what&arch=ever")
             .Returns("""
             [
                 { "id": "first" },

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -154,7 +154,7 @@ namespace SonarScanner.MSBuild.PreProcessor
             OperatingSystem = GetOperatingSystem(AggregateProperties);
             Architecture = AggregateProperties.TryGetProperty(SonarProperties.Architecture, out var architecture)
                 ? architecture.Value
-                : RuntimeInformation.OSArchitecture.ToString();
+                : RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
 
             if (AggregateProperties.TryGetProperty(SonarProperties.JavaExePath, out var javaExePath))
             {

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServer.cs
@@ -146,7 +146,7 @@ namespace SonarScanner.MSBuild.PreProcessor.WebServer
             Contract.ThrowIfNullOrWhitespace(operatingSystem, nameof(operatingSystem));
             Contract.ThrowIfNullOrWhitespace(architecture, nameof(architecture));
 
-            var uri = WebUtils.Escape("analysis/jres?os={0}>&arch={1}", operatingSystem, architecture);
+            var uri = WebUtils.Escape("analysis/jres?os={0}&arch={1}", operatingSystem, architecture);
             try
             {
                 var result = await apiDownloader.Download(uri);


### PR DESCRIPTION
The server expects architecture to be in lowercase, as in:

```
https://next.sonarqube.com/api/v2/analysis/jres?os=X64 <-- Fails
https://next.sonarqube.com/api/v2/analysis/jres?arch=x64 <-- Succeeds
```

Also fixed a small typo.