### PR TITLE
JRE Provisioning: Rework file permissions on linux

### DIFF
--- a/scripts/package-artifacts.ps1
+++ b/scripts/package-artifacts.ps1
@@ -54,6 +54,7 @@ function Package-NetScanner {
     Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.Shim.dll" -Destination $destination
     Copy-Item -Path "$sourceRoot\Google.Protobuf.dll" -Destination $destination
     Copy-Item -Path "$sourceRoot\Newtonsoft.Json.dll" -Destination $destination
+    Copy-Item -Path "$sourceRoot\ICSharpCode.SharpZipLib.dll" -Destination $destination
     Copy-Item -Path "$PSScriptRoot\..\src\SonarScanner.MSBuild.Tasks\bin\Release\netstandard2.0\SonarScanner.MSBuild.Tasks.dll" -Destination $destination
 
     Expand-Archive -Path "$scannerCliDownloadDir\$scannerCliArtifact" -DestinationPath $destination -Force
@@ -80,7 +81,7 @@ function Sign-Assemblies {
 
 function Download-ScannerCli {
     $artifactoryUrlEnv = "ARTIFACTORY_URL"
-    
+
     $artifactoryUrl = [environment]::GetEnvironmentVariable($artifactoryUrlEnv, "Process")
     if (!$artifactoryUrl) {
         Write-Host "Could not find ARTIFACTORY_URL variable, defaulting to repox URL.";

--- a/src/SonarScanner.MSBuild.PreProcessor/FilePermissionsWrapper.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/FilePermissionsWrapper.cs
@@ -33,35 +33,25 @@ public class FilePermissionsWrapper(IOperatingSystemProvider operatingSystemProv
     {
         if (operatingSystemProvider.IsUnix())
         {
-            if (operatingSystemProvider.OperatingSystem() is PlatformOS.Alpine)
+            // https://github.com/Jackett/Jackett/blob/master/src/Jackett.Server/Services/FilePermissionService.cs#L27
+            var process = new Process
             {
-                // https://github.com/Jackett/Jackett/blob/master/src/Jackett.Server/Services/FilePermissionService.cs#L27
-                var process = new Process
+                StartInfo = new ProcessStartInfo
                 {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        RedirectStandardError = true,
-                        UseShellExecute = false,
-                        CreateNoWindow = true,
-                        WindowStyle = ProcessWindowStyle.Hidden,
-                        FileName = "chmod",
-                        Arguments = $"""{Convert.ToString(mode, 8)} "{destinationPath}" """,
-                    }
-                };
-                process.Start();
-                var stdError = process.StandardError.ReadToEnd();
-                process.WaitForExit();
-                if (process.ExitCode != 0)
-                {
-                    throw new InvalidOperationException(stdError);
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    FileName = "chmod",
+                    Arguments = $"""{Convert.ToString(mode, 8)} "{destinationPath}" """,
                 }
-            }
-            else
+            };
+            process.Start();
+            var stdError = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            if (process.ExitCode != 0)
             {
-                _ = new Mono.Unix.UnixFileInfo(destinationPath)
-                {
-                    FileAccessPermissions = (Mono.Unix.FileAccessPermissions)mode,
-                };
+                throw new InvalidOperationException(stdError);
             }
         }
     }

--- a/src/SonarScanner.MSBuild.PreProcessor/FilePermissionsWrapper.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/FilePermissionsWrapper.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.PreProcessor.Interfaces;
 
@@ -34,16 +35,16 @@ public class FilePermissionsWrapper(IOperatingSystemProvider operatingSystemProv
         if (operatingSystemProvider.IsUnix())
         {
             // https://github.com/Jackett/Jackett/blob/master/src/Jackett.Server/Services/FilePermissionService.cs#L27
-            var process = new Process
+            using var process = new Process
             {
-                StartInfo = new ProcessStartInfo
+                StartInfo = new()
                 {
                     RedirectStandardError = true,
                     UseShellExecute = false,
                     CreateNoWindow = true,
                     WindowStyle = ProcessWindowStyle.Hidden,
                     FileName = "chmod",
-                    Arguments = $"""{Convert.ToString(mode, 8)} "{destinationPath}" """,
+                    Arguments = $"""{Convert.ToString(mode, 8)} "{Path.GetFullPath(destinationPath)}" """,
                 }
             };
             process.Start();

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarScanner.MSBuild.PreProcessor.csproj
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarScanner.MSBuild.PreProcessor.csproj
@@ -18,7 +18,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Mono.Posix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />


### PR DESCRIPTION
Mono.Posix did not work on Alpine already, and the way it is build would mess with our release (it requires a multi-platform SO dependency).

We will keep it simple and use `chmod` everywhere.