### PR TITLE
SCAN4NET-187 Upgrade CodeCoverage IT to .NET 9

### DIFF
--- a/its/projects/CodeCoverage/CodeCoverage.Test/CodeCoverage.Test.csproj
+++ b/its/projects/CodeCoverage/CodeCoverage.Test/CodeCoverage.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/its/projects/CodeCoverage/CodeCoverage/CodeCoverage.csproj
+++ b/its/projects/CodeCoverage/CodeCoverage/CodeCoverage.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>


### PR DESCRIPTION
[SCAN4NET-187](https://sonarsource.atlassian.net/browse/SCAN4NET-187)

Prerequesite for [removing .NET 7 from the CI image](https://trello.com/c/rusfGxhV/1617-remove-dotnet-7-installation-from-the-ci-image)

[SCAN4NET-187]: https://sonarsource.atlassian.net/browse/SCAN4NET-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ