### PR TITLE
SCAN4NET-38 Remove python promote script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,17 +56,17 @@ stages:
         steps:
         - checkout: none
         - powershell: |
-            $isPr = $env:BUILD_REASON == 'PullRequest'
+            $isPr=$env:BUILD_REASON -eq 'PullRequest'
             $repoPrefix = 'sonarsource-public'
             $it = Get-Date -Format s
-            if (isPr)
+            if ($isPr)
             {
-              $targetRepo = repoPrefix + '-dev'
+              $targetRepo = $repoPrefix + '-dev'
               $repoxStatus = 'it-passed-pr'
             } 
             else
             {
-              $targetRepo = repoPrefix + '-builds'
+              $targetRepo = $repoPrefix + '-builds'
               $repoxStatus = 'it-passed'
             }
             Write-Host "##vso[task.setvariable variable=targetRepo;]$targetRepo"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,9 +61,11 @@ stages:
           commonMavenArguments: -B -Pdeploy-sonarsource -Dmaven.test.skip=true
         steps:
           - checkout: self
-          - powershell: ls env:* | sort | fl
+          - powershell: |
+              Write-Host Hello from script
+              ls env:* | sort | fl
             displayName: Print env
-            
+
           - task: NuGetToolInstaller@1
             displayName: "Install NuGet"
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,10 +61,6 @@ stages:
           commonMavenArguments: -B -Pdeploy-sonarsource -Dmaven.test.skip=true
         steps:
           - checkout: self
-          - powershell: |
-              Write-Host Hello from script
-              ls env:* | sort | fl
-            displayName: Print env
 
           - task: NuGetToolInstaller@1
             displayName: "Install NuGet"
@@ -502,26 +498,9 @@ stages:
       displayName: Call repox
       steps:
       - checkout: none
-      - powershell: |
-          $isPr=$env:BUILD_REASON -eq 'PullRequest'
-          $repoPrefix = 'sonarsource-public'
-          $it = Get-Date -Format s
-          if ($isPr)
-          {
-            $targetRepo = $repoPrefix + '-dev'
-            $repoxStatus = 'it-passed-pr'
-          } 
-          else
-          {
-            $targetRepo = $repoPrefix + '-builds'
-            $repoxStatus = 'it-passed'
-          }
-          Write-Host "##vso[task.setvariable variable=targetRepo;]$targetRepo"
-          Write-Host "##vso[task.setvariable variable=repoxStatus;]$repoxStatus"
-          Write-Host "##vso[task.setvariable variable=it;]$it"
-        displayName: Calculate promotion values
       - task: JFrogBuildPromotion@1
         name: promoteRepoxCLI
+        displayName: Promote build in Repox
         inputs:
           artifactoryConnection: repox_promoter_token
           buildName: sonar-scanner-msbuild
@@ -531,55 +510,4 @@ stages:
             status: 'it-passed-pr'
           ${{ else }}:
             targetRepo: 'sonarsource-public-builds'
-            status: 'it-passed'          
-          dryRun: true
-          
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: '3.x'
-      - bash: pip3 install requests
-
-      - task: PythonScript@0
-        name: promoteRepox
-        inputs:
-          scriptSource: 'inline'
-          script: |
-            import requests
-            import os
-            import sys
-            import json
-            from datetime import datetime
-
-            def getFirstModuleProperty(buildInfo, property):
-              if 'modules' in buildInfo:
-                return buildInfo['modules'][0].get('properties', {}).get(property, None)
-              else:
-                return None
-
-            githubSlug = '$(Build.Repository.ID)'
-            githubProject = githubSlug.split("/", 1)[1]
-            buildNumber = '$(Build.BuildId)'
-            isPr = '$(Build.Reason)' == 'PullRequest'
-            repoPrefix = 'sonarsource-public'
-            targetRepo = None
-            repoxStatus = None
-            if isPr:
-              targetRepo = repoPrefix + '-dev'
-              repoxStatus = 'it-passed-pr'
-            else:
-              targetRepo = repoPrefix + '-builds'
-              repoxStatus = 'it-passed'
-
-            promoted = False
-            status = 'passed'
-            print(f'Promoting build {githubProject}#{buildNumber} to {targetRepo}')
-            headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer $(ARTIFACTORY_PROMOTER_ACCESS_TOKEN)'}
-            now = datetime.now().isoformat()
-            message = {'status': repoxStatus, 'properties': {'it' : [ now ] }, 'targetRepo': targetRepo}
-            url = f'$(ARTIFACTORY_URL)/api/build/promote/{githubProject}/{buildNumber}'
-            response = requests.post(url, headers=headers, json=message)
-            promoted = response.status_code == 200
-            if not promoted:
-              status = 'failed'
-              print(response.content)
-              sys.exit(f"Promotion failed: ERROR {response.status_code}")
+            status: 'it-passed'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -526,7 +526,11 @@ stages:
     - build
     - qa
     condition: and(succeeded(), or(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.SourceBranchName'], 'main', 'master'), startsWith(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'branch')))
-    jobs:    
+    jobs:
+    - job: promoteRepox
+      displayName: Call repox
+      steps:
+      - checkout: none
       - task: UsePythonVersion@0
         inputs:
           versionSpec: '3.x'
@@ -554,6 +558,8 @@ stages:
             buildNumber = '$(Build.BuildId)'
             isPr = '$(Build.Reason)' == 'PullRequest'
             repoPrefix = 'sonarsource-public'
+            targetRepo = None
+            repoxStatus = None            
             if isPr:
               targetRepo = repoPrefix + '-dev'
               repoxStatus = 'it-passed-pr'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,38 +51,6 @@ stages:
   - stage: build
     displayName: 'Build:'
     jobs:
-      - job: promoteRepox
-        displayName: Call repox
-        steps:
-        - checkout: none
-        - powershell: |
-            $isPr=$env:BUILD_REASON -eq 'PullRequest'
-            $repoPrefix = 'sonarsource-public'
-            $it = Get-Date -Format s
-            if ($isPr)
-            {
-              $targetRepo = $repoPrefix + '-dev'
-              $repoxStatus = 'it-passed-pr'
-            } 
-            else
-            {
-              $targetRepo = $repoPrefix + '-builds'
-              $repoxStatus = 'it-passed'
-            }
-            Write-Host "##vso[task.setvariable variable=targetRepo;]$targetRepo"
-            Write-Host "##vso[task.setvariable variable=repoxStatus;]$repoxStatus"
-            Write-Host "##vso[task.setvariable variable=it;]$it"
-          displayName: Calculate promotion values
-        - task: JFrogBuildPromotion@1
-          name: promoteRepoxCLI
-          inputs:
-            artifactoryConnection: repox_promoter_token
-            buildName: sonar-scanner-msbuild
-            buildNumber: $(Build.BuildId)
-            targetRepo: $(targetRepo)
-            status: $(repoxStatus)
-            dryRun: true
-
       - job: build
         displayName: 'Build and stage to repox'
         workspace:
@@ -530,6 +498,34 @@ stages:
     - qa
     condition: and(succeeded(), or(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.SourceBranchName'], 'main', 'master'), startsWith(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'branch')))
     jobs:
+    - powershell: |
+        $isPr=$env:BUILD_REASON -eq 'PullRequest'
+        $repoPrefix = 'sonarsource-public'
+        $it = Get-Date -Format s
+        if ($isPr)
+        {
+          $targetRepo = $repoPrefix + '-dev'
+          $repoxStatus = 'it-passed-pr'
+        } 
+        else
+        {
+          $targetRepo = $repoPrefix + '-builds'
+          $repoxStatus = 'it-passed'
+        }
+        Write-Host "##vso[task.setvariable variable=targetRepo;]$targetRepo"
+        Write-Host "##vso[task.setvariable variable=repoxStatus;]$repoxStatus"
+        Write-Host "##vso[task.setvariable variable=it;]$it"
+      displayName: Calculate promotion values
+    - task: JFrogBuildPromotion@1
+      name: promoteRepoxCLI
+      inputs:
+        artifactoryConnection: repox_promoter_token
+        buildName: sonar-scanner-msbuild
+        buildNumber: $(Build.BuildId)
+        targetRepo: $(targetRepo)
+        status: $(repoxStatus)
+        dryRun: true
+
     - job: promoteRepox
       displayName: Call repox
       steps:
@@ -562,7 +558,7 @@ stages:
             isPr = '$(Build.Reason)' == 'PullRequest'
             repoPrefix = 'sonarsource-public'
             targetRepo = None
-            repoxStatus = None            
+            repoxStatus = None
             if isPr:
               targetRepo = repoPrefix + '-dev'
               repoxStatus = 'it-passed-pr'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -502,7 +502,31 @@ stages:
       displayName: Call repox
       steps:
       - checkout: none
-
+      - powershell: |
+          $isPr = $env:BUILD_REASON == 'PullRequest'
+          $repoPrefix = 'sonarsource-public'
+          $it = Get-Date -Format s
+          if (isPr)
+          {
+            $targetRepo = repoPrefix + '-dev'
+            $repoxStatus = 'it-passed-pr'
+          } 
+          else
+          {
+            $targetRepo = repoPrefix + '-builds'
+            $repoxStatus = 'it-passed'
+          }
+          Write-Host "##vso[task.setvariable variable=targetRepo;]$targetRepo"
+          Write-Host "##vso[task.setvariable variable=repoxStatus;]$repoxStatus"
+          Write-Host "##vso[task.setvariable variable=it;]$it"
+        displayName: Calculate promotion values
+      - task: JfrogCliV2@1
+        name: promoteRepoxCLI
+        inputs:
+          jfrogPlatformConnection: repox_promoter_token
+          command: |
+            jf rt bpr sonar-scanner-msbuild $(Build.BuildId) $(targetRepo) --status $repoxStatus --props "it=$(it)" --dry-run
+      
       - task: UsePythonVersion@0
         inputs:
           versionSpec: '3.x'
@@ -530,8 +554,6 @@ stages:
             buildNumber = '$(Build.BuildId)'
             isPr = '$(Build.Reason)' == 'PullRequest'
             repoPrefix = 'sonarsource-public'
-            targetRepo = None
-            repoxStatus = None
             if isPr:
               targetRepo = repoPrefix + '-dev'
               repoxStatus = 'it-passed-pr'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,7 +80,7 @@ stages:
             buildName: sonar-scanner-msbuild
             buildNumber: $(Build.BuildId)
             targetRepo: $(targetRepo)
-            status: $repoxStatus
+            status: $(repoxStatus)
             dryRun: true
 
       - job: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,35 @@ stages:
   - stage: build
     displayName: 'Build:'
     jobs:
+    - job: promoteRepox
+      displayName: Call repox
+      steps:
+      - checkout: none
+      - powershell: |
+          $isPr = $env:BUILD_REASON == 'PullRequest'
+          $repoPrefix = 'sonarsource-public'
+          $it = Get-Date -Format s
+          if (isPr)
+          {
+            $targetRepo = repoPrefix + '-dev'
+            $repoxStatus = 'it-passed-pr'
+          } 
+          else
+          {
+            $targetRepo = repoPrefix + '-builds'
+            $repoxStatus = 'it-passed'
+          }
+          Write-Host "##vso[task.setvariable variable=targetRepo;]$targetRepo"
+          Write-Host "##vso[task.setvariable variable=repoxStatus;]$repoxStatus"
+          Write-Host "##vso[task.setvariable variable=it;]$it"
+        displayName: Calculate promotion values
+      - task: JfrogCliV2@1
+        name: promoteRepoxCLI
+        inputs:
+          jfrogPlatformConnection: repox_promoter_token
+          command: |
+            jf rt bpr sonar-scanner-msbuild $(Build.BuildId) $(targetRepo) --status $repoxStatus --props "it=$(it)" --dry-run
+
       - job: build
         displayName: 'Build and stage to repox'
         workspace:
@@ -497,36 +526,7 @@ stages:
     - build
     - qa
     condition: and(succeeded(), or(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.SourceBranchName'], 'main', 'master'), startsWith(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'branch')))
-    jobs:
-    - job: promoteRepox
-      displayName: Call repox
-      steps:
-      - checkout: none
-      - powershell: |
-          $isPr = $env:BUILD_REASON == 'PullRequest'
-          $repoPrefix = 'sonarsource-public'
-          $it = Get-Date -Format s
-          if (isPr)
-          {
-            $targetRepo = repoPrefix + '-dev'
-            $repoxStatus = 'it-passed-pr'
-          } 
-          else
-          {
-            $targetRepo = repoPrefix + '-builds'
-            $repoxStatus = 'it-passed'
-          }
-          Write-Host "##vso[task.setvariable variable=targetRepo;]$targetRepo"
-          Write-Host "##vso[task.setvariable variable=repoxStatus;]$repoxStatus"
-          Write-Host "##vso[task.setvariable variable=it;]$it"
-        displayName: Calculate promotion values
-      - task: JfrogCliV2@1
-        name: promoteRepoxCLI
-        inputs:
-          jfrogPlatformConnection: repox_promoter_token
-          command: |
-            jf rt bpr sonar-scanner-msbuild $(Build.BuildId) $(targetRepo) --status $repoxStatus --props "it=$(it)" --dry-run
-      
+    jobs:    
       - task: UsePythonVersion@0
         inputs:
           versionSpec: '3.x'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -498,38 +498,38 @@ stages:
     - qa
     condition: and(succeeded(), or(eq(variables['Build.Reason'], 'PullRequest'), in(variables['Build.SourceBranchName'], 'main', 'master'), startsWith(replace(variables['Build.SourceBranch'], 'refs/heads/', ''), 'branch')))
     jobs:
-    - powershell: |
-        $isPr=$env:BUILD_REASON -eq 'PullRequest'
-        $repoPrefix = 'sonarsource-public'
-        $it = Get-Date -Format s
-        if ($isPr)
-        {
-          $targetRepo = $repoPrefix + '-dev'
-          $repoxStatus = 'it-passed-pr'
-        } 
-        else
-        {
-          $targetRepo = $repoPrefix + '-builds'
-          $repoxStatus = 'it-passed'
-        }
-        Write-Host "##vso[task.setvariable variable=targetRepo;]$targetRepo"
-        Write-Host "##vso[task.setvariable variable=repoxStatus;]$repoxStatus"
-        Write-Host "##vso[task.setvariable variable=it;]$it"
-      displayName: Calculate promotion values
-    - task: JFrogBuildPromotion@1
-      name: promoteRepoxCLI
-      inputs:
-        artifactoryConnection: repox_promoter_token
-        buildName: sonar-scanner-msbuild
-        buildNumber: $(Build.BuildId)
-        targetRepo: $(targetRepo)
-        status: $(repoxStatus)
-        dryRun: true
-
     - job: promoteRepox
       displayName: Call repox
       steps:
       - checkout: none
+      - powershell: |
+          $isPr=$env:BUILD_REASON -eq 'PullRequest'
+          $repoPrefix = 'sonarsource-public'
+          $it = Get-Date -Format s
+          if ($isPr)
+          {
+            $targetRepo = $repoPrefix + '-dev'
+            $repoxStatus = 'it-passed-pr'
+          } 
+          else
+          {
+            $targetRepo = $repoPrefix + '-builds'
+            $repoxStatus = 'it-passed'
+          }
+          Write-Host "##vso[task.setvariable variable=targetRepo;]$targetRepo"
+          Write-Host "##vso[task.setvariable variable=repoxStatus;]$repoxStatus"
+          Write-Host "##vso[task.setvariable variable=it;]$it"
+        displayName: Calculate promotion values
+      - task: JFrogBuildPromotion@1
+        name: promoteRepoxCLI
+        inputs:
+          artifactoryConnection: repox_promoter_token
+          buildName: sonar-scanner-msbuild
+          buildNumber: $(Build.BuildId)
+          targetRepo: $(targetRepo)
+          status: $(repoxStatus)
+          dryRun: true
+          
       - task: UsePythonVersion@0
         inputs:
           versionSpec: '3.x'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,12 +73,15 @@ stages:
             Write-Host "##vso[task.setvariable variable=repoxStatus;]$repoxStatus"
             Write-Host "##vso[task.setvariable variable=it;]$it"
           displayName: Calculate promotion values
-        - task: JfrogCliV2@1
+        - task: JFrogBuildPromotion@1
           name: promoteRepoxCLI
           inputs:
-            jfrogPlatformConnection: repox_promoter_token
-            command: |
-              jf rt bpr sonar-scanner-msbuild $(Build.BuildId) $(targetRepo) --status $repoxStatus --props "it=$(it)" --dry-run
+            artifactoryConnection: repox_promoter_token
+            buildName: sonar-scanner-msbuild
+            buildNumber: $(Build.BuildId)
+            targetRepo: $(targetRepo)
+            status: $repoxStatus
+            dryRun: true
 
       - job: build
         displayName: 'Build and stage to repox'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,8 @@ stages:
         steps:
           - checkout: self
           - powershell: ls env:* | sort | fl
-            displayname: Print env
+            displayName: Print env
+            
           - task: NuGetToolInstaller@1
             displayName: "Install NuGet"
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -526,8 +526,12 @@ stages:
           artifactoryConnection: repox_promoter_token
           buildName: sonar-scanner-msbuild
           buildNumber: $(Build.BuildId)
-          targetRepo: $(targetRepo)
-          status: $(repoxStatus)
+          ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+            targetRepo: 'sonarsource-public-dev'
+            status: 'it-passed-pr'
+          ${{ else }}:
+            targetRepo: 'sonarsource-public-builds'
+            status: 'it-passed'          
           dryRun: true
           
       - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,7 +61,8 @@ stages:
           commonMavenArguments: -B -Pdeploy-sonarsource -Dmaven.test.skip=true
         steps:
           - checkout: self
-
+          - powershell: ls env:* | sort | fl
+            displayname: Print env
           - task: NuGetToolInstaller@1
             displayName: "Install NuGet"
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,34 +51,34 @@ stages:
   - stage: build
     displayName: 'Build:'
     jobs:
-    - job: promoteRepox
-      displayName: Call repox
-      steps:
-      - checkout: none
-      - powershell: |
-          $isPr = $env:BUILD_REASON == 'PullRequest'
-          $repoPrefix = 'sonarsource-public'
-          $it = Get-Date -Format s
-          if (isPr)
-          {
-            $targetRepo = repoPrefix + '-dev'
-            $repoxStatus = 'it-passed-pr'
-          } 
-          else
-          {
-            $targetRepo = repoPrefix + '-builds'
-            $repoxStatus = 'it-passed'
-          }
-          Write-Host "##vso[task.setvariable variable=targetRepo;]$targetRepo"
-          Write-Host "##vso[task.setvariable variable=repoxStatus;]$repoxStatus"
-          Write-Host "##vso[task.setvariable variable=it;]$it"
-        displayName: Calculate promotion values
-      - task: JfrogCliV2@1
-        name: promoteRepoxCLI
-        inputs:
-          jfrogPlatformConnection: repox_promoter_token
-          command: |
-            jf rt bpr sonar-scanner-msbuild $(Build.BuildId) $(targetRepo) --status $repoxStatus --props "it=$(it)" --dry-run
+      - job: promoteRepox
+        displayName: Call repox
+        steps:
+        - checkout: none
+        - powershell: |
+            $isPr = $env:BUILD_REASON == 'PullRequest'
+            $repoPrefix = 'sonarsource-public'
+            $it = Get-Date -Format s
+            if (isPr)
+            {
+              $targetRepo = repoPrefix + '-dev'
+              $repoxStatus = 'it-passed-pr'
+            } 
+            else
+            {
+              $targetRepo = repoPrefix + '-builds'
+              $repoxStatus = 'it-passed'
+            }
+            Write-Host "##vso[task.setvariable variable=targetRepo;]$targetRepo"
+            Write-Host "##vso[task.setvariable variable=repoxStatus;]$repoxStatus"
+            Write-Host "##vso[task.setvariable variable=it;]$it"
+          displayName: Calculate promotion values
+        - task: JfrogCliV2@1
+          name: promoteRepoxCLI
+          inputs:
+            jfrogPlatformConnection: repox_promoter_token
+            command: |
+              jf rt bpr sonar-scanner-msbuild $(Build.BuildId) $(targetRepo) --status $repoxStatus --props "it=$(it)" --dry-run
 
       - job: build
         displayName: 'Build and stage to repox'


### PR DESCRIPTION
[SCAN4NET-38](https://sonarsource.atlassian.net/browse/SCAN4NET-38)

Published artifacts:

The last run of the python script based promotion:
https://repox.jfrog.io/ui/builds/sonar-scanner-msbuild/99288/1725524835930/published/org.sonarsource.scanner.msbuild:scanner-msbuild-its:9.0.0.99288

The first run with the [JFrogBuildPromotion](https://github.com/jfrog/jfrog-azure-devops-extension?tab=readme-ov-file#jfrog-build-promotion) task
https://repox.jfrog.io/ui/builds/sonar-scanner-msbuild/99295/1725527058518/published/org.sonarsource.scanner.msbuild:scanner-msbuild-its:9.0.0.99295

[SCAN4NET-38]: https://sonarsource.atlassian.net/browse/SCAN4NET-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ