### PR TITLE
SCAN4NET-41 Prerelease versioning: Allow numbering

### DIFF
--- a/scripts/version/set-version.ps1
+++ b/scripts/version/set-version.ps1
@@ -12,7 +12,7 @@ Param(
     [string]$version,
 
     [Parameter(Mandatory = $False)]
-    [ValidatePattern("^alpha|beta|rc$")] # see https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#pre-release-versions
+    [ValidatePattern("^(alpha|beta|rc)\d{0,2}$")] # see https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#pre-release-versions
     [string]$prereleaseSuffix = ""
 )
 


### PR DESCRIPTION
[SCAN4NET-41](https://sonarsource.atlassian.net/browse/SCAN4NET-41)

Allows numbering in prereleases, e.g.:

- rc
- rc2
- rc99

[SCAN4NET-41]: https://sonarsource.atlassian.net/browse/SCAN4NET-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ