### PR TITLE
SCAN4NET-26: Exit-early on sonar.sources or sonar.tests

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/SonarPropertiesTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/SonarPropertiesTests.cs
@@ -63,7 +63,9 @@ public class SonarPropertiesTests
             SonarProperties.WorkingDirectory,
             SonarProperties.CacheBaseUrl,
             SonarProperties.HttpTimeout,
-            SonarProperties.ScanAllAnalysis
+            SonarProperties.ScanAllAnalysis,
+            SonarProperties.SonarSources,
+            SonarProperties.SonarTests,
         ]);
 
     /// <summary>

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
@@ -134,6 +134,20 @@ public class ProcessedArgsTests
         action.Should().Throw<ArgumentNullException>().WithParameterName("scannerEnvProperties");
     }
 
+    [DataTestMethod]
+    [DataRow("sonar.sources")]
+    [DataRow("sonar.tests")]
+    public void ProcArgs_InvalidPropertiesSet(string propertyName)
+    {
+        var provider = Substitute.For<IAnalysisPropertyProvider>();
+        provider.HasProperty(propertyName).Returns(true);
+
+        args = CreateDefaultArgs(provider);
+
+        args.IsValid.Should().BeFalse();
+        logger.AssertSingleErrorExists("The arguments 'sonar.sources' and 'sonar.tests' are not supported. Please remove them and invoke the scanner again.");
+    }
+
     [TestMethod]
     public void ProcArgs_Organization()
     {

--- a/src/SonarScanner.MSBuild.Common/SonarProperties.cs
+++ b/src/SonarScanner.MSBuild.Common/SonarProperties.cs
@@ -78,6 +78,10 @@ public static class SonarProperties
 
     public const string HttpTimeout = "sonar.http.timeout";
 
+    // sources and tests are not supported and should crash the analysis early.
+    public const string SonarSources = "sonar.sources";
+    public const string SonarTests = "sonar.tests";
+
     /// <summary>
     /// Strings that should throw a warning if they are set together with sonar.scanner.scanAll (not supported scenario).
     /// </summary>

--- a/src/SonarScanner.MSBuild.Common/SonarProperties.cs
+++ b/src/SonarScanner.MSBuild.Common/SonarProperties.cs
@@ -78,7 +78,7 @@ public static class SonarProperties
 
     public const string HttpTimeout = "sonar.http.timeout";
 
-    // sources and tests are not supported and should crash the analysis early.
+    // Sources and tests parameters are not supported and should stop the analysis early.
     public const string SonarSources = "sonar.sources";
     public const string SonarTests = "sonar.tests";
 

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -168,6 +168,12 @@ public class ProcessedArgs
             ? architecture.Value
             : RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
 
+        if (AggregateProperties.HasProperty(SonarProperties.SonarSources)
+            || AggregateProperties.HasProperty(SonarProperties.SonarTests))
+        {
+            IsValid = false;
+            logger.LogError(Resources.ERROR_SonarSourcesAndTestsNotSupported);
+        }
         if (AggregateProperties.TryGetProperty(SonarProperties.JavaExePath, out var javaExePath))
         {
             if (!fileWrapper.Exists(javaExePath.Value))

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -441,6 +441,15 @@ internal class Resources {
     }
     
     /// <summary>
+    ///   Looks up a localized string similar to The arguments &apos;sonar.sources&apos; and &apos;sonar.tests&apos; are not supported. Please remove them and invoke the scanner again..
+    /// </summary>
+    internal static string ERROR_SonarSourcesAndTestsNotSupported {
+        get {
+            return ResourceManager.GetString("ERROR_SonarSourcesAndTestsNotSupported", resourceCulture);
+        }
+    }
+    
+    /// <summary>
     ///   Looks up a localized string similar to It seems that you are using an old version of SonarQube which is not supported anymore. Please update to at least 6.7..
     /// </summary>
     internal static string ERROR_UnsupportedSonarQubeVersion {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -528,4 +528,7 @@ If you already have a compatible java version installed, please add either the p
   <data name="MSG_JreResolver_NotSupportedByServer" xml:space="preserve">
     <value>JreResolver: Skipping Java runtime environment provisioning because this version of SonarQube does not support it.</value>
   </data>
+  <data name="ERROR_SonarSourcesAndTestsNotSupported" xml:space="preserve">
+    <value>The arguments 'sonar.sources' and 'sonar.tests' are not supported. Please remove them and invoke the scanner again.</value>
+  </data>
 </root>


### PR DESCRIPTION
SCAN4NET-26
