### PR TITLE
SCAN4NET-96 and SCAN4NET-97: Fix logger timestamp duplication

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/Infrastructure/OutputCaptureScope.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/Infrastructure/OutputCaptureScope.cs
@@ -64,6 +64,12 @@ public sealed class OutputCaptureScope : IDisposable
         lastMessage.Should().Be(expected, "Expected message was not logged");
     }
 
+    public void AssertExpectedLastMessageRegex(string expected)
+    {
+        var lastMessage = GetLastMessage(outputWriter);
+        lastMessage.Should().MatchRegex(expected, "Expected message was not logged");
+    }
+
     public void AssertLastMessageEndsWith(string expected)
     {
         var lastMessage = GetLastMessage(outputWriter);


### PR DESCRIPTION
[SCAN4NET-96](https://sonarsource.atlassian.net/browse/SCAN4NET-96)
[SCAN4NET-97](https://sonarsource.atlassian.net/browse/SCAN4NET-97)



[SCAN4NET-96]: https://sonarsource.atlassian.net/browse/SCAN4NET-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCAN4NET-97]: https://sonarsource.atlassian.net/browse/SCAN4NET-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ