### PR TITLE
SCAN4NET-110 Bump version to 9.1.0

### DIFF
--- a/AssemblyInfo.Shared.cs
+++ b/AssemblyInfo.Shared.cs
@@ -22,9 +22,9 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("9.0.0")]
-[assembly: AssemblyFileVersion("9.0.0.0")]
-[assembly: AssemblyInformationalVersion("Version:9.0.0.0 Branch:not-set Sha1:not-set")]
+[assembly: AssemblyVersion("9.1.0")]
+[assembly: AssemblyFileVersion("9.1.0.0")]
+[assembly: AssemblyInformationalVersion("Version:9.1.0.0 Branch:not-set Sha1:not-set")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SonarSource and Microsoft")]
 [assembly: AssemblyCopyright("Copyright © SonarSource and Microsoft 2015-2023")]

--- a/nuspec/netcoreglobaltool/dotnet-sonarscanner.nuspec
+++ b/nuspec/netcoreglobaltool/dotnet-sonarscanner.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>dotnet-sonarscanner</id>
-    <version>9.0.0</version>
+    <version>9.1.0</version>
     <title>SonarScanner for .NET</title>
     <authors>SonarSource,Microsoft</authors>
     <projectUrl>https://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>

--- a/scripts/version/Version.props
+++ b/scripts/version/Version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MainVersion>9.0.0</MainVersion>
+    <MainVersion>9.1.0</MainVersion>
     <BuildNumber>0</BuildNumber>
     <PrereleaseSuffix>
     </PrereleaseSuffix>


### PR DESCRIPTION
[SCAN4NET-110](https://sonarsource.atlassian.net/browse/SCAN4NET-110)



[SCAN4NET-110]: https://sonarsource.atlassian.net/browse/SCAN4NET-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ