### PR TITLE
SCAN4NET-142 Revert to using predefined variables to build coverage path

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -292,8 +292,8 @@ stages:
               projectVersion: '$(SONAR_PROJECT_VERSION)'
               scannerMode: 'dotnet'
               extraProperties: |
-                sonar.cs.opencover.reportsPaths="**/coverage/**.xml"
-                sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"
+                sonar.cs.opencover.reportsPaths="$(Build.SourcesDirectory)/coverage/**.xml"
+                sonar.cs.vstest.reportsPaths="$(Build.SourcesDirectory)/TestResults/*.trx"
 
           - task: VSBuild@1
             displayName: "Build and analyze project"


### PR DESCRIPTION
[SCAN4NET-142](https://sonarsource.atlassian.net/browse/SCAN4NET-142)


[SCAN4NET-142]: https://sonarsource.atlassian.net/browse/SCAN4NET-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ