### PR TITLE
SCAN4NET-154 ITs: Update the Xamarin test project dependencies

### DIFF
--- a/its/projects/XamarinApplication/XamarinApplication.iOS/XamarinApplication.iOS.csproj
+++ b/its/projects/XamarinApplication/XamarinApplication.iOS/XamarinApplication.iOS.csproj
@@ -82,7 +82,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/its/projects/XamarinApplication/XamarinApplication/XamarinApplication.csproj
+++ b/its/projects/XamarinApplication/XamarinApplication/XamarinApplication.csproj
@@ -12,6 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2012" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.8.1" />
   </ItemGroup>
 </Project>

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -525,6 +525,11 @@ class ScannerMSBuildTest {
 
   @Test
   void testXamlCompilation() throws IOException {
+    // We can't build with MSBuild 15
+    // error MSB4018: System.InvalidOperationException: This implementation is not part of the Windows Platform FIPS validated cryptographic algorithms.
+    // at System.Security.Cryptography.MD5CryptoServiceProvider..ctor()
+    assumeFalse(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2017"));
+
     String localProjectKey = PROJECT_KEY + ".11";
     ORCHESTRATOR.getServer().provisionProject(localProjectKey, "Xamarin");
 


### PR DESCRIPTION
On the latest Golden AMI, when using MSBuild 15, the build fails with 
```
error MSB4018: System.InvalidOperationException: This implementation is not part of the Windows Platform FIPS validated cryptographic algorithms.
at System.Security.Cryptography.MD5CryptoServiceProvider..ctor()
```
I've updated the dependencies and skipped the test for XAML Compilation on MSBuild 15.