### PR TITLE
SCAN4NET-39 Bump version to 9.0.0

### DIFF
--- a/AssemblyInfo.Shared.cs
+++ b/AssemblyInfo.Shared.cs
@@ -24,7 +24,7 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyVersion("9.0.0")]
 [assembly: AssemblyFileVersion("9.0.0.0")]
-[assembly: AssemblyInformationalVersion("Version:9.0.0-rc.0 Branch:not-set Sha1:not-set")]
+[assembly: AssemblyInformationalVersion("Version:9.0.0.0 Branch:not-set Sha1:not-set")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SonarSource and Microsoft")]
 [assembly: AssemblyCopyright("Copyright © SonarSource and Microsoft 2015-2023")]

--- a/nuspec/netcoreglobaltool/dotnet-sonarscanner.nuspec
+++ b/nuspec/netcoreglobaltool/dotnet-sonarscanner.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>dotnet-sonarscanner</id>
-    <version>9.0.0-rc</version>
+    <version>9.0.0</version>
     <title>SonarScanner for .NET</title>
     <authors>SonarSource,Microsoft</authors>
     <projectUrl>https://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>

--- a/scripts/version/Version.props
+++ b/scripts/version/Version.props
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <MainVersion>9.0.0</MainVersion>
     <BuildNumber>0</BuildNumber>
-    <PrereleaseSuffix>-rc</PrereleaseSuffix>
+    <PrereleaseSuffix>
+    </PrereleaseSuffix>
     <Sha1>not-set</Sha1>
     <BranchName>not-set</BranchName>
     <AssemblyVersion>$(MainVersion)</AssemblyVersion>


### PR DESCRIPTION
[SCAN4NET-39](https://sonarsource.atlassian.net/browse/SCAN4NET-39)



[SCAN4NET-39]: https://sonarsource.atlassian.net/browse/SCAN4NET-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ