### PR TITLE
SCAN4NET-88 INFO level for invalid project GUIDs messages

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
@@ -146,7 +146,8 @@ public class E2EAnalysisTests
         actualStructure.ProjectInfo.ProjectGuid.Should().Be(Guid.Empty);
 
         result.AssertErrorCount(0);
-        result.Warnings.Should().Contain(x => x.Contains(projectFilePath), "Expecting the warning to contain the full path to the bad project file");
+        result.AssertNoWarningsOrErrors();
+        result.Messages.Should().Contain(x => x.Contains(projectFilePath), "Expecting the warning to contain the full path to the bad project file");
     }
 
     [TestMethod]

--- a/src/SonarScanner.MSBuild.Tasks/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.Tasks/Resources.Designer.cs
@@ -342,7 +342,7 @@ namespace SonarScanner.MSBuild.Tasks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The project does not have a valid ProjectGuid. Analysis results for this project will not be uploaded. Project file: {0}.
+        ///   Looks up a localized string similar to Sonar: The project does not have a valid ProjectGuid. Analysis results for this project will not be uploaded. Project file: {0}.
         /// </summary>
         internal static string WPIF_MissingOrInvalidProjectGuid {
             get {

--- a/src/SonarScanner.MSBuild.Tasks/Resources.resx
+++ b/src/SonarScanner.MSBuild.Tasks/Resources.resx
@@ -145,7 +145,7 @@ Error: {1}</value>
     <value>Failed to resolve path relative to project file. Path: {0}</value>
   </data>
   <data name="WPIF_MissingOrInvalidProjectGuid" xml:space="preserve">
-    <value>The project does not have a valid ProjectGuid. Analysis results for this project will not be uploaded. Project file: {0}</value>
+    <value>Sonar: The project does not have a valid ProjectGuid. Analysis results for this project will not be uploaded. Project file: {0}</value>
   </data>
   <data name="WPIF_ResolvedPath" xml:space="preserve">
     <value>Resolved relative path. Path: {0}</value>

--- a/src/SonarScanner.MSBuild.Tasks/WriteProjectInfoFile.cs
+++ b/src/SonarScanner.MSBuild.Tasks/WriteProjectInfoFile.cs
@@ -106,7 +106,7 @@ public class WriteProjectInfoFile(IEncodingProvider encodingProvider) : Task
         }
         else
         {
-            Log.LogWarning(Resources.WPIF_MissingOrInvalidProjectGuid, FullProjectPath);
+            Log.LogMessage(MessageImportance.High, Resources.WPIF_MissingOrInvalidProjectGuid, FullProjectPath);
         }
 
         pi.AnalysisResults = TryCreateAnalysisResults(AnalysisResults);


### PR DESCRIPTION
[SCAN4NET-88](https://sonarsource.atlassian.net/browse/SCAN4NET-88)

Part of https://sonarsource.atlassian.net/browse/SCAN4NET-59

[SCAN4NET-88]: https://sonarsource.atlassian.net/browse/SCAN4NET-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ