### PR TITLE
SCAN4NET-44 Multi Language Suport: Properly revert projectBaseDir when scanAll=false

### DIFF
--- a/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/PropertiesFileGeneratorTests.cs
@@ -1178,7 +1178,7 @@ public class PropertiesFileGeneratorTests
     [TestMethod]
     public void ComputeProjectBaseDir_WorkingDirectory_AllFilesInWorkingDirectory()
     {
-        var sut = new PropertiesFileGenerator(new AnalysisConfig { SonarScannerWorkingDirectory = @"C:\Projects" }, logger);
+        var sut = new PropertiesFileGenerator(new AnalysisConfig {ScanAllAnalysis = true, SonarScannerWorkingDirectory = @"C:\Projects" }, logger);
         var projectPaths = new[]
         {
             new DirectoryInfo(@"C:\Projects\Name\Lib"),
@@ -1189,6 +1189,27 @@ public class PropertiesFileGeneratorTests
         sut.ComputeProjectBaseDir(projectPaths).FullName.Should().Be(@"C:\Projects");
         logger.AssertNoWarningsLogged();
         logger.DebugMessages.Should().BeEquivalentTo(@"Using working directory as project base directory: 'C:\Projects'.");
+    }
+
+    [TestMethod]
+    public void ComputeProjectBaseDir_WorkingDirectory_AllFilesInWorkingDirectory_ScanAllAnalysisDisabled()
+    {
+        var sut = new PropertiesFileGenerator(new AnalysisConfig { ScanAllAnalysis = false, SonarScannerWorkingDirectory = @"C:\Projects" }, logger);
+        var projectPaths = new[]
+        {
+            new DirectoryInfo(@"C:\Projects\Name\Lib"),
+            new DirectoryInfo(@"C:\Projects\Name\Src"),
+            new DirectoryInfo(@"C:\Projects\Name\Test"),
+        };
+
+        sut.ComputeProjectBaseDir(projectPaths).FullName.Should().Be(@"C:\Projects\Name");
+        logger.AssertNoWarningsLogged();
+        logger.DebugMessages.Should().BeEquivalentTo("""
+            Using longest common projects path as a base directory: 'C:\Projects\Name'. Identified project paths:
+            C:\Projects\Name\Lib
+            C:\Projects\Name\Src
+            C:\Projects\Name\Test
+            """);
     }
 
     [TestMethod]

--- a/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesFileGenerator.cs
@@ -272,7 +272,8 @@ public class PropertiesFileGenerator : IPropertiesFileGenerator
             logger.LogDebug(Resources.MSG_UsingAzDoSourceDirectoryAsProjectBaseDir, baseDirectory.FullName);
             return baseDirectory;
         }
-        else if (analysisConfig.SonarScannerWorkingDirectory is { } workingDirectoryPath
+        else if (analysisConfig.ScanAllAnalysis // When ScanAll functionality is disabled, we also disable the current working directory functionality.
+            && analysisConfig.SonarScannerWorkingDirectory is { } workingDirectoryPath
             && new DirectoryInfo(workingDirectoryPath) is { } workingDirectory
             && projectPaths.All(x => x.FullName.StartsWith(workingDirectory.FullName, pathComparison)))
         {


### PR DESCRIPTION
[SCAN4NET-44](https://sonarsource.atlassian.net/browse/SCAN4NET-44)

Part of <!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->


[SCAN4NET-44]: https://sonarsource.atlassian.net/browse/SCAN4NET-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ