### PR TITLE
Releases produce zip files with a backslash as a separator (#2087)

### DIFF
--- a/scripts/package-artifacts.ps1
+++ b/scripts/package-artifacts.ps1
@@ -29,7 +29,9 @@
         Sign-Assemblies -Pattern "$destination\Sonar*" -TargetName ".NET Framework assemblies"
     }
 
-    Compress-Archive -Path "$destination\*" -DestinationPath "$destination.zip" -Force
+    # Don't use Compress-Archive because https://github.com/SonarSource/sonar-scanner-msbuild/issues/2086
+    # This is propably fixed in Powershell 7
+    tar -c -a -C "$destination" --options "zip:compression-level=9" -f "$destination.zip" *
 }
 
 function Package-NetScanner {
@@ -62,8 +64,10 @@ function Package-NetScanner {
     if ($SignAssemblies) {
         Sign-Assemblies -Pattern "$destination\Sonar*" -TargetName ".NET assemblies"
     }
-
-    Compress-Archive -Path "$destination\*" -DestinationPath "$destination.zip" -Force
+    
+    # Don't use Compress-Archive because https://github.com/SonarSource/sonar-scanner-msbuild/issues/2086
+    # This is propably fixed in Powershell 7
+    tar -c -a -C "$destination" --options "zip:compression-level=9" -f "$destination.zip" *
 }
 
 function Sign-Assemblies {


### PR DESCRIPTION
Cherry-picked from #2087