### PR TITLE
SCAN4NET-217 Refactor RoslynAnalyzerProviderTests and RoslynRuleSetGeneratorTests

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockAnalyzerInstaller.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockAnalyzerInstaller.cs
@@ -27,11 +27,16 @@ using SonarScanner.MSBuild.PreProcessor.Roslyn;
 
 namespace SonarScanner.MSBuild.PreProcessor.Test;
 
-internal class MockAnalyzerInstaller : IAnalyzerInstaller
+internal class MockAnalyzerInstaller() : IAnalyzerInstaller
 {
     public List<Plugin> SuppliedPlugins = [];
 
     public IList<AnalyzerPlugin> AnalyzerPluginsToReturn { get; set; }
+
+    public MockAnalyzerInstaller(IList<AnalyzerPlugin> analyzerPluginsToReturn) : this()
+    {
+        AnalyzerPluginsToReturn = analyzerPluginsToReturn;
+    }
 
     public void AssertExpectedPluginsRequested(IEnumerable<string> plugins)
     {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockAnalyzerInstaller.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockAnalyzerInstaller.cs
@@ -27,16 +27,14 @@ using SonarScanner.MSBuild.PreProcessor.Roslyn;
 
 namespace SonarScanner.MSBuild.PreProcessor.Test;
 
-internal class MockAnalyzerInstaller() : IAnalyzerInstaller
+internal class MockAnalyzerInstaller : IAnalyzerInstaller
 {
     public List<Plugin> SuppliedPlugins = [];
 
     public IList<AnalyzerPlugin> AnalyzerPluginsToReturn { get; set; }
 
-    public MockAnalyzerInstaller(IList<AnalyzerPlugin> analyzerPluginsToReturn) : this()
-    {
+    public MockAnalyzerInstaller(IList<AnalyzerPlugin> analyzerPluginsToReturn = null) =>
         AnalyzerPluginsToReturn = analyzerPluginsToReturn;
-    }
 
     public void AssertExpectedPluginsRequested(IEnumerable<string> plugins)
     {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockRoslynAnalyzerProvider.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockRoslynAnalyzerProvider.cs
@@ -34,7 +34,6 @@ internal class MockRoslynAnalyzerProvider : RoslynAnalyzerProvider
     public IAnalysisPropertyProvider SuppliedSonarProperties { get; private set; }
 
     public MockRoslynAnalyzerProvider() : base(new MockAnalyzerInstaller(), new TestLogger()) {}
-
     public override AnalyzerSettings SetupAnalyzer(BuildSettings buildSettings, IAnalysisPropertyProvider sonarProperties, IEnumerable<SonarRule> rules, string language)
     {
         buildSettings.Should().NotBeNull();

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockRoslynAnalyzerProvider.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockRoslynAnalyzerProvider.cs
@@ -34,6 +34,7 @@ internal class MockRoslynAnalyzerProvider : RoslynAnalyzerProvider
     public IAnalysisPropertyProvider SuppliedSonarProperties { get; private set; }
 
     public MockRoslynAnalyzerProvider() : base(new MockAnalyzerInstaller(), new TestLogger()) {}
+
     public override AnalyzerSettings SetupAnalyzer(BuildSettings buildSettings, IAnalysisPropertyProvider sonarProperties, IEnumerable<SonarRule> rules, string language)
     {
         buildSettings.Should().NotBeNull();

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynAnalyzerProviderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynAnalyzerProviderTests.cs
@@ -54,9 +54,7 @@ public class RoslynAnalyzerProviderTests
         var language = RoslynAnalyzerProvider.CSharpLanguage;
         var sonarProperties = new ListPropertiesProvider();
         var settings = CreateSettings(TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext));
-
-        var testSubject = CreateTestSubject(logger);
-
+        var testSubject = new RoslynAnalyzerProvider(new MockAnalyzerInstaller(), logger);
         Action act = () => testSubject.SetupAnalyzer(null, sonarProperties, rules, language);
         act.Should().ThrowExactly<ArgumentNullException>();
         act = () => testSubject.SetupAnalyzer(settings, null, rules, language);
@@ -70,25 +68,13 @@ public class RoslynAnalyzerProviderTests
     [TestMethod]
     public void RoslynConfig_NoActiveRules()
     {
-        var logger = new TestLogger();
-        var rules = Enumerable.Empty<SonarRule>();
-        var pluginKey = "csharp";
-        var sonarProperties = new ListPropertiesProvider();
-        var settings = CreateSettings(TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext));
-
-        var testSubject = CreateTestSubject(logger);
-
-        testSubject.SetupAnalyzer(settings, sonarProperties, rules, pluginKey).Should().NotBeNull();
+        RoslynAnalyzerTestContext context = new(TestContext, TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext), []);
+        context.ExecuteTest().Should().NotBeNull();
     }
 
     [TestMethod]
     public void RoslynConfig_NoAssemblies()
     {
-        var rootFolder = CreateTestFolders();
-        var logger = new TestLogger();
-        var rules = CreateRules();
-        var language = RoslynAnalyzerProvider.CSharpLanguage;
-        // missing properties to get plugin related properties
         var sonarProperties = new ListPropertiesProvider(new Dictionary<string, string>
         {
             { "wintellect.analyzerId", "Wintellect.Analyzers" },
@@ -96,53 +82,30 @@ public class RoslynAnalyzerProviderTests
             { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
             { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" }
         });
-        var mockInstaller = new MockAnalyzerInstaller
-        {
-            AnalyzerPluginsToReturn = new List<AnalyzerPlugin> { CreateAnalyzerPlugin("c:\\assembly1.dll", "d:\\foo\\assembly2.dll") }
-        };
-        var settings = CreateSettings(rootFolder);
-        var testSubject = new RoslynAnalyzerProvider(mockInstaller, logger);
 
-        var actualSettings = testSubject.SetupAnalyzer(settings, sonarProperties, rules, language);
+        RoslynAnalyzerTestContext context = new(TestContext, [["c:\\assembly1.dll"]], sonarProperties);
 
-        CheckSettingsInvariants(actualSettings);
-        logger.AssertWarningsLogged(0);
-        logger.AssertErrorsLogged(0);
-        CheckRuleset(actualSettings.RulesetPath, rootFolder, language);
-        CheckTestRuleset(actualSettings.DeactivatedRulesetPath, rootFolder, language);
-        actualSettings.AnalyzerPlugins.Should().BeEmpty();
-        var plugins = new List<string>();
-        mockInstaller.AssertExpectedPluginsRequested(plugins);
+        context.ExecuteTest();
+
+        context.AssertAnalyzerSettingsAreCorrect();
+        context.AssertNoWarningsOrErrors();
+        context.AssertRulesetsAreCorrect();
+        context.AssertExpectedAssemblies([]);
+        context.AssertExpectedPluginsRequested([]);
     }
 
     [TestMethod]
     public void RoslynConfig_ValidProfile()
     {
-        var rootFolder = CreateTestFolders();
-        var logger = new TestLogger();
-        var rules = CreateRules();
-        var language = RoslynAnalyzerProvider.CSharpLanguage;
-        var mockInstaller = new MockAnalyzerInstaller
-        {
-            AnalyzerPluginsToReturn = new List<AnalyzerPlugin>
-            {
-                CreateAnalyzerPlugin("c:\\assembly1.dll"),
-                CreateAnalyzerPlugin("d:\\foo\\assembly2.dll")
-            }
-        };
-        var settings = CreateSettings(rootFolder);
-
         var sonarProperties = new ListPropertiesProvider(new Dictionary<string, string>
         {
             // for ruleset
             {"wintellect.analyzerId", "Wintellect.Analyzers" },
             {"wintellect.ruleNamespace", "Wintellect.Analyzers" },
-
             // to fetch assemblies
             {"wintellect.pluginKey", "wintellect"},
             {"wintellect.pluginVersion", "1.13.0"},
             {"wintellect.staticResourceName", "SonarAnalyzer.zip"},
-
             {"sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp"},
             {"sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp"},
             {"sonaranalyzer-cs.pluginKey", "csharp"},
@@ -150,13 +113,14 @@ public class RoslynAnalyzerProviderTests
             {"sonaranalyzer-cs.nuget.packageId", "SonarAnalyzer.CSharp"},
             {"sonaranalyzer-cs.pluginVersion", "1.13.0"},
             {"sonaranalyzer-cs.nuget.packageVersion", "1.13.0"},
-
             // Extra properties - those started sonar.cs should be included, the others ignored
             {"sonar.vb.testPropertyPattern", "foo"},
             {"sonar.cs.testPropertyPattern", "foo"},
             {"sonar.sources", "**/*.*"},
             {"sonar.cs.foo", "bar"}
         });
+        RoslynAnalyzerTestContext context = new(TestContext, [["c:\\assembly1.dll"], ["d:\\foo\\assembly2.dll"]], sonarProperties);
+
         var expectedSonarLintXml = """
             <?xml version="1.0" encoding="UTF-8"?>
             <AnalysisInput>
@@ -189,29 +153,18 @@ public class RoslynAnalyzerProviderTests
             </AnalysisInput>
 
             """;
-        var testSubject = new RoslynAnalyzerProvider(mockInstaller, logger);
 
-        var actualSettings = testSubject.SetupAnalyzer(settings, sonarProperties, rules, language);
+        context.ExecuteTest();
 
-        CheckSettingsInvariants(actualSettings);
-        logger.AssertWarningsLogged(0);
-        logger.AssertErrorsLogged(0);
-        CheckRuleset(actualSettings.RulesetPath, rootFolder, language);
-        CheckTestRuleset(actualSettings.DeactivatedRulesetPath, rootFolder, language);
-        // Currently, only SonarLint.xml is written
-        var filePaths = actualSettings.AdditionalFilePaths;
-        filePaths.Should().ContainSingle();
-        CheckExpectedAdditionalFileExists("SonarLint.xml", expectedSonarLintXml, actualSettings);
-        CheckExpectedAssemblies(actualSettings, "c:\\assembly1.dll", "d:\\foo\\assembly2.dll");
-        var plugins = new List<string>
-        {
-            "wintellect",
-            "csharp"
-        };
-        mockInstaller.AssertExpectedPluginsRequested(plugins);
+        context.AssertAnalyzerSettingsAreCorrect();
+        context.AssertNoWarningsOrErrors();
+        context.AssertRulesetsAreCorrect();
+        context.AssertExpectedAssemblies("c:\\assembly1.dll", "d:\\foo\\assembly2.dll");
+        context.AssertExpectedPluginsRequested(["wintellect", "csharp"]);
+        context.AssertExpectedAdditionalFileExists(expectedSonarLintXml);
     }
 
-    private List<SonarRule> CreateRules() =>
+    private static List<SonarRule> CreateRules() =>
         /*
         <Rules AnalyzerId=""SonarLint.CSharp"" RuleNamespace=""SonarLint.CSharp"">
         <Rule Id=""S1116"" Action=""Warning""/>
@@ -222,143 +175,157 @@ public class RoslynAnalyzerProviderTests
         </Rules>
         */
         [
-            new SonarRule("csharpsquid", "S1116", true)
+            new("csharpsquid", "S1116", true)
             {
-                Parameters = new Dictionary<string, string> { { "key", "value" } }
+                Parameters = new Dictionary<string, string> { { "key", "value" } },
             },
-            new SonarRule("csharpsquid", "S1125", true),
-            new SonarRule("roslyn.wintellect", "Wintellect003", true),
-            new SonarRule("csharpsquid", "S1000", false)
+            new("csharpsquid", "S1125", true),
+            new("roslyn.wintellect", "Wintellect003", true),
+            new("csharpsquid", "S1000", false)
         ];
-
-    private string CreateTestFolders()
-    {
-        var rootFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
-
-        // Create the binary and conf folders that are created by the bootstrapper
-        Directory.CreateDirectory(GetBinaryPath(rootFolder));
-        Directory.CreateDirectory(GetConfPath(rootFolder));
-
-        return rootFolder;
-    }
-
-    private static RoslynAnalyzerProvider CreateTestSubject(ILogger logger) =>
-        new(new MockAnalyzerInstaller(), logger);
 
     private static BuildSettings CreateSettings(string rootDir) =>
         BuildSettings.CreateNonTeamBuildSettingsForTesting(rootDir);
 
-    private static string GetConfPath(string rootDir) =>
-        Path.Combine(rootDir, "conf");
-
-    private static string GetBinaryPath(string rootDir) =>
-        Path.Combine(rootDir, "bin");
-
-    private static AnalyzerPlugin CreateAnalyzerPlugin(params string[] fileList) =>
-        new()
-        {
-            AssemblyPaths = new List<string>(fileList)
-        };
-
-    private static void CheckSettingsInvariants(AnalyzerSettings actualSettings)
+    private class RoslynAnalyzerTestContext
     {
-        actualSettings.Should().NotBeNull("Not expecting the config to be null");
-        actualSettings.AdditionalFilePaths.Should().NotBeNull();
-        actualSettings.AnalyzerPlugins.Should().NotBeNull();
-        actualSettings.RulesetPath.Should().NotBeNullOrEmpty();
-        // Any file paths returned in the config should exist
-        foreach (var filePath in actualSettings.AdditionalFilePaths)
+        public TestContext TestContext { get; set; }
+        public TestLogger Logger { get; } = new TestLogger();
+        public string RootDir { get; }
+        public IEnumerable<SonarRule> Rules { get; }
+        public string Language { get; }
+        public MockAnalyzerInstaller MockInstaller { get; }
+        public BuildSettings Settings { get; }
+        public ListPropertiesProvider SonarProperties { get; }
+        public RoslynAnalyzerProvider TestSubject { get; }
+        public AnalyzerSettings ActualSettings { get; set; }
+
+        public RoslynAnalyzerTestContext(TestContext testContext, string rootDir = null, IEnumerable<SonarRule> rules = null, List<string[]> analyzerPlugins = null, ListPropertiesProvider properties = null, string language = RoslynAnalyzerProvider.CSharpLanguage)
         {
-            File.Exists(filePath).Should().BeTrue("Expected additional file does not exist: {0}", filePath);
+            TestContext = testContext;
+            RootDir = rootDir;
+            Rules = rules;
+            Language = language;
+            Settings = rootDir is null ? null : CreateSettings(rootDir);
+            SonarProperties = properties ?? new ListPropertiesProvider();
+            MockInstaller = new MockAnalyzerInstaller(CreateAnalyzerPlugins(analyzerPlugins ?? new()));
+            TestSubject = new RoslynAnalyzerProvider(MockInstaller, Logger);
         }
-        File.Exists(actualSettings.RulesetPath).Should().BeTrue("Specified ruleset does not exist: {0}", actualSettings.RulesetPath);
-    }
 
-    private void CheckRuleset(string ruleSetPath, string rootDir, string language)
-    {
-        ruleSetPath.Should().NotBeNullOrEmpty("Ruleset file path should be set");
-        Path.IsPathRooted(ruleSetPath).Should().BeTrue("Ruleset file path should be absolute");
-        File.Exists(ruleSetPath).Should().BeTrue("Specified ruleset file does not exist: {0}", ruleSetPath);
-        TestContext.AddResultFile(ruleSetPath);
-        CheckFileIsXml(ruleSetPath);
-        Path.GetFileName(ruleSetPath).Should().Be($"Sonar-{language}.ruleset", "Ruleset file does not have the expected name");
-        Path.GetDirectoryName(ruleSetPath).Should().Be(GetConfPath(rootDir), "Ruleset was not written to the expected location");
-        var expectedContent = """
-            <?xml version="1.0" encoding="utf-8"?>
-            <RuleSet xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Rules for SonarQube" Description="This rule set was automatically generated from SonarQube" ToolsVersion="14.0">
-              <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
-                <Rule Id="S1116" Action="Warning" />
-                <Rule Id="S1125" Action="Warning" />
-                <Rule Id="S1000" Action="None" />
-              </Rules>
-              <Rules AnalyzerId="Wintellect.Analyzers" RuleNamespace="Wintellect.Analyzers">
-                <Rule Id="Wintellect003" Action="Warning" />
-              </Rules>
-            </RuleSet>
-            """;
-        File.ReadAllText(ruleSetPath).Should().Be(expectedContent, "Ruleset file does not have the expected content: {0}", ruleSetPath);
-    }
+        public RoslynAnalyzerTestContext(TestContext testContext, List<string[]> analyzerPlugins = null, ListPropertiesProvider properties = null)
+            : this(testContext, CreateTestFolders(testContext), CreateRules(), analyzerPlugins, properties) { }
 
-    private void CheckTestRuleset(string ruleSetPath, string rootDir, string language)
-    {
-        ruleSetPath.Should().NotBeNullOrEmpty("Ruleset file path should be set");
-        Path.IsPathRooted(ruleSetPath).Should().BeTrue("Ruleset file path should be absolute");
-        File.Exists(ruleSetPath).Should().BeTrue("Specified ruleset file does not exist: {0}", ruleSetPath);
-        TestContext.AddResultFile(ruleSetPath);
-        CheckFileIsXml(ruleSetPath);
-        Path.GetFileName(ruleSetPath).Should().Be($"Sonar-{language}-none.ruleset", "Ruleset file does not have the expected name");
-        Path.GetDirectoryName(ruleSetPath).Should().Be(GetConfPath(rootDir), "Ruleset was not written to the expected location");
-        var expectedContent = """
-            <?xml version="1.0" encoding="utf-8"?>
-            <RuleSet xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Rules for SonarQube" Description="This rule set was automatically generated from SonarQube" ToolsVersion="14.0">
-              <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
-                <Rule Id="S1116" Action="None" />
-                <Rule Id="S1125" Action="None" />
-                <Rule Id="S1000" Action="None" />
-              </Rules>
-              <Rules AnalyzerId="Wintellect.Analyzers" RuleNamespace="Wintellect.Analyzers">
-                <Rule Id="Wintellect003" Action="None" />
-              </Rules>
-            </RuleSet>
-            """;
-        File.ReadAllText(ruleSetPath).Should().Be(expectedContent, "Ruleset file does not have the expected content: {0}", ruleSetPath);
-    }
-
-    private void CheckExpectedAdditionalFileExists(string expectedFileName, string expectedContent, AnalyzerSettings actualSettings)
-    {
-        // Check one file of the expected name exists
-        var matches = actualSettings.AdditionalFilePaths.Where(x => string.Equals(expectedFileName, Path.GetFileName(x), StringComparison.OrdinalIgnoreCase));
-        matches.Should().ContainSingle("Unexpected number of files named \"{0}\". One and only one expected", expectedFileName);
-        // Check the file exists and has the expected content
-        var actualFilePath = matches.First();
-        File.Exists(actualFilePath).Should().BeTrue("AdditionalFile does not exist: {0}", actualFilePath);
-        // Dump the contents to help with debugging
-        TestContext.AddResultFile(actualFilePath);
-        TestContext.WriteLine("File contents: {0}", actualFilePath);
-        TestContext.WriteLine(File.ReadAllText(actualFilePath));
-        TestContext.WriteLine(string.Empty);
-        if (expectedContent is not null)
+        public AnalyzerSettings ExecuteTest()
         {
-            File.ReadAllText(actualFilePath).Should().Be(expectedContent, "Additional file does not have the expected content: {0}", expectedFileName);
+            ActualSettings = TestSubject.SetupAnalyzer(Settings, SonarProperties, Rules, Language);
+            return ActualSettings;
         }
-    }
 
-    private static void CheckFileIsXml(string fullPath)
-    {
-        var doc = new XmlDocument();
-        doc.Load(fullPath);
-        doc.FirstChild.Should().NotBeNull("Expecting the file to contain some valid XML");
-    }
-
-    private static void CheckExpectedAssemblies(AnalyzerSettings actualSettings, params string[] expected)
-    {
-        foreach (var expectedItem in expected)
+        public void AssertRulesetsAreCorrect()
         {
-            actualSettings.AnalyzerPlugins
-                .SelectMany(x => x.AssemblyPaths)
-                .Contains(expectedItem, StringComparer.OrdinalIgnoreCase)
-                .Should().BeTrue("Expected assembly file path was not returned: {0}", expectedItem);
+            CheckRuleset(ActualSettings.RulesetPath, false);
+            CheckRuleset(ActualSettings.DeactivatedRulesetPath, true);
         }
-        actualSettings.AnalyzerPlugins.Should().HaveCount(expected.Length, "Too many assembly file paths returned");
+
+        public void AssertNoWarningsOrErrors()
+        {
+            Logger.AssertWarningsLogged(0);
+            Logger.AssertErrorsLogged(0);
+        }
+
+        public void AssertAnalyzerSettingsAreCorrect()
+        {
+            ActualSettings.Should().NotBeNull("Not expecting the config to be null");
+            ActualSettings.AdditionalFilePaths.Should().NotBeNull();
+            ActualSettings.AnalyzerPlugins.Should().NotBeNull();
+            ActualSettings.RulesetPath.Should().NotBeNullOrEmpty();
+            // Any file paths returned in the config should exist
+            foreach (var filePath in ActualSettings.AdditionalFilePaths)
+            {
+                File.Exists(filePath).Should().BeTrue("Expected additional file does not exist: {0}", filePath);
+            }
+            File.Exists(ActualSettings.RulesetPath).Should().BeTrue("Specified ruleset does not exist: {0}", ActualSettings.RulesetPath);
+        }
+
+        public void AssertExpectedAssemblies(params string[] expected)
+        {
+            foreach (var expectedItem in expected)
+            {
+                ActualSettings.AnalyzerPlugins
+                    .SelectMany(x => x.AssemblyPaths)
+                    .Contains(expectedItem, StringComparer.OrdinalIgnoreCase)
+                    .Should().BeTrue("Expected assembly file path was not returned: {0}", expectedItem);
+            }
+            ActualSettings.AnalyzerPlugins.Should().HaveCount(expected.Length, "Too many assembly file paths returned");
+        }
+
+        public void AssertExpectedPluginsRequested(IEnumerable<string> plugins) =>
+            MockInstaller.AssertExpectedPluginsRequested(plugins);
+
+        public void AssertExpectedAdditionalFileExists(string expectedContent, string expectedFileName = "SonarLint.xml")
+        {
+            var filePaths = ActualSettings.AdditionalFilePaths.Should().ContainSingle();
+            // Check one file of the expected name exists
+            var matches = ActualSettings.AdditionalFilePaths.Where(x => string.Equals(expectedFileName, Path.GetFileName(x), StringComparison.OrdinalIgnoreCase));
+            matches.Should().ContainSingle("Unexpected number of files named \"{0}\". One and only one expected", expectedFileName);
+            // Check the file exists and has the expected content
+            var actualFilePath = matches.First();
+            File.Exists(actualFilePath).Should().BeTrue("AdditionalFile does not exist: {0}", actualFilePath);
+            // Dump the contents to help with debugging
+            TestContext.AddResultFile(actualFilePath);
+            TestContext.WriteLine("File contents: {0}", actualFilePath);
+            TestContext.WriteLine(File.ReadAllText(actualFilePath));
+            TestContext.WriteLine(string.Empty);
+            if (expectedContent is not null)
+            {
+                File.ReadAllText(actualFilePath).Should().Be(expectedContent, "Additional file does not have the expected content: {0}", expectedFileName);
+            }
+        }
+
+        private void CheckRuleset(string ruleSetPath, bool isDeactivated)
+        {
+            ruleSetPath.Should().NotBeNullOrEmpty("Ruleset file path should be set");
+            Path.IsPathRooted(ruleSetPath).Should().BeTrue("Ruleset file path should be absolute");
+            File.Exists(ruleSetPath).Should().BeTrue("Specified ruleset file does not exist: {0}", ruleSetPath);
+            TestContext.AddResultFile(ruleSetPath);
+            CheckFileIsXml(ruleSetPath);
+            var expectedFileName = isDeactivated ? $"Sonar-{Language}-none.ruleset" : $"Sonar-{Language}.ruleset";
+            Path.GetFileName(ruleSetPath).Should().Be(expectedFileName, "Ruleset file does not have the expected name");
+            Path.GetDirectoryName(ruleSetPath).Should().Be(Path.Combine(RootDir, "conf"), "Ruleset was not written to the expected location");
+            var expectedRule = isDeactivated ? "None" : "Warning";
+            var expectedContent = $"""
+                <?xml version="1.0" encoding="utf-8"?>
+                <RuleSet xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Name="Rules for SonarQube" Description="This rule set was automatically generated from SonarQube" ToolsVersion="14.0">
+                  <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
+                    <Rule Id="S1116" Action="{expectedRule}" />
+                    <Rule Id="S1125" Action="{expectedRule}" />
+                    <Rule Id="S1000" Action="None" />
+                  </Rules>
+                  <Rules AnalyzerId="Wintellect.Analyzers" RuleNamespace="Wintellect.Analyzers">
+                    <Rule Id="Wintellect003" Action="{expectedRule}" />
+                  </Rules>
+                </RuleSet>
+                """;
+            File.ReadAllText(ruleSetPath).Should().Be(expectedContent, "Ruleset file does not have the expected content: {0}", ruleSetPath);
+        }
+
+        private static IList<AnalyzerPlugin> CreateAnalyzerPlugins(List<string[]> pluginList) =>
+            pluginList.Select(x => new AnalyzerPlugin { AssemblyPaths = new List<string>(x) }).ToList();
+
+        private static void CheckFileIsXml(string fullPath)
+        {
+            var doc = new XmlDocument();
+            doc.Load(fullPath);
+            doc.FirstChild.Should().NotBeNull("Expecting the file to contain some valid XML");
+        }
+
+        private static string CreateTestFolders(TestContext testContext)
+        {
+            var rootFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(testContext);
+            // Create the binary and conf folders that are created by the bootstrapper
+            Directory.CreateDirectory(Path.Combine(rootFolder, "bin"));
+            Directory.CreateDirectory(Path.Combine(rootFolder, "conf"));
+            return rootFolder;
+        }
     }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynAnalyzerProviderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynAnalyzerProviderTests.cs
@@ -68,8 +68,8 @@ public class RoslynAnalyzerProviderTests
     [TestMethod]
     public void RoslynConfig_NoActiveRules()
     {
-        RoslynAnalyzerTestContext context = new(TestContext, TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext), []);
-        context.ExecuteTest().Should().NotBeNull();
+        var context = new Context(TestContext, new ListPropertiesProvider(), [], []);
+        context.ActualSettings.Should().NotBeNull();
     }
 
     [TestMethod]
@@ -83,13 +83,11 @@ public class RoslynAnalyzerProviderTests
             { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" }
         });
 
-        RoslynAnalyzerTestContext context = new(TestContext, [["c:\\assembly1.dll"]], sonarProperties);
+        var context = new Context(TestContext, sonarProperties, [[@"c:\assembly1.dll"]]);
 
-        context.ExecuteTest();
-
-        context.AssertAnalyzerSettingsAreCorrect();
+        context.AssertCorrectAnalyzerSettings();
         context.AssertNoWarningsOrErrors();
-        context.AssertRulesetsAreCorrect();
+        context.AssertCorrectRulesets();
         context.AssertExpectedAssemblies([]);
         context.AssertExpectedPluginsRequested([]);
     }
@@ -119,7 +117,7 @@ public class RoslynAnalyzerProviderTests
             {"sonar.sources", "**/*.*"},
             {"sonar.cs.foo", "bar"}
         });
-        RoslynAnalyzerTestContext context = new(TestContext, [["c:\\assembly1.dll"], ["d:\\foo\\assembly2.dll"]], sonarProperties);
+        var context = new Context(TestContext, sonarProperties, [[@"c:\assembly1.dll"], [@"d:\foo\assembly2.dll"]]);
 
         var expectedSonarLintXml = """
             <?xml version="1.0" encoding="UTF-8"?>
@@ -154,12 +152,10 @@ public class RoslynAnalyzerProviderTests
 
             """;
 
-        context.ExecuteTest();
-
-        context.AssertAnalyzerSettingsAreCorrect();
+        context.AssertCorrectAnalyzerSettings();
         context.AssertNoWarningsOrErrors();
-        context.AssertRulesetsAreCorrect();
-        context.AssertExpectedAssemblies("c:\\assembly1.dll", "d:\\foo\\assembly2.dll");
+        context.AssertCorrectRulesets();
+        context.AssertExpectedAssemblies(@"c:\assembly1.dll", @"d:\foo\assembly2.dll");
         context.AssertExpectedPluginsRequested(["wintellect", "csharp"]);
         context.AssertExpectedAdditionalFileExists(expectedSonarLintXml);
     }
@@ -187,41 +183,34 @@ public class RoslynAnalyzerProviderTests
     private static BuildSettings CreateSettings(string rootDir) =>
         BuildSettings.CreateNonTeamBuildSettingsForTesting(rootDir);
 
-    private class RoslynAnalyzerTestContext
+    private class Context
     {
-        public TestContext TestContext { get; set; }
-        public TestLogger Logger { get; } = new TestLogger();
-        public string RootDir { get; }
-        public IEnumerable<SonarRule> Rules { get; }
-        public string Language { get; }
-        public MockAnalyzerInstaller MockInstaller { get; }
-        public BuildSettings Settings { get; }
-        public ListPropertiesProvider SonarProperties { get; }
-        public RoslynAnalyzerProvider TestSubject { get; }
+        private readonly TestContext testContext;
+        private readonly TestLogger logger = new TestLogger();
+        private readonly string rootDir;
+        private readonly IEnumerable<SonarRule> sonarRules;
+        private readonly string language;
+        private readonly MockAnalyzerInstaller mockInstaller;
+        private readonly BuildSettings settings;
+        private readonly ListPropertiesProvider sonarProperties;
+        private readonly RoslynAnalyzerProvider testSubject;
+
         public AnalyzerSettings ActualSettings { get; set; }
 
-        public RoslynAnalyzerTestContext(TestContext testContext, string rootDir = null, IEnumerable<SonarRule> rules = null, List<string[]> analyzerPlugins = null, ListPropertiesProvider properties = null, string language = RoslynAnalyzerProvider.CSharpLanguage)
+        public Context(TestContext testContext, ListPropertiesProvider properties, List<string[]> analyzerPlugins, IEnumerable<SonarRule> rules = null)
         {
-            TestContext = testContext;
-            RootDir = rootDir;
-            Rules = rules;
-            Language = language;
-            Settings = rootDir is null ? null : CreateSettings(rootDir);
-            SonarProperties = properties ?? new ListPropertiesProvider();
-            MockInstaller = new MockAnalyzerInstaller(CreateAnalyzerPlugins(analyzerPlugins ?? new()));
-            TestSubject = new RoslynAnalyzerProvider(MockInstaller, Logger);
+            this.testContext = testContext;
+            rootDir = CreateTestFolders();
+            this.sonarRules = rules ?? CreateRules();
+            language = RoslynAnalyzerProvider.CSharpLanguage;
+            settings = CreateSettings(rootDir);
+            sonarProperties = properties;
+            mockInstaller = new MockAnalyzerInstaller(CreateAnalyzerPlugins(analyzerPlugins));
+            testSubject = new RoslynAnalyzerProvider(mockInstaller, logger);
+            ActualSettings = testSubject.SetupAnalyzer(settings, sonarProperties, sonarRules, language);
         }
 
-        public RoslynAnalyzerTestContext(TestContext testContext, List<string[]> analyzerPlugins = null, ListPropertiesProvider properties = null)
-            : this(testContext, CreateTestFolders(testContext), CreateRules(), analyzerPlugins, properties) { }
-
-        public AnalyzerSettings ExecuteTest()
-        {
-            ActualSettings = TestSubject.SetupAnalyzer(Settings, SonarProperties, Rules, Language);
-            return ActualSettings;
-        }
-
-        public void AssertRulesetsAreCorrect()
+        public void AssertCorrectRulesets()
         {
             CheckRuleset(ActualSettings.RulesetPath, false);
             CheckRuleset(ActualSettings.DeactivatedRulesetPath, true);
@@ -229,11 +218,11 @@ public class RoslynAnalyzerProviderTests
 
         public void AssertNoWarningsOrErrors()
         {
-            Logger.AssertWarningsLogged(0);
-            Logger.AssertErrorsLogged(0);
+            logger.AssertWarningsLogged(0);
+            logger.AssertErrorsLogged(0);
         }
 
-        public void AssertAnalyzerSettingsAreCorrect()
+        public void AssertCorrectAnalyzerSettings()
         {
             ActualSettings.Should().NotBeNull("Not expecting the config to be null");
             ActualSettings.AdditionalFilePaths.Should().NotBeNull();
@@ -260,11 +249,11 @@ public class RoslynAnalyzerProviderTests
         }
 
         public void AssertExpectedPluginsRequested(IEnumerable<string> plugins) =>
-            MockInstaller.AssertExpectedPluginsRequested(plugins);
+            mockInstaller.AssertExpectedPluginsRequested(plugins);
 
         public void AssertExpectedAdditionalFileExists(string expectedContent, string expectedFileName = "SonarLint.xml")
         {
-            var filePaths = ActualSettings.AdditionalFilePaths.Should().ContainSingle();
+            ActualSettings.AdditionalFilePaths.Should().ContainSingle();
             // Check one file of the expected name exists
             var matches = ActualSettings.AdditionalFilePaths.Where(x => string.Equals(expectedFileName, Path.GetFileName(x), StringComparison.OrdinalIgnoreCase));
             matches.Should().ContainSingle("Unexpected number of files named \"{0}\". One and only one expected", expectedFileName);
@@ -272,10 +261,10 @@ public class RoslynAnalyzerProviderTests
             var actualFilePath = matches.First();
             File.Exists(actualFilePath).Should().BeTrue("AdditionalFile does not exist: {0}", actualFilePath);
             // Dump the contents to help with debugging
-            TestContext.AddResultFile(actualFilePath);
-            TestContext.WriteLine("File contents: {0}", actualFilePath);
-            TestContext.WriteLine(File.ReadAllText(actualFilePath));
-            TestContext.WriteLine(string.Empty);
+            testContext.AddResultFile(actualFilePath);
+            testContext.WriteLine("File contents: {0}", actualFilePath);
+            testContext.WriteLine(File.ReadAllText(actualFilePath));
+            testContext.WriteLine(string.Empty);
             if (expectedContent is not null)
             {
                 File.ReadAllText(actualFilePath).Should().Be(expectedContent, "Additional file does not have the expected content: {0}", expectedFileName);
@@ -284,14 +273,7 @@ public class RoslynAnalyzerProviderTests
 
         private void CheckRuleset(string ruleSetPath, bool isDeactivated)
         {
-            ruleSetPath.Should().NotBeNullOrEmpty("Ruleset file path should be set");
-            Path.IsPathRooted(ruleSetPath).Should().BeTrue("Ruleset file path should be absolute");
-            File.Exists(ruleSetPath).Should().BeTrue("Specified ruleset file does not exist: {0}", ruleSetPath);
-            TestContext.AddResultFile(ruleSetPath);
-            CheckFileIsXml(ruleSetPath);
-            var expectedFileName = isDeactivated ? $"Sonar-{Language}-none.ruleset" : $"Sonar-{Language}.ruleset";
-            Path.GetFileName(ruleSetPath).Should().Be(expectedFileName, "Ruleset file does not have the expected name");
-            Path.GetDirectoryName(ruleSetPath).Should().Be(Path.Combine(RootDir, "conf"), "Ruleset was not written to the expected location");
+            var expectedFileName = isDeactivated ? $"Sonar-{language}-none.ruleset" : $"Sonar-{language}.ruleset";
             var expectedRule = isDeactivated ? "None" : "Warning";
             var expectedContent = $"""
                 <?xml version="1.0" encoding="utf-8"?>
@@ -306,11 +288,18 @@ public class RoslynAnalyzerProviderTests
                   </Rules>
                 </RuleSet>
                 """;
+            ruleSetPath.Should().NotBeNullOrEmpty("Ruleset file path should be set");
+            Path.IsPathRooted(ruleSetPath).Should().BeTrue("Ruleset file path should be absolute");
+            Path.GetFileName(ruleSetPath).Should().Be(expectedFileName, "Ruleset file does not have the expected name");
+            Path.GetDirectoryName(ruleSetPath).Should().Be(Path.Combine(rootDir, "conf"), "Ruleset was not written to the expected location");
+            File.Exists(ruleSetPath).Should().BeTrue("Specified ruleset file does not exist: {0}", ruleSetPath);
+            testContext.AddResultFile(ruleSetPath);
+            CheckFileIsXml(ruleSetPath);
             File.ReadAllText(ruleSetPath).Should().Be(expectedContent, "Ruleset file does not have the expected content: {0}", ruleSetPath);
         }
 
         private static IList<AnalyzerPlugin> CreateAnalyzerPlugins(List<string[]> pluginList) =>
-            pluginList.Select(x => new AnalyzerPlugin { AssemblyPaths = new List<string>(x) }).ToList();
+            pluginList.Select(x => new AnalyzerPlugin { AssemblyPaths = x.ToList() }).ToList();
 
         private static void CheckFileIsXml(string fullPath)
         {
@@ -319,7 +308,7 @@ public class RoslynAnalyzerProviderTests
             doc.FirstChild.Should().NotBeNull("Expecting the file to contain some valid XML");
         }
 
-        private static string CreateTestFolders(TestContext testContext)
+        private string CreateTestFolders()
         {
             var rootFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(testContext);
             // Create the binary and conf folders that are created by the bootstrapper

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynRuleSetGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynRuleSetGeneratorTests.cs
@@ -55,13 +55,9 @@ public class RoslynRuleSetGeneratorTests
     [TestMethod]
     public void RoslynRuleSet_Empty()
     {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider());
-        var rules = new List<SonarRule>
-        {
-            new("repo", "key"),
-        };
+        var context = new RuleSetTestContext([new("repo", "key")], []);
 
-        var ruleSet = generator.Generate("cs", rules);
+        var ruleSet = context.GenerateRuleSet();
 
         ruleSet.Rules.Should().BeEmpty(); // No analyzers
         ruleSet.Description.Should().Be("This rule set was automatically generated from SonarQube");
@@ -72,58 +68,35 @@ public class RoslynRuleSetGeneratorTests
     [TestMethod]
     public void RoslynRuleSet_ActiveRuleAction_OverrideToNone()
     {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider(new Dictionary<string, string>
-        {
-            ["sonaranalyzer-cs.analyzerId"] = "SonarAnalyzer.CSharp",
-            ["sonaranalyzer-cs.ruleNamespace"] = "SonarAnalyzer.CSharp",
-        }), deactivateAll: true);
-        var rules = new List<SonarRule>
-        {
-            new("csharpsquid", "rule1", isActive: true),
-            new("csharpsquid", "rule2", isActive: true),
-        };
+        var context = new RuleSetTestContext(true);
 
-        var ruleSet = generator.Generate("cs", rules);
+        var ruleSet = context.GenerateRuleSet();
 
-        ruleSet.Rules.Should().HaveCount(1);
+        ruleSet.Rules.Should().ContainSingle();
         ruleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo("None", "None");
     }
 
     [TestMethod]
     public void RoslynRuleSet_ActiveRuleAction_Warning()
     {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider(new Dictionary<string, string>
-        {
-            ["sonaranalyzer-cs.analyzerId"] = "SonarAnalyzer.CSharp",
-            ["sonaranalyzer-cs.ruleNamespace"] = "SonarAnalyzer.CSharp",
-        }));
-        var rules = new List<SonarRule>
-        {
-            new("csharpsquid", "rule1", isActive: true),
-            new("csharpsquid", "rule2", isActive: true),
-        };
+        var context = new RuleSetTestContext();
 
-        var ruleSet = generator.Generate("cs", rules);
+        var ruleSet = context.GenerateRuleSet();
 
-        ruleSet.Rules.Should().HaveCount(1);
+        ruleSet.Rules.Should().ContainSingle();
         ruleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo("Warning", "Warning");
     }
 
     [TestMethod]
     public void RoslynRuleSet_InactiveRules_None()
     {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider(new Dictionary<string, string>
-        {
-            ["sonaranalyzer-cs.analyzerId"] = "SonarAnalyzer.CSharp",
-            ["sonaranalyzer-cs.ruleNamespace"] = "SonarAnalyzer.CSharp",
-        }));
-        var rules = new List<SonarRule>
-        {
+        var context = new RuleSetTestContext(
+        [
             new("csharpsquid", "rule1", isActive: false),
             new("csharpsquid", "rule2", isActive: false),
-        };
+        ]);
 
-        var ruleSet = generator.Generate("cs", rules);
+        var ruleSet = context.GenerateRuleSet();
 
         ruleSet.Rules.Should().HaveCount(1);
         ruleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo("None", "None");
@@ -132,14 +105,13 @@ public class RoslynRuleSetGeneratorTests
     [TestMethod]
     public void RoslynRuleSet_Unsupported_Rules_Ignored()
     {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider());
-        var rules = new List<SonarRule>
-        {
-            new("other.repo", "other.rule1", true),
-            new("other.repo", "other.rule2", false),
-        };
+        var context = new RuleSetTestContext(
+        [
+            new("other.repo", "other.rule1", isActive: true),
+            new("other.repo", "other.rule2", isActive: false),
+        ]);
 
-        var ruleSet = generator.Generate("cs", rules);
+        var ruleSet = context.GenerateRuleSet();
 
         ruleSet.Rules.Should().BeEmpty();
     }
@@ -147,22 +119,22 @@ public class RoslynRuleSetGeneratorTests
     [TestMethod]
     public void RoslynRuleSet_RoslynSDK_Rules_Added()
     {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider(new Dictionary<string, string>
+        var context = new RuleSetTestContext(
+        [
+            new("roslyn.custom1", "active1", true),
+            new("roslyn.custom2", "active2", true),
+            new("roslyn.custom1", "inactive1", false),
+            new("roslyn.custom2", "inactive2", false),
+        ],
+        new Dictionary<string, string>
         {
             ["custom1.analyzerId"] = "CustomAnalyzer1",
             ["custom1.ruleNamespace"] = "CustomNamespace1",
             ["custom2.analyzerId"] = "CustomAnalyzer2",
             ["custom2.ruleNamespace"] = "CustomNamespace2",
-        }));
-        var rules = new List<SonarRule>
-        {
-            new("roslyn.custom1", "active1", true),
-            new("roslyn.custom2", "active2", true),
-            new("roslyn.custom1", "inactive1", false),
-            new("roslyn.custom2", "inactive2", false),
-        };
+        });
 
-        var ruleSet = generator.Generate("cs", rules);
+        var ruleSet = context.GenerateRuleSet();
 
         ruleSet.Rules.Should().HaveCount(2);
         ruleSet.Rules[0].RuleNamespace.Should().Be("CustomNamespace1");
@@ -180,22 +152,17 @@ public class RoslynRuleSetGeneratorTests
     [TestMethod]
     public void RoslynRuleSet_Sonar_Rules_Added()
     {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider(new Dictionary<string, string>
-        {
-            { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
-            { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
-        }));
-        var rules = new List<SonarRule>
-        {
+        var context = new RuleSetTestContext(
+            [
             new("csharpsquid", "active1", true),
             // Even though this rule is for VB it will be added as C#, see NOTE below
             new("vbnet", "active2", true),
             new("csharpsquid", "inactive1", false),
             // Even though this rule is for VB it will be added as C#, see NOTE below
             new("vbnet", "inactive2", false),
-        };
+            ]);
 
-        var ruleSet = generator.Generate("cs", rules);
+        var ruleSet = context.GenerateRuleSet();
 
         ruleSet.Rules.Should().ContainSingle();
 
@@ -206,16 +173,18 @@ public class RoslynRuleSetGeneratorTests
         ruleSet.Rules[0].RuleNamespace.Should().Be("SonarAnalyzer.CSharp");
         ruleSet.Rules[0].AnalyzerId.Should().Be("SonarAnalyzer.CSharp");
         ruleSet.Rules[0].RuleList.Should().HaveCount(4);
-        ruleSet.Rules[0].RuleList.Select(x => x.Id).Should().BeEquivalentTo("active1", "active2", "inactive1", "inactive2");
-        ruleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo("Warning", "Warning", "None", "None");
+        ruleSet.Rules[0].RuleList.Select(x => x.Id).Should().BeEquivalentTo(
+            "active1", "active2", "inactive1", "inactive2");
+        ruleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo(
+            "Warning", "Warning", "None", "None");
     }
 
     [TestMethod]
     public void RoslynRuleSet_Common_Parameters()
     {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider());
+        var context = new RuleSetTestContext([], new Dictionary<string, string>());
 
-        var ruleSet = generator.Generate("cs", Enumerable.Empty<SonarRule>());
+        var ruleSet = context.GenerateRuleSet();
 
         ruleSet.Description.Should().Be("This rule set was automatically generated from SonarQube");
         ruleSet.ToolsVersion.Should().Be("14.0");
@@ -225,51 +194,73 @@ public class RoslynRuleSetGeneratorTests
     [TestMethod]
     public void RoslynRuleSet_AnalyzerId_Proprety_Missing()
     {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider(new Dictionary<string, string>
-        {
-            { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
-        }));
-        var rules = new[]
-        {
-            new SonarRule("csharpsquid", "active1", true),
-        };
+        var context = new RuleSetTestContext(
+            [new("csharpsquid", "active1", true)],
+            new Dictionary<string, string>
+            {
+                { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
+            });
 
-        new Action(() => generator.Generate("cs", rules)).Should()
+        new Action(() => context.GenerateRuleSet()).Should()
             .ThrowExactly<AnalysisException>().WithMessage("Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");
     }
 
     [TestMethod]
     public void RoslynRuleSet_RuleNamespace_Proprety_Missing()
     {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider(new Dictionary<string, string>
-        {
-            { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
-        }));
+        var context = new RuleSetTestContext(
+            [new("csharpsquid", "active1", true)],
+            new Dictionary<string, string>
+            {
+                { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
+            });
 
-        var rules = new[]
-        {
-            new SonarRule("csharpsquid", "active1", true),
-        };
-
-        new Action(() => generator.Generate("cs", rules)).Should()
+        new Action(() => context.GenerateRuleSet()).Should()
             .ThrowExactly<AnalysisException>().WithMessage("Property does not exist: sonaranalyzer-cs.ruleNamespace. This property should be set by the plugin in SonarQube.");
     }
 
     [TestMethod]
     public void RoslynRuleSet_PropertyName_IsCaseSensitive()
     {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider(new Dictionary<string, string>
-        {
+        var context = new RuleSetTestContext(
+            [new("csharpsquid", "active1", true)],
+            new Dictionary<string, string>
+            {
             { "sonaranalyzer-cs.ANALYZERId", "SonarAnalyzer.CSharp" },
             { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
-        }));
+            });
 
-        var rules = new[]
-        {
-            new SonarRule("csharpsquid", "active1", true),
-        };
-
-        new Action(() => generator.Generate("cs", rules)).Should()
+        new Action(() => context.GenerateRuleSet()).Should()
             .ThrowExactly<AnalysisException>().WithMessage("Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");
+    }
+
+    private class RuleSetTestContext
+    {
+        private RoslynRuleSetGenerator RuleSetGenerator { get; }
+        private List<SonarRule> Rules { get; }
+        private string Language { get; }
+
+        public RuleSetTestContext(bool deactivateAll = false, List<SonarRule> rules = null, Dictionary<string, string> properties = null)
+        {
+            RuleSetGenerator =  new RoslynRuleSetGenerator(new ListPropertiesProvider(
+                properties is null ? new Dictionary<string, string>
+            {
+                { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
+                { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
+            }
+                : properties), deactivateAll);
+            Rules = rules is null ?
+            [
+                new("csharpsquid", "rule1", true),
+                new("csharpsquid", "rule2", true),
+            ] : rules;
+            Language = "cs";
+        }
+
+        public RuleSetTestContext(List<SonarRule> rules) : this(false, rules) { }
+
+        public RuleSetTestContext(List<SonarRule> rules, Dictionary<string, string> properties) : this(false, rules, properties) { }
+
+        public RuleSet GenerateRuleSet() => RuleSetGenerator.Generate(Language, Rules);
     }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynRuleSetGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynRuleSetGeneratorTests.cs
@@ -55,78 +55,66 @@ public class RoslynRuleSetGeneratorTests
     [TestMethod]
     public void RoslynRuleSet_Empty()
     {
-        var context = new RuleSetTestContext([new("repo", "key")], []);
-
-        var ruleSet = context.GenerateRuleSet();
-
-        ruleSet.Rules.Should().BeEmpty(); // No analyzers
-        ruleSet.Description.Should().Be("This rule set was automatically generated from SonarQube");
-        ruleSet.ToolsVersion.Should().Be("14.0");
-        ruleSet.Name.Should().Be("Rules for SonarQube");
+        var context = new Context([new("repo", "key")], []);
+        context.RuleSet.Rules.Should().BeEmpty(); // No analyzers
+        context.ValidateCommonParameters();
     }
 
     [TestMethod]
     public void RoslynRuleSet_ActiveRuleAction_OverrideToNone()
     {
-        var context = new RuleSetTestContext(true);
-
-        var ruleSet = context.GenerateRuleSet();
-
-        ruleSet.Rules.Should().ContainSingle();
-        ruleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo("None", "None");
+        var context = new Context([
+                new("csharpsquid", "rule1", true),
+                new("csharpsquid", "rule2", true),
+            ],
+            null,
+            true);
+        context.ValidateSingleRuleList(["None", "None"]);
     }
 
     [TestMethod]
     public void RoslynRuleSet_ActiveRuleAction_Warning()
     {
-        var context = new RuleSetTestContext();
-
-        var ruleSet = context.GenerateRuleSet();
-
-        ruleSet.Rules.Should().ContainSingle();
-        ruleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo("Warning", "Warning");
+        var context = new Context([
+                new("csharpsquid", "rule1", true),
+                new("csharpsquid", "rule2", true),
+            ]);
+        context.ValidateSingleRuleList(["Warning", "Warning"]);
     }
 
     [TestMethod]
     public void RoslynRuleSet_InactiveRules_None()
     {
-        var context = new RuleSetTestContext(
+        var context = new Context(
         [
             new("csharpsquid", "rule1", isActive: false),
             new("csharpsquid", "rule2", isActive: false),
         ]);
-
-        var ruleSet = context.GenerateRuleSet();
-
-        ruleSet.Rules.Should().HaveCount(1);
-        ruleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo("None", "None");
+        context.ValidateSingleRuleList(["None", "None"]);
     }
 
     [TestMethod]
     public void RoslynRuleSet_Unsupported_Rules_Ignored()
     {
-        var context = new RuleSetTestContext(
+        var context = new Context(
         [
             new("other.repo", "other.rule1", isActive: true),
             new("other.repo", "other.rule2", isActive: false),
         ]);
-
-        var ruleSet = context.GenerateRuleSet();
-
-        ruleSet.Rules.Should().BeEmpty();
+        context.RuleSet.Rules.Should().BeEmpty();
     }
 
     [TestMethod]
     public void RoslynRuleSet_RoslynSDK_Rules_Added()
     {
-        var context = new RuleSetTestContext(
+        var context = new Context(
         [
             new("roslyn.custom1", "active1", true),
             new("roslyn.custom2", "active2", true),
             new("roslyn.custom1", "inactive1", false),
             new("roslyn.custom2", "inactive2", false),
         ],
-        new Dictionary<string, string>
+        new()
         {
             ["custom1.analyzerId"] = "CustomAnalyzer1",
             ["custom1.ruleNamespace"] = "CustomNamespace1",
@@ -134,133 +122,116 @@ public class RoslynRuleSetGeneratorTests
             ["custom2.ruleNamespace"] = "CustomNamespace2",
         });
 
-        var ruleSet = context.GenerateRuleSet();
-
-        ruleSet.Rules.Should().HaveCount(2);
-        ruleSet.Rules[0].RuleNamespace.Should().Be("CustomNamespace1");
-        ruleSet.Rules[0].AnalyzerId.Should().Be("CustomAnalyzer1");
-        ruleSet.Rules[0].RuleList.Should().HaveCount(2);
-        ruleSet.Rules[0].RuleList.Select(x => x.Id).Should().BeEquivalentTo("active1", "inactive1");
-        ruleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo("Warning", "None");
-        ruleSet.Rules[1].RuleNamespace.Should().Be("CustomNamespace2");
-        ruleSet.Rules[1].AnalyzerId.Should().Be("CustomAnalyzer2");
-        ruleSet.Rules[1].RuleList.Should().HaveCount(2);
-        ruleSet.Rules[1].RuleList.Select(x => x.Id).Should().BeEquivalentTo("active2", "inactive2");
-        ruleSet.Rules[1].RuleList.Select(x => x.Action).Should().BeEquivalentTo("Warning", "None");
+        context.ValidateRuleSet(["CustomNamespace1", "CustomNamespace2"],
+                                ["CustomAnalyzer1", "CustomAnalyzer2"],
+                                [["active1", "inactive1"], ["active2", "inactive2"]],
+                                [["Warning", "None"], ["Warning", "None"]]);
     }
 
     [TestMethod]
     public void RoslynRuleSet_Sonar_Rules_Added()
     {
-        var context = new RuleSetTestContext(
+        var context = new Context(
             [
-            new("csharpsquid", "active1", true),
-            // Even though this rule is for VB it will be added as C#, see NOTE below
-            new("vbnet", "active2", true),
-            new("csharpsquid", "inactive1", false),
-            // Even though this rule is for VB it will be added as C#, see NOTE below
-            new("vbnet", "inactive2", false),
+                new("csharpsquid", "active1", true),
+                // Even though this rule is for VB it will be added as C#, see NOTE below
+                new("vbnet", "active2", true),
+                new("csharpsquid", "inactive1", false),
+                // Even though this rule is for VB it will be added as C#, see NOTE below
+                new("vbnet", "inactive2", false),
             ]);
-
-        var ruleSet = context.GenerateRuleSet();
-
-        ruleSet.Rules.Should().ContainSingle();
 
         // NOTE: The RuleNamespace and AnalyzerId are taken from the language parameter of the
         // Generate method. The FetchArgumentsAndRulesets method will retrieve active/inactive
         // rules from SonarQube per language/quality profile and mixture of VB-C# rules is not
         // expected.
-        ruleSet.Rules[0].RuleNamespace.Should().Be("SonarAnalyzer.CSharp");
-        ruleSet.Rules[0].AnalyzerId.Should().Be("SonarAnalyzer.CSharp");
-        ruleSet.Rules[0].RuleList.Should().HaveCount(4);
-        ruleSet.Rules[0].RuleList.Select(x => x.Id).Should().BeEquivalentTo(
-            "active1", "active2", "inactive1", "inactive2");
-        ruleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo(
-            "Warning", "Warning", "None", "None");
+        context.ValidateRuleSet(["SonarAnalyzer.CSharp"],
+                                ["SonarAnalyzer.CSharp"],
+                                [["active1", "active2", "inactive1", "inactive2"]],
+                                [["Warning", "Warning", "None", "None"]]);
     }
 
     [TestMethod]
     public void RoslynRuleSet_Common_Parameters()
     {
-        var context = new RuleSetTestContext([], new Dictionary<string, string>());
-
-        var ruleSet = context.GenerateRuleSet();
-
-        ruleSet.Description.Should().Be("This rule set was automatically generated from SonarQube");
-        ruleSet.ToolsVersion.Should().Be("14.0");
-        ruleSet.Name.Should().Be("Rules for SonarQube");
+        var context = new Context([], []);
+        context.ValidateCommonParameters();
     }
 
     [TestMethod]
     public void RoslynRuleSet_AnalyzerId_Proprety_Missing()
     {
-        var context = new RuleSetTestContext(
+        new Action(() => new Context(
             [new("csharpsquid", "active1", true)],
-            new Dictionary<string, string>
-            {
-                { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
-            });
-
-        new Action(() => context.GenerateRuleSet()).Should()
-            .ThrowExactly<AnalysisException>().WithMessage("Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");
+            new() { { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" } }))
+            .Should().ThrowExactly<AnalysisException>()
+            .WithMessage("Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");
     }
 
     [TestMethod]
     public void RoslynRuleSet_RuleNamespace_Proprety_Missing()
     {
-        var context = new RuleSetTestContext(
+        new Action(() => new Context(
             [new("csharpsquid", "active1", true)],
-            new Dictionary<string, string>
-            {
-                { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
-            });
-
-        new Action(() => context.GenerateRuleSet()).Should()
-            .ThrowExactly<AnalysisException>().WithMessage("Property does not exist: sonaranalyzer-cs.ruleNamespace. This property should be set by the plugin in SonarQube.");
+            new() { { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" } }))
+            .Should().ThrowExactly<AnalysisException>()
+            .WithMessage("Property does not exist: sonaranalyzer-cs.ruleNamespace. This property should be set by the plugin in SonarQube.");
     }
 
     [TestMethod]
     public void RoslynRuleSet_PropertyName_IsCaseSensitive()
     {
-        var context = new RuleSetTestContext(
+        new Action(() => new Context(
             [new("csharpsquid", "active1", true)],
-            new Dictionary<string, string>
-            {
-            { "sonaranalyzer-cs.ANALYZERId", "SonarAnalyzer.CSharp" },
-            { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
-            });
-
-        new Action(() => context.GenerateRuleSet()).Should()
-            .ThrowExactly<AnalysisException>().WithMessage("Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");
+            new() { { "sonaranalyzer-cs.ANALYZERId", "SonarAnalyzer.CSharp" }, { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" } }))
+            .Should().ThrowExactly<AnalysisException>()
+            .WithMessage("Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");
     }
 
-    private class RuleSetTestContext
+    private class Context
     {
-        private RoslynRuleSetGenerator RuleSetGenerator { get; }
-        private List<SonarRule> Rules { get; }
-        private string Language { get; }
+        private readonly RoslynRuleSetGenerator ruleSetGenerator;
+        private readonly List<SonarRule> sonarRules;
+        private readonly string language;
 
-        public RuleSetTestContext(bool deactivateAll = false, List<SonarRule> rules = null, Dictionary<string, string> properties = null)
+        public RuleSet RuleSet { get; set; }
+
+        public Context(List<SonarRule> rules, Dictionary<string, string> properties = null, bool deactivateAll = false)
         {
-            RuleSetGenerator =  new RoslynRuleSetGenerator(new ListPropertiesProvider(
-                properties is null ? new Dictionary<string, string>
+            ruleSetGenerator =  new RoslynRuleSetGenerator(new ListPropertiesProvider(
+                properties ?? new Dictionary<string, string>
             {
                 { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
                 { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
-            }
-                : properties), deactivateAll);
-            Rules = rules is null ?
-            [
-                new("csharpsquid", "rule1", true),
-                new("csharpsquid", "rule2", true),
-            ] : rules;
-            Language = "cs";
+            }), deactivateAll);
+            sonarRules = rules;
+            language = "cs";
+            RuleSet = ruleSetGenerator.Generate(language, sonarRules);
         }
 
-        public RuleSetTestContext(List<SonarRule> rules) : this(false, rules) { }
+        public void ValidateSingleRuleList(List<string> rule)
+        {
+            RuleSet.Rules.Should().ContainSingle();
+            RuleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo(rule);
+        }
 
-        public RuleSetTestContext(List<SonarRule> rules, Dictionary<string, string> properties) : this(false, rules, properties) { }
+        public void ValidateRuleSet(List<string> nameSpaces, List<string> analyzerIds, List<List<string>> rulesIDs, List<List<string>> rulesWarnings)
+        {
+            for (var i = 0; i < nameSpaces.Count; i++)
+            {
+                RuleSet.Rules[i].RuleNamespace.Should().Be(nameSpaces[i]);
+                RuleSet.Rules[i].AnalyzerId.Should().Be(analyzerIds[i]);
+                RuleSet.Rules[i].RuleList.Should().HaveCount(rulesIDs[i].Count);
+                RuleSet.Rules[i].RuleList.Select(x => x.Id).Should().BeEquivalentTo(rulesIDs[i]);
+                RuleSet.Rules[i].RuleList.Select(x => x.Action).Should().BeEquivalentTo(rulesWarnings[i]);
+            }
+        }
 
-        public RuleSet GenerateRuleSet() => RuleSetGenerator.Generate(Language, Rules);
+        public void ValidateCommonParameters()
+        {
+            RuleSet.Description.Should().Be("This rule set was automatically generated from SonarQube");
+            RuleSet.ToolsVersion.Should().Be("14.0");
+            RuleSet.Name.Should().Be("Rules for SonarQube");
+        }
     }
 }


### PR DESCRIPTION
[SCAN4NET-217](https://sonarsource.atlassian.net/browse/SCAN4NET-217)

Part of SCAN4NET-171

This PR is based on top of https://github.com/SonarSource/sonar-scanner-msbuild/pull/2295. 

[SCAN4NET-217]: https://sonarsource.atlassian.net/browse/SCAN4NET-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ