### PR TITLE
SCAN4NET-148 Use the correct environment variable name

### DIFF
--- a/src/SonarScanner.MSBuild.Common/TFS/BuildSettings.cs
+++ b/src/SonarScanner.MSBuild.Common/TFS/BuildSettings.cs
@@ -234,7 +234,7 @@ public class BuildSettings : IBuildSettings
         /// </summary>
         public const string LegacyCodeCoverageTimeoutInMs = "SQ_LegacyCodeCoverageInMs";
 
-        public const string IsInTeamFoundationBuild = "TF_Build"; // Common to legacy and non-legacy TeamBuilds
+        public const string IsInTeamFoundationBuild = "TF_BUILD"; // Common to legacy and non-legacy TeamBuilds
 
         // Legacy TeamBuild environment variables (XAML Builds)
         public const string TfsCollectionUri_Legacy = "TF_BUILD_COLLECTIONURI";


### PR DESCRIPTION
[SCAN4NET-148](https://sonarsource.atlassian.net/browse/SCAN4NET-148)

Part of https://sonarsource.atlassian.net/browse/SCAN4NET-147

The environment variables under Unix are case-sensitive. Is set the value from the [documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#:~:text=No-,TF_BUILD,-Set%20to%20True).

Since the current pipeline is configured to run under Windows, I currently cannot add an integration test. I added a point on https://trello.com/c/f58uStZK to add an integration test once we have a Unix pipeline.

[SCAN4NET-148]: https://sonarsource.atlassian.net/browse/SCAN4NET-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ