### PR TITLE
JRE Provisioning: Refactor IFilePermissionsWrapper

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -94,7 +94,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test
 
             args.ServerInfo.ApiBaseUrl.Should().Be("test");
             logger.AssertDebugLogged($"Server Url: https://sonarcloud.io");
-            logger.AssertDebugLogged($"Api Url: https://api.sonarcloud.io");
+            logger.AssertDebugLogged($"Api Url: test");
             logger.AssertDebugLogged("Is SonarCloud: True");
         }
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Unpacking/TarGzUnpackTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Unpacking/TarGzUnpackTests.cs
@@ -58,7 +58,7 @@ public class TarGzUnpackTests
         using var archive = new MemoryStream(Convert.FromBase64String(sampleTarGzFile));
         using var unzipped = new MemoryStream();
         fileWrapper.Create($"""{baseDirectory}\Main\Sub2\Sample.txt""").Returns(unzipped);
-        filePermissionsWrapper.When(x => x.Copy(Arg.Any<int>(), Arg.Any<string>())).Throw(new Exception("Sample exception message"));
+        filePermissionsWrapper.When(x => x.Set(Arg.Any<int>(), Arg.Any<string>())).Throw(new Exception("Sample exception message"));
 
         CreateUnpacker().Unpack(archive, baseDirectory);
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Unpacking/TarGzUnpackTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Unpacking/TarGzUnpackTests.cs
@@ -23,7 +23,6 @@ using System.IO;
 using System.Text;
 using FluentAssertions;
 using ICSharpCode.SharpZipLib.Core;
-using ICSharpCode.SharpZipLib.Tar;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using SonarScanner.MSBuild.Common;
@@ -59,7 +58,7 @@ public class TarGzUnpackTests
         using var archive = new MemoryStream(Convert.FromBase64String(sampleTarGzFile));
         using var unzipped = new MemoryStream();
         fileWrapper.Create($"""{baseDirectory}\Main\Sub2\Sample.txt""").Returns(unzipped);
-        filePermissionsWrapper.When(x => x.Copy(Arg.Any<TarEntry>(), Arg.Any<string>())).Throw(new Exception("Sample exception message"));
+        filePermissionsWrapper.When(x => x.Copy(Arg.Any<int>(), Arg.Any<string>())).Throw(new Exception("Sample exception message"));
 
         CreateUnpacker().Unpack(archive, baseDirectory);
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Unpacking/TarGzUnpackTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Unpacking/TarGzUnpackTests.cs
@@ -58,7 +58,7 @@ public class TarGzUnpackTests
         using var archive = new MemoryStream(Convert.FromBase64String(sampleTarGzFile));
         using var unzipped = new MemoryStream();
         fileWrapper.Create($"""{baseDirectory}\Main\Sub2\Sample.txt""").Returns(unzipped);
-        filePermissionsWrapper.When(x => x.Set(Arg.Any<int>(), Arg.Any<string>())).Throw(new Exception("Sample exception message"));
+        filePermissionsWrapper.When(x => x.Set(Arg.Any<string>(), Arg.Any<int>())).Throw(new Exception("Sample exception message"));
 
         CreateUnpacker().Unpack(archive, baseDirectory);
 

--- a/src/SonarScanner.MSBuild.PreProcessor/FilePermissionsWrapper.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/FilePermissionsWrapper.cs
@@ -28,8 +28,8 @@ namespace SonarScanner.MSBuild.PreProcessor;
 
 public class FilePermissionsWrapper(IOperatingSystemProvider operatingSystemProvider) : IFilePermissionsWrapper
 {
-    [ExcludeFromCodeCoverage] // We don't have *inx UT images at th time of writing. We tested the functionality manually.
-    public void Set(int mode, string destinationPath)
+    [ExcludeFromCodeCoverage] // We don't have *inx UT images at the time of writing. We tested the functionality manually.
+    public void Set(string destinationPath, int mode)
     {
         if (operatingSystemProvider.IsUnix())
         {

--- a/src/SonarScanner.MSBuild.PreProcessor/FilePermissionsWrapper.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/FilePermissionsWrapper.cs
@@ -29,7 +29,7 @@ namespace SonarScanner.MSBuild.PreProcessor;
 public class FilePermissionsWrapper(IOperatingSystemProvider operatingSystemProvider) : IFilePermissionsWrapper
 {
     [ExcludeFromCodeCoverage] // We don't have *inx UT images at th time of writing. We tested the functionality manually.
-    public void Copy(int mode, string destinationPath)
+    public void Set(int mode, string destinationPath)
     {
         if (operatingSystemProvider.IsUnix())
         {

--- a/src/SonarScanner.MSBuild.PreProcessor/FilePermissionsWrapper.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/FilePermissionsWrapper.cs
@@ -21,7 +21,6 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using ICSharpCode.SharpZipLib.Tar;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.PreProcessor.Interfaces;
 
@@ -29,8 +28,8 @@ namespace SonarScanner.MSBuild.PreProcessor;
 
 public class FilePermissionsWrapper(IOperatingSystemProvider operatingSystemProvider) : IFilePermissionsWrapper
 {
-    [ExcludeFromCodeCoverage]
-    public void Copy(TarEntry sourceEntry, string destinationPath)
+    [ExcludeFromCodeCoverage] // We don't have *inx UT images at th time of writing. We tested the functionality manually.
+    public void Copy(int mode, string destinationPath)
     {
         if (operatingSystemProvider.IsUnix())
         {
@@ -46,7 +45,7 @@ public class FilePermissionsWrapper(IOperatingSystemProvider operatingSystemProv
                         CreateNoWindow = true,
                         WindowStyle = ProcessWindowStyle.Hidden,
                         FileName = "chmod",
-                        Arguments = $"""{Convert.ToString(sourceEntry.TarHeader.Mode, 8)} "{destinationPath}" """,
+                        Arguments = $"""{Convert.ToString(mode, 8)} "{destinationPath}" """,
                     }
                 };
                 process.Start();
@@ -61,7 +60,7 @@ public class FilePermissionsWrapper(IOperatingSystemProvider operatingSystemProv
             {
                 _ = new Mono.Unix.UnixFileInfo(destinationPath)
                 {
-                    FileAccessPermissions = (Mono.Unix.FileAccessPermissions)sourceEntry.TarHeader.Mode // set the same permissions as inside the archive
+                    FileAccessPermissions = (Mono.Unix.FileAccessPermissions)mode,
                 };
             }
         }

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IFilePermissionsWrapper.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IFilePermissionsWrapper.cs
@@ -25,7 +25,7 @@ public interface IFilePermissionsWrapper
     /// <summary>
     /// Set the *nix file permission on a file.
     /// </summary>
-    /// <param name="mode">The file numeric notation as used by chmod.</param>
     /// <param name="destinationPath">The path to the file.</param>
-    void Set(int mode, string destinationPath);
+    /// <param name="mode">The numeric notation of file permissions as used by chmod.</param>
+    void Set(string destinationPath, int mode);
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IFilePermissionsWrapper.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IFilePermissionsWrapper.cs
@@ -27,5 +27,5 @@ public interface IFilePermissionsWrapper
     /// </summary>
     /// <param name="mode">The file numeric notation as used by chmod.</param>
     /// <param name="destinationPath">The path to the file.</param>
-    void Copy(int mode, string destinationPath);
+    void Set(int mode, string destinationPath);
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IFilePermissionsWrapper.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/IFilePermissionsWrapper.cs
@@ -18,11 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using ICSharpCode.SharpZipLib.Tar;
-
 namespace SonarScanner.MSBuild.PreProcessor.Interfaces;
 
 public interface IFilePermissionsWrapper
 {
-    void Copy(TarEntry sourceEntry, string destinationPath);
+    /// <summary>
+    /// Set the *nix file permission on a file.
+    /// </summary>
+    /// <param name="mode">The file numeric notation as used by chmod.</param>
+    /// <param name="destinationPath">The path to the file.</param>
+    void Copy(int mode, string destinationPath);
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -279,7 +279,7 @@ namespace SonarScanner.MSBuild.PreProcessor
                     : info.ApiBaseUrl;
 
                 logger.LogDebug(Resources.MSG_ServerInfo_ServerUrlDetected, info.ServerUrl);
-                logger.LogDebug(Resources.MSG_ServerInfo_ApiUrlDetected, info.ApiBaseUrl);
+                logger.LogDebug(Resources.MSG_ServerInfo_ApiUrlDetected, apiBaseUrl);
                 logger.LogDebug(Resources.MSG_ServerInfo_IsSonarCloudDetected, info.IsSonarCloud);
                 return new(info.ServerUrl, apiBaseUrl, info.IsSonarCloud);
             }

--- a/src/SonarScanner.MSBuild.PreProcessor/Unpacking/TarGzUnpacker.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Unpacking/TarGzUnpacker.cs
@@ -79,7 +79,7 @@ public class TarGzUnpacker(ILogger logger, IDirectoryWrapper directoryWrapper, I
             outputStream.Close();
             try
             {
-                filePermissionsWrapper.Copy(entry.TarHeader.Mode, destinationFile);
+                filePermissionsWrapper.Set(entry.TarHeader.Mode, destinationFile);
             }
             catch (Exception ex) // TODO: Test this when SetPermissions is extracted
             {

--- a/src/SonarScanner.MSBuild.PreProcessor/Unpacking/TarGzUnpacker.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Unpacking/TarGzUnpacker.cs
@@ -79,7 +79,7 @@ public class TarGzUnpacker(ILogger logger, IDirectoryWrapper directoryWrapper, I
             outputStream.Close();
             try
             {
-                filePermissionsWrapper.Set(entry.TarHeader.Mode, destinationFile);
+                filePermissionsWrapper.Set(destinationFile, entry.TarHeader.Mode);
             }
             catch (Exception ex) // TODO: Test this when SetPermissions is extracted
             {

--- a/src/SonarScanner.MSBuild.PreProcessor/Unpacking/TarGzUnpacker.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Unpacking/TarGzUnpacker.cs
@@ -81,7 +81,7 @@ public class TarGzUnpacker(ILogger logger, IDirectoryWrapper directoryWrapper, I
             {
                 filePermissionsWrapper.Set(destinationFile, entry.TarHeader.Mode);
             }
-            catch (Exception ex) // TODO: Test this when SetPermissions is extracted
+            catch (Exception ex)
             {
                 logger.LogDebug(Resources.MSG_FilePermissionsCopyFailed, destinationFile, ex.Message);
             }

--- a/src/SonarScanner.MSBuild.PreProcessor/Unpacking/TarGzUnpacker.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Unpacking/TarGzUnpacker.cs
@@ -79,7 +79,7 @@ public class TarGzUnpacker(ILogger logger, IDirectoryWrapper directoryWrapper, I
             outputStream.Close();
             try
             {
-                filePermissionsWrapper.Copy(entry, destinationFile);
+                filePermissionsWrapper.Copy(entry.TarHeader.Mode, destinationFile);
             }
             catch (Exception ex) // TODO: Test this when SetPermissions is extracted
             {


### PR DESCRIPTION
Follow-up to #2048

Remove the TarEntry dependency from IFilePermissionsWrapper 