### PR TITLE
SCAN4NET-100 Remove timestamps from UI Warnings

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/ILoggerTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/ILoggerTests.cs
@@ -318,20 +318,21 @@ public class ILoggerTests
     [TestMethod]
     public void ConsoleLogger_WriteUIWarnings_GenerateFile()
     {
+        const string prefixRegex = @"\d{2}:\d{2}:\d{2}(.\d{1,3})?  WARNING:";
         using var output = new OutputCaptureScope();
-        var logger = new ConsoleLogger(includeTimestamp: false, fileWrapper);
+        var logger = new ConsoleLogger(includeTimestamp: true, fileWrapper);
 
         logger.LogUIWarning("uiWarn1");
-        output.AssertLastMessageEndsWith("uiWarn1"); // UI warnings should also be logged in the console
+        output.AssertExpectedLastMessageRegex($"{prefixRegex} uiWarn1");
 
         logger.LogUIWarning("uiWarn2", null);
-        output.AssertLastMessageEndsWith("uiWarn2");
+        output.AssertExpectedLastMessageRegex($"{prefixRegex} uiWarn2");
 
         logger.LogUIWarning("uiWarn3 {0}", "xxx");
-        output.AssertLastMessageEndsWith("uiWarn3 xxx");
+        output.AssertExpectedLastMessageRegex($"{prefixRegex} uiWarn3 xxx");
 
         const string outputDir = "outputDir";
-        logger.WriteUIWarnings(outputDir);
+        logger.WriteUIWarnings(outputDir); // this should not contain any timestamps.
         fileWrapper.Received(1).WriteAllText(
              Path.Combine(outputDir, FileConstants.UIWarningsFileName),
              """
@@ -347,23 +348,6 @@ public class ILoggerTests
                }
              ]
              """);
-    }
-
-    [TestMethod]
-    public void ConsoleLogger_WriteUIWarnings_ContainsTimeStampOnce()
-    {
-        const string prefixRegex = @"\d{2}:\d{2}:\d{2}(.\d{1,3})?  WARNING:";
-        using var output = new OutputCaptureScope();
-        var logger = new ConsoleLogger(includeTimestamp: true, fileWrapper);
-
-        logger.LogUIWarning("uiWarn1");
-        output.AssertExpectedLastMessageRegex($"{prefixRegex} uiWarn1");
-
-        logger.LogUIWarning("uiWarn2", null);
-        output.AssertExpectedLastMessageRegex($"{prefixRegex} uiWarn2");
-
-        logger.LogUIWarning("uiWarn3 {0}", "xxx");
-        output.AssertExpectedLastMessageRegex($"{prefixRegex} uiWarn3 xxx");
     }
 
     [TestMethod]

--- a/src/SonarScanner.MSBuild.Common/ConsoleLogger.cs
+++ b/src/SonarScanner.MSBuild.Common/ConsoleLogger.cs
@@ -124,7 +124,10 @@ public class ConsoleLogger : ILogger
 
     public void LogUIWarning(string message, params object[] args)
     {
+        var before = IncludeTimestamp; // this is a hack to prevent the timestamp from appearing on the UI, if it was set beforehand.
+        IncludeTimestamp = false;
         uiWarnings.Add(GetFormattedMessage(message, args));
+        IncludeTimestamp = before;
         LogWarning(message, args);
     }
 


### PR DESCRIPTION
SCAN4NET-100

Before:

![image](https://github.com/user-attachments/assets/ee27f39e-8753-416a-8b9f-570256cf1979)


After:

![image](https://github.com/user-attachments/assets/83feb62d-2b2e-4c3a-abc6-e80242cf14d7)

