### PR TITLE
JRE cache: Fix old default sonar.host.url value

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -175,7 +175,7 @@ public class PreprocessorObjectFactoryTests
         logger.AssertSingleErrorExists(@"Organization parameter (/o:""<organization>"") is required and needs to be provided!");
         logger.AssertSingleWarningExists("""
             In version 7 of the scanner, the default value for the sonar.host.url changed from "http://localhost:9000" to "https://sonarcloud.io".
-            If the intention was to connect to the local SonarQube instance, please add the "/d:sonar.host.url=https://localhost:9000" parameter.
+            If the intention was to connect to the local SonarQube instance, please add the "/d:sonar.host.url=http://localhost:9000" parameter.
             """);
     }
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -196,7 +196,7 @@ public class PreprocessorObjectFactoryTests
             "Authentication with the server has failed.",
             """
             In version 7 of the scanner, the default value for the sonar.host.url changed from "http://localhost:9000" to "https://sonarcloud.io".
-            If the intention was to connect to the local SonarQube instance, please add the "/d:sonar.host.url=https://localhost:9000" parameter.
+            If the intention was to connect to the local SonarQube instance, please add the "/d:sonar.host.url=http://localhost:9000" parameter.
             """);
     }
 

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTest/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTest/GetAnalyzerSettingsTests.cs
@@ -491,7 +491,7 @@ namespace SonarScanner.MSBuild.Tasks.UnitTest
             var config = new AnalysisConfig
             {
                 SonarQubeVersion = sonarQubeVersion,
-                SonarQubeHostUrl = "https://localhost:9000", // If any SQ 8.0 version is passed (other than 8.0.0.29455), this will be classified as SonarCloud
+                SonarQubeHostUrl = "http://localhost:9000", // If any SQ 8.0 version is passed (other than 8.0.0.29455), this will be classified as SonarCloud
                 ServerSettings = new AnalysisProperties
                 {
                     // Server settings should be ignored. "true" value should break existing tests.

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -1145,7 +1145,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         
         /// <summary>
         ///   Looks up a localized string similar to In version 7 of the scanner, the default value for the sonar.host.url changed from &quot;http://localhost:9000&quot; to &quot;https://sonarcloud.io&quot;.
-        ///If the intention was to connect to the local SonarQube instance, please add the &quot;/d:sonar.host.url=https://localhost:9000&quot; parameter..
+        ///If the intention was to connect to the local SonarQube instance, please add the &quot;/d:sonar.host.url=http://localhost:9000&quot; parameter..
         /// </summary>
         internal static string WARN_DefaultHostUrlChanged {
             get {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -500,7 +500,7 @@ Use '/?' or '/h' to see the help message.</value>
   </data>
   <data name="WARN_DefaultHostUrlChanged" xml:space="preserve">
     <value>In version 7 of the scanner, the default value for the sonar.host.url changed from "http://localhost:9000" to "https://sonarcloud.io".
-If the intention was to connect to the local SonarQube instance, please add the "/d:sonar.host.url=https://localhost:9000" parameter.</value>
+If the intention was to connect to the local SonarQube instance, please add the "/d:sonar.host.url=http://localhost:9000" parameter.</value>
   </data>
   <data name="WARN_AuthenticationFailed" xml:space="preserve">
     <value>Authentication with the server has failed.</value>


### PR DESCRIPTION
The old default of `sonar.host.url` was `http://localhost:9000` instead of `http://localhost:9000`