### PR TITLE
SCAN4NET-105 Update MSBuild.StructuredLogger to fix build

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/Infrastructure/TargetConstants.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/Infrastructure/TargetConstants.cs
@@ -121,8 +121,8 @@ internal static class TargetProperties
     public const string AdditionalFilesItemType = "AdditionalFiles";
 
     public const string SonarProjectOutFolderFilePath = "SonarProjectOutFolderFilePath";
-    public const string SonarProjectConfigFilePath = "SonarProjectConfigFilePath from parameter ProjectConfigFilePath"; // Issue in the MsBuild structured logger.
-    public const string ProjectSpecificOutDir = "ProjectSpecificOutDir from parameter UniquePath"; // Issue in the MsBuild structured logger.
+    public const string SonarProjectConfigFilePath = "SonarProjectConfigFilePath";
+    public const string ProjectSpecificOutDir = "ProjectSpecificOutDir";
     public const string ProjectSpecificConfDir = "ProjectSpecificConfDir";
 
     // Legacy TeamBuild environment variables (XAML Builds)

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/SonarScanner.MSBuild.Tasks.IntegrationTest.csproj
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/SonarScanner.MSBuild.Tasks.IntegrationTest.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Build.Framework" Version="17.8.3" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.291" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.2.350" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.5.0" />
     <PackageReference Include="MSTest.TestFramework" Version="3.5.0" />


### PR DESCRIPTION
SCAN4NET-105
Part of https://sonarsource.atlassian.net/browse/SCAN4NET-93

Unit tests are failing since the MsBuild structured logger is logging this warning: https://github.com/KirillOsenkov/MSBuildStructuredLog/blob/main/src/StructuredLogger/BinaryLog.cs#L169 when running on .NET 9 rc-1