### PR TITLE
SCAN4NET-74 Bump version to 8.0.4

### DIFF
--- a/AssemblyInfo.Shared.cs
+++ b/AssemblyInfo.Shared.cs
@@ -22,9 +22,9 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("8.0.3")]
-[assembly: AssemblyFileVersion("8.0.3.0")]
-[assembly: AssemblyInformationalVersion("Version:8.0.3.0 Branch:not-set Sha1:not-set")]
+[assembly: AssemblyVersion("8.0.4")]
+[assembly: AssemblyFileVersion("8.0.4.0")]
+[assembly: AssemblyInformationalVersion("Version:8.0.4.0 Branch:not-set Sha1:not-set")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SonarSource and Microsoft")]
 [assembly: AssemblyCopyright("Copyright © SonarSource and Microsoft 2015-2023")]

--- a/nuspec/netcoreglobaltool/dotnet-sonarscanner.nuspec
+++ b/nuspec/netcoreglobaltool/dotnet-sonarscanner.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>dotnet-sonarscanner</id>
-    <version>8.0.3</version>
+    <version>8.0.4</version>
     <title>SonarScanner for .NET</title>
     <authors>SonarSource,Microsoft</authors>
     <projectUrl>https://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>

--- a/scripts/version/Version.props
+++ b/scripts/version/Version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MainVersion>8.0.3</MainVersion>
+    <MainVersion>8.0.4</MainVersion>
     <BuildNumber>0</BuildNumber>
     <Sha1>not-set</Sha1>
     <BranchName>not-set</BranchName>


### PR DESCRIPTION
[SCAN4NET-74](https://sonarsource.atlassian.net/browse/SCAN4NET-74)



[SCAN4NET-74]: https://sonarsource.atlassian.net/browse/SCAN4NET-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ