### PR TITLE
JRE Provisioning: Add ITs for SonarCloud

### DIFF
--- a/its/projects/JreProvisioning/JreProvisioning.sln
+++ b/its/projects/JreProvisioning/JreProvisioning.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JreProvisioning", "JreProvisioning\JreProvisioning.csproj", "{F23C1D62-EF53-4FD3-8C83-D8442119689E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F23C1D62-EF53-4FD3-8C83-D8442119689E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F23C1D62-EF53-4FD3-8C83-D8442119689E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F23C1D62-EF53-4FD3-8C83-D8442119689E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F23C1D62-EF53-4FD3-8C83-D8442119689E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5B5BD38E-39CA-4785-8456-B49260EADC24}
+	EndGlobalSection
+EndGlobal

--- a/its/projects/JreProvisioning/JreProvisioning/JreProvisioning.csproj
+++ b/its/projects/JreProvisioning/JreProvisioning/JreProvisioning.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/its/projects/JreProvisioning/JreProvisioning/Sample.cs
+++ b/its/projects/JreProvisioning/JreProvisioning/Sample.cs
@@ -1,0 +1,6 @@
+﻿namespace JreProvisioning
+{
+    public class Sample
+    {
+    }
+}

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/Constants.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/Constants.java
@@ -1,0 +1,29 @@
+/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.it.scanner.msbuild.sonarcloud;
+
+public class Constants {
+  public final static Integer COMMAND_TIMEOUT = 2 * 60 * 1000;
+  public final static String SCANNER_PATH = "../build/sonarscanner-net-framework/SonarScanner.MSBuild.exe";
+
+  public final static String SONARCLOUD_ORGANIZATION = System.getenv("SONARCLOUD_ORGANIZATION");
+  public final static String SONARCLOUD_URL = System.getenv("SONARCLOUD_URL");
+  public final static String SONARCLOUD_API_URL = System.getenv("SONARCLOUD_API_URL");
+}

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/Constants.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/Constants.java
@@ -20,10 +20,10 @@
 package com.sonar.it.scanner.msbuild.sonarcloud;
 
 public class Constants {
-  public final static Integer COMMAND_TIMEOUT = 2 * 60 * 1000;
-  public final static String SCANNER_PATH = "../build/sonarscanner-net-framework/SonarScanner.MSBuild.exe";
+  public static final Integer COMMAND_TIMEOUT = 2 * 60 * 1000;
+  public static final String SCANNER_PATH = "../build/sonarscanner-net-framework/SonarScanner.MSBuild.exe";
 
-  public final static String SONARCLOUD_ORGANIZATION = System.getenv("SONARCLOUD_ORGANIZATION");
-  public final static String SONARCLOUD_URL = System.getenv("SONARCLOUD_URL");
-  public final static String SONARCLOUD_API_URL = System.getenv("SONARCLOUD_API_URL");
+  public static final String SONARCLOUD_ORGANIZATION = System.getenv("SONARCLOUD_ORGANIZATION");
+  public static final String SONARCLOUD_URL = System.getenv("SONARCLOUD_URL");
+  public static final String SONARCLOUD_API_URL = System.getenv("SONARCLOUD_API_URL");
 }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/IncrementalPRAnalysisSonarCloudTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/IncrementalPRAnalysisSonarCloudTest.java
@@ -20,9 +20,6 @@
 package com.sonar.it.scanner.msbuild.sonarcloud;
 
 import com.sonar.it.scanner.msbuild.utils.TestUtils;
-import com.sonar.orchestrator.http.HttpException;
-import com.sonar.orchestrator.util.Command;
-import com.sonar.orchestrator.util.CommandExecutor;
 import com.sonar.orchestrator.util.StreamConsumer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -34,45 +31,33 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils.getEnvBuildDirectory;
 import static com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils.isRunningUnderAzureDevOps;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 class IncrementalPRAnalysisSonarCloudTest {
   private final static Logger LOG = LoggerFactory.getLogger(IncrementalPRAnalysisSonarCloudTest.class);
-  private final static Integer COMMAND_TIMEOUT = 2 * 60 * 1000;
-  private final static String SCANNER_PATH = "../build/sonarscanner-net-framework/SonarScanner.MSBuild.exe";
+  private final static String SONARCLOUD_PROJECT_KEY = "team-lang-dotnet_incremental-pr-analysis";
+  private final static String PROJECT_NAME = "IncrementalPRAnalysis";
   private final static String[] prArguments = {
     "/d:sonar.pullrequest.base=master",
     "/d:sonar.pullrequest.branch=pull-request-branch",
     "/d:sonar.pullrequest.key=pull-request-key"
   };
-  private final static String SONARCLOUD_ORGANIZATION = System.getenv("SONARCLOUD_ORGANIZATION");
-  private final static String SONARCLOUD_PROJECT_KEY = System.getenv("SONARCLOUD_PROJECT_KEY");
-  private final static String SONARCLOUD_URL = System.getenv("SONARCLOUD_URL");
-  private final static String SONARCLOUD_API_URL = System.getenv("SONARCLOUD_API_URL");
 
   @TempDir
   public Path basePath;
 
   @Test
   void master_emptyCache() throws IOException {
-    var projectDir = TestUtils.projectDir(basePath, "IncrementalPRAnalysis");
+    var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
     var logWriter = new StringWriter();
     StreamConsumer.Pipe logsConsumer = new StreamConsumer.Pipe(logWriter);
 
-    runBeginStep(projectDir, logsConsumer);
+    SonarCloudUtils.runBeginStep(projectDir, SONARCLOUD_PROJECT_KEY, logsConsumer);
 
     assertThat(logWriter.toString()).contains(
       "Processing analysis cache",
@@ -82,38 +67,36 @@ class IncrementalPRAnalysisSonarCloudTest {
 
   @Test
   void prWithoutChanges_producesUnchangedFilesWithAllFiles() throws IOException {
-    var projectDir = TestUtils.projectDir(basePath, "IncrementalPRAnalysis");
+    var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
 
-    runAnalysis(projectDir); // Initial build - master.
-    var logs = runAnalysis(projectDir, prArguments); // PR analysis.
+    SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY); // Initial build - master.
+    var logs = SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY, prArguments); // PR analysis.
 
     // Verify that the file hashes are considered and all of them will be skipped.
-    // The (?s) flag indicates that the dot special character ( . ) should additionally match the following
-    // line terminator ("newline") characters in a string, which it would not match otherwise.
     // We do not know the total number of cache entries because other plugin can cache as well.
-    assertThat(logs).matches("(?s).*Incremental PR analysis: 3 files out of \\d+ are unchanged.*");
+    TestUtils.matchesSingleLine(logs, "Incremental PR analysis: 3 files out of \\d+ are unchanged");
     Path unchangedFilesPath = getUnchangedFilesPath(projectDir);
     assertThat(Files.readString(unchangedFilesPath)).contains("Unchanged1.cs", "Unchanged2.cs", "WithChanges.cs");
   }
 
   @Test
   void prWithChanges_detectsUnchangedFile() throws IOException {
-    var projectDir = TestUtils.projectDir(basePath, "IncrementalPRAnalysis");
+    var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
 
-    runAnalysis(projectDir); // Initial build - master.
+    SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY); // Initial build - master.
     changeFile(projectDir, "IncrementalPRAnalysis\\WithChanges.cs"); // Change a file to force analysis.
-    runAnalysis(projectDir, prArguments); // PR analysis.
+    SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY, prArguments); // PR analysis.
 
     assertOnlyWithChangesFileIsConsideredChanged(projectDir);
   }
 
   @Test
   void prWithChanges_basedOnDifferentBranchThanMaster_detectsUnchangedFiles() throws IOException {
-    var projectDir = TestUtils.projectDir(basePath, "IncrementalPRAnalysis");
+    var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
 
-    runAnalysis(projectDir, "/d:sonar.branch.name=different-branch"); // Initial build - different branch.
+    SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY, "/d:sonar.branch.name=different-branch"); // Initial build - different branch.
     changeFile(projectDir, "IncrementalPRAnalysis\\WithChanges.cs"); // Change a file to force analysis.
-    runAnalysis(projectDir, "/d:sonar.pullrequest.base=different-branch", "/d:sonar.pullrequest.branch=second-pull-request-branch", "/d:sonar.pullrequest.key=second-pull-request-key");
+    SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY, "/d:sonar.pullrequest.base=different-branch", "/d:sonar.pullrequest.branch=second-pull-request-branch", "/d:sonar.pullrequest.key=second-pull-request-key");
 
     assertOnlyWithChangesFileIsConsideredChanged(projectDir);
   }
@@ -135,92 +118,8 @@ class IncrementalPRAnalysisSonarCloudTest {
     writer.close();
   }
 
-  private static String runAnalysis(Path projectDir, String... arguments) {
-    var logWriter = new StringWriter();
-    StreamConsumer.Pipe logsConsumer = new StreamConsumer.Pipe(logWriter);
-
-    runBeginStep(projectDir, logsConsumer, arguments);
-    runBuild(projectDir);
-    runEndStep(projectDir, logsConsumer);
-    var logs = logWriter.toString();
-    waitForTaskProcessing(logs);
-    return logs;
-  }
-
   private static Path getUnchangedFilesPath(Path projectDir) {
     Path buildDirectory = isRunningUnderAzureDevOps() ? Path.of(getEnvBuildDirectory()) : projectDir;
     return buildDirectory.resolve(".sonarqube\\conf\\UnchangedFiles.txt").toAbsolutePath();
-  }
-
-  private static void runBeginStep(Path projectDir, StreamConsumer.Pipe logsConsumer, String... additionalArguments) {
-    var beginCommand = Command.create(new File(SCANNER_PATH).getAbsolutePath())
-      .setDirectory(projectDir.toFile())
-      .addArgument("begin")
-      .addArgument("/o:" + SONARCLOUD_ORGANIZATION)
-      .addArgument("/k:" + SONARCLOUD_PROJECT_KEY)
-      .addArgument("/d:sonar.host.url=" + SONARCLOUD_URL)
-      .addArgument("/d:sonar.scanner.sonarcloudUrl=" + SONARCLOUD_URL)
-      .addArgument("/d:sonar.scanner.apiBaseUrl=" + SONARCLOUD_API_URL)
-      .addArgument("/d:sonar.login=%SONARCLOUD_PROJECT_TOKEN%") // SonarCloud does not support yet sonar.token
-      .addArgument("/d:sonar.projectBaseDir=" + projectDir.toAbsolutePath())
-      .addArgument("/d:sonar.verbose=true");
-
-    for (var argument : additionalArguments)
-    {
-      beginCommand.addArgument(argument);
-    }
-
-    LOG.info("Scanner path: " + SCANNER_PATH);
-    LOG.info("Command line: " + beginCommand.toCommandLine());
-    var beginResult = CommandExecutor.create().execute(beginCommand, logsConsumer, COMMAND_TIMEOUT);
-    assertThat(beginResult).isZero();
-  }
-
-  private static void runEndStep(Path projectDir, StreamConsumer.Pipe logConsumer) {
-    var endCommand = Command.create(new File(SCANNER_PATH).getAbsolutePath())
-      .setDirectory(projectDir.toFile())
-      .addArgument("end")
-      .addArgument("/d:sonar.login=%SONARCLOUD_PROJECT_TOKEN%"); // SonarCloud does not support yet sonar.token
-
-    var endResult = CommandExecutor.create().execute(endCommand, logConsumer, COMMAND_TIMEOUT);
-    assertThat(endResult).isZero();
-  }
-
-  private static void runBuild(Path projectDir) {
-    var result = TestUtils.runDotnetCommand(projectDir, "build", "--no-incremental");
-    assertThat(result.isSuccess()).isTrue();
-  }
-
-  private static void waitForTaskProcessing(String logs) {
-    Pattern pattern = Pattern.compile("INFO: More about the report processing at (.*)");
-    Matcher matcher = pattern.matcher(logs);
-    if (matcher.find())
-    {
-      var uri = URI.create(matcher.group(1));
-      var client = HttpClient.newHttpClient();
-
-      await()
-        .pollInterval(Duration.ofSeconds(5))
-        .atMost(Duration.ofSeconds(120))
-        .until(() -> {
-          try
-          {
-            LOG.info("Pooling for task status using {}", uri);
-            var request = HttpRequest.newBuilder(uri).header("Authorization", "Bearer " + System.getenv("SONARCLOUD_PROJECT_TOKEN")).build();
-            var response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            return response.statusCode() == 200 && response.body().contains("\"status\":\"SUCCESS\"");
-          }
-          catch (HttpException ex) {
-            return false;
-          }
-        });
-    }
-  }
-
-  private static String getMSBuildPath() {
-    var msBuildPath = System.getenv("MSBUILD_PATH");
-    return msBuildPath == null
-      ? TestUtils.MSBUILD_DEFAULT_PATH
-      : msBuildPath;
   }
 }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/JreProvisioningTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/JreProvisioningTest.java
@@ -1,0 +1,115 @@
+/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.it.scanner.msbuild.sonarcloud;
+
+import com.sonar.it.scanner.msbuild.utils.TestUtils;
+import com.sonar.orchestrator.util.Command;
+import com.sonar.orchestrator.util.CommandExecutor;
+import com.sonar.orchestrator.util.StreamConsumer;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JreProvisioningTest {
+  private final static Logger LOG = LoggerFactory.getLogger(JreProvisioningTest.class);
+  private final static Integer COMMAND_TIMEOUT = 2 * 60 * 1000;
+  private final static String SCANNER_PATH = "../build/sonarscanner-net-framework/SonarScanner.MSBuild.exe";
+  private final static String SONARCLOUD_PROJECT_KEY = "team-lang-dotnet_jre-provisioning";
+  private final static String PROJECT_NAME = "JreProvisioning";
+
+  @TempDir
+  public Path basePath;
+
+  @Test
+  void different_hostUrl_sonarcloudUrl_logsAndExitsEarly() {
+    var logWriter = new StringWriter();
+    StreamConsumer.Pipe logsConsumer = new StreamConsumer.Pipe(logWriter);
+
+    var beginCommand = Command.create(new File(SCANNER_PATH).getAbsolutePath())
+      .addArgument("begin")
+      .addArgument("/o:org")
+      .addArgument("/k:project")
+      .addArgument("/d:sonar.host.url=http://localhost:4242")
+      .addArgument("/d:sonar.scanner.sonarcloudUrl=" + Constants.SONARCLOUD_URL);
+
+    LOG.info("Scanner path: " + SCANNER_PATH);
+    LOG.info("Command line: " + beginCommand.toCommandLine());
+    var beginResult = CommandExecutor.create().execute(beginCommand, logsConsumer, COMMAND_TIMEOUT);
+    assertThat(beginResult).isOne();
+
+    assertThat(logWriter.toString()).contains(
+      "The arguments 'sonar.host.url' and 'sonar.scanner.sonarcloudUrl' are both set and are different. Please set either 'sonar.host" +
+        ".url' for SonarQube or 'sonar.scanner.sonarcloudUrl' for SonarCloud.");
+  }
+
+  @Test
+  void jreProvisioning_skipProvisioning_doesNotDownloadJre() throws IOException {
+    var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
+    var logWriter = new StringWriter();
+    StreamConsumer.Pipe logsConsumer = new StreamConsumer.Pipe(logWriter);
+
+    SonarCloudUtils.runBeginStep(projectDir,SONARCLOUD_PROJECT_KEY, logsConsumer, "/d:sonar.scanner.skipJreProvisioning=true");
+
+    assertThat(logWriter.toString()).contains(
+      "JreResolver: Resolving JRE path.",
+      "JreResolver: sonar.scanner.skipJreProvisioning is set, skipping JRE provisioning.");
+    assertThat(logWriter.toString()).doesNotContain(
+      "JreResolver: Cache miss.",
+      "JreResolver: Cache hit",
+      "JreResolver: Cache failure.");
+  }
+
+  @Test
+  void jreProvisioning_endToEnd_cacheMiss_downloadsJre() throws IOException {
+    var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
+
+    var logs = SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY, "/d:sonar.userHome=" + projectDir.toAbsolutePath());
+
+    var root = projectDir.toAbsolutePath().toString().replace("\\", "\\\\");
+    // begin step
+    assertThat(logs).contains(
+      "JreResolver: Resolving JRE path.",
+      "Downloading from " + Constants.SONARCLOUD_API_URL + "/analysis/jres?os=windows&arch=x64...",
+      "Response received from " + Constants.SONARCLOUD_API_URL + "/analysis/jres?os=windows&arch=x64...",
+      "JreResolver: Cache miss. Attempting to download JRE.",
+      "Starting the Java Runtime Environment download.");
+    TestUtils.matchesSingleLine(logs, "Downloading Java JRE from https://.+/jres/.+.zip");
+    TestUtils.matchesSingleLine(logs, "The checksum of the downloaded file is '.+' and the expected checksum is '.+'");
+    TestUtils.matchesSingleLine(logs,
+      "Starting extracting the Java runtime environment from archive '" + root + "\\\\cache.+' to folder '" + root +
+        "\\\\cache.+'");
+    TestUtils.matchesSingleLine(logs,
+      "Moving extracted Java runtime environment from '" + root + "\\\\cache.+' to '" + root + "\\\\cache" +
+        ".+_extracted'");
+    TestUtils.matchesSingleLine(logs, "The Java runtime environment was successfully added to '" + root + "\\\\cache.+_extracted'");
+    TestUtils.matchesSingleLine(logs, "JreResolver: Download success. JRE can be found at '" + root + "\\\\cache.+_extracted.+java.exe'");
+    // end step
+    TestUtils.matchesSingleLine(logs, "Setting the JAVA_HOME for the scanner cli to " + root + "\\\\cache.+_extracted.+");
+    TestUtils.matchesSingleLine(logs, "Overwriting the value of environment variable 'JAVA_HOME'. Old value: .+, new value: " + root +
+      "\\\\cache.+extracted.+");
+  }
+}

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/JreProvisioningTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/JreProvisioningTest.java
@@ -35,11 +35,9 @@ import org.slf4j.LoggerFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JreProvisioningTest {
-  private final static Logger LOG = LoggerFactory.getLogger(JreProvisioningTest.class);
-  private final static Integer COMMAND_TIMEOUT = 2 * 60 * 1000;
-  private final static String SCANNER_PATH = "../build/sonarscanner-net-framework/SonarScanner.MSBuild.exe";
-  private final static String SONARCLOUD_PROJECT_KEY = "team-lang-dotnet_jre-provisioning";
-  private final static String PROJECT_NAME = "JreProvisioning";
+  private static final Logger LOG = LoggerFactory.getLogger(JreProvisioningTest.class);
+  private static final String SONARCLOUD_PROJECT_KEY = "team-lang-dotnet_jre-provisioning";
+  private static final String PROJECT_NAME = "JreProvisioning";
 
   @TempDir
   public Path basePath;
@@ -49,16 +47,16 @@ class JreProvisioningTest {
     var logWriter = new StringWriter();
     StreamConsumer.Pipe logsConsumer = new StreamConsumer.Pipe(logWriter);
 
-    var beginCommand = Command.create(new File(SCANNER_PATH).getAbsolutePath())
+    var beginCommand = Command.create(new File(Constants.SCANNER_PATH).getAbsolutePath())
       .addArgument("begin")
       .addArgument("/o:org")
       .addArgument("/k:project")
       .addArgument("/d:sonar.host.url=http://localhost:4242")
       .addArgument("/d:sonar.scanner.sonarcloudUrl=" + Constants.SONARCLOUD_URL);
 
-    LOG.info("Scanner path: " + SCANNER_PATH);
-    LOG.info("Command line: " + beginCommand.toCommandLine());
-    var beginResult = CommandExecutor.create().execute(beginCommand, logsConsumer, COMMAND_TIMEOUT);
+    LOG.info("Scanner path: {}", Constants.SCANNER_PATH);
+    LOG.info("Command line: {}", beginCommand.toCommandLine());
+    var beginResult = CommandExecutor.create().execute(beginCommand, logsConsumer, Constants.COMMAND_TIMEOUT);
     assertThat(beginResult).isOne();
 
     assertThat(logWriter.toString()).contains(

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/SonarCloudUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/SonarCloudUtils.java
@@ -73,8 +73,9 @@ public class SonarCloudUtils {
       beginCommand.addArgument(argument);
     }
 
-    LOG.info("Scanner path: " + Constants.SCANNER_PATH);
-    LOG.info("Command line: " + beginCommand.toCommandLine());
+    LOG.info("Scanner path: {}", Constants.SCANNER_PATH);
+    LOG.info("Command line: {}", beginCommand.toCommandLine());
+
     var beginResult = CommandExecutor.create().execute(beginCommand, logsConsumer, Constants.COMMAND_TIMEOUT);
     assertThat(beginResult).isZero();
   }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/SonarCloudUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/SonarCloudUtils.java
@@ -1,0 +1,122 @@
+/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.it.scanner.msbuild.sonarcloud;
+
+import com.sonar.it.scanner.msbuild.utils.TestUtils;
+import com.sonar.orchestrator.http.HttpException;
+import com.sonar.orchestrator.util.Command;
+import com.sonar.orchestrator.util.CommandExecutor;
+import com.sonar.orchestrator.util.StreamConsumer;
+import java.io.File;
+import java.io.StringWriter;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+public class SonarCloudUtils {
+  private final static Logger LOG = LoggerFactory.getLogger(SonarCloudUtils.class);
+
+  public static String runAnalysis(Path projectDir, String projectKey, String... arguments) {
+    var logWriter = new StringWriter();
+    StreamConsumer.Pipe logsConsumer = new StreamConsumer.Pipe(logWriter);
+
+    runBeginStep(projectDir, projectKey, logsConsumer, arguments);
+    runBuild(projectDir);
+    runEndStep(projectDir, logsConsumer);
+    var logs = logWriter.toString();
+    waitForTaskProcessing(logs);
+    return logs;
+  }
+
+  public static void runBeginStep(Path projectDir, String projectKey, StreamConsumer.Pipe logsConsumer, String... additionalArguments) {
+    var beginCommand = Command.create(new File(Constants.SCANNER_PATH).getAbsolutePath())
+      .setDirectory(projectDir.toFile())
+      .addArgument("begin")
+      .addArgument("/o:" + Constants.SONARCLOUD_ORGANIZATION)
+      .addArgument("/k:" + projectKey)
+      .addArgument("/d:sonar.host.url=" + Constants.SONARCLOUD_URL)
+      .addArgument("/d:sonar.scanner.sonarcloudUrl=" + Constants.SONARCLOUD_URL)
+      .addArgument("/d:sonar.scanner.apiBaseUrl=" + Constants.SONARCLOUD_API_URL)
+      .addArgument("/d:sonar.login=%SONARCLOUD_PROJECT_TOKEN%") // SonarCloud does not support yet sonar.token
+      .addArgument("/d:sonar.projectBaseDir=" + projectDir.toAbsolutePath())
+      .addArgument("/d:sonar.verbose=true");
+
+    for (var argument : additionalArguments)
+    {
+      beginCommand.addArgument(argument);
+    }
+
+    LOG.info("Scanner path: " + Constants.SCANNER_PATH);
+    LOG.info("Command line: " + beginCommand.toCommandLine());
+    var beginResult = CommandExecutor.create().execute(beginCommand, logsConsumer, Constants.COMMAND_TIMEOUT);
+    assertThat(beginResult).isZero();
+  }
+
+  private static void runEndStep(Path projectDir, StreamConsumer.Pipe logConsumer) {
+    var endCommand = Command.create(new File(Constants.SCANNER_PATH).getAbsolutePath())
+      .setDirectory(projectDir.toFile())
+      .addArgument("end")
+      .addArgument("/d:sonar.login=%SONARCLOUD_PROJECT_TOKEN%"); // SonarCloud does not support yet sonar.token
+
+    var endResult = CommandExecutor.create().execute(endCommand, logConsumer, Constants.COMMAND_TIMEOUT);
+    assertThat(endResult).isZero();
+  }
+
+  public static void runBuild(Path projectDir) {
+    var result = TestUtils.runDotnetCommand(projectDir, "build", "--no-incremental");
+    assertThat(result.isSuccess()).isTrue();
+  }
+
+  private static void waitForTaskProcessing(String logs) {
+    Pattern pattern = Pattern.compile("INFO: More about the report processing at (.*)");
+    Matcher matcher = pattern.matcher(logs);
+    if (matcher.find())
+    {
+      var uri = URI.create(matcher.group(1));
+      var client = HttpClient.newHttpClient();
+
+      await()
+        .pollInterval(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(120))
+        .until(() -> {
+          try
+          {
+            LOG.info("Pooling for task status using {}", uri);
+            var request = HttpRequest.newBuilder(uri).header("Authorization", "Bearer " + System.getenv("SONARCLOUD_PROJECT_TOKEN")).build();
+            var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            return response.statusCode() == 200 && response.body().contains("\"status\":\"SUCCESS\"");
+          }
+          catch (HttpException ex) {
+            return false;
+          }
+        });
+    }
+  }
+}

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
@@ -438,6 +438,12 @@ public class TestUtils {
     return result;
   }
 
+  // The (?s) flag indicates that the dot special character ( . ) should additionally match the following
+  // line terminator ("newline") characters in a string, which it would not match otherwise.
+  public static void matchesSingleLine(String input, String pattern) {
+    assertThat(input).matches("(?s).*"+pattern+".*");
+  }
+
   @CheckForNull
   private static Measures.Measure getMeasure(@Nullable String componentKey, String metricKey, Orchestrator orchestrator) {
     Measures.ComponentWsResponse response = newWsClient(orchestrator).measures().component(new ComponentRequest()


### PR DESCRIPTION
Adds 3 ITs:
- skip-provisioning set to true
- mismatch in host.url and sonarcloudUrl
- E2E with cache miss, downloading the JRE.

There are many more tests that could be added, but I added these as a baby step, so that we at least have something on the pipeline before we start the manual testing.