### PR TITLE
SCAN4NET-221 Use constants for RoslynRuleSetGenerator legacy attributes

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynRuleSetGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynRuleSetGeneratorTests.cs
@@ -32,206 +32,131 @@ namespace SonarScanner.MSBuild.PreProcessor.Test;
 public class RoslynRuleSetGeneratorTests
 {
     [TestMethod]
-    public void RoslynRuleSet_ConstructorArgumentChecks()
+    public void Generate_Null() =>
+        ((Func<RuleSet>)(() => new RoslynRuleSetGenerator(false).Generate(null))).Should().ThrowExactly<ArgumentNullException>();
+
+    [TestMethod]
+    public void Generate_Empty()
     {
-        Action act = () => new RoslynRuleSetGenerator(null);
-        act.Should().ThrowExactly<ArgumentNullException>();
+        var context = new Context([]);
+        context.RuleSet.Rules.Single().RuleList.Should().BeEmpty();
     }
 
     [TestMethod]
-    public void RoslynRuleSet_GeneratorArgumentChecks()
-    {
-        var generator = new RoslynRuleSetGenerator(new ListPropertiesProvider());
-        var rules = Enumerable.Empty<SonarRule>();
-        var language = "cs";
-
-        Action act1 = () => generator.Generate(null, rules);
-        act1.Should().ThrowExactly<ArgumentNullException>();
-
-        Action act2 = () => generator.Generate(language, null);
-        act2.Should().ThrowExactly<ArgumentNullException>();
-    }
-
-    [TestMethod]
-    public void RoslynRuleSet_Empty()
-    {
-        var context = new Context([new("repo", "key")], []);
-        context.RuleSet.Rules.Should().BeEmpty(); // No analyzers
-        context.ValidateCommonParameters();
-    }
-
-    [TestMethod]
-    public void RoslynRuleSet_ActiveRuleAction_OverrideToNone()
+    public void Generate_ActiveRule_OverrideToNone()
     {
         var context = new Context([
                 new("csharpsquid", "rule1", true),
                 new("csharpsquid", "rule2", true),
-            ],
-            null,
-            true);
-        context.ValidateSingleRuleList(["None", "None"]);
+            ], true);
+        context.ValidateRuleSet(
+            new("rule1", "None"),
+            new("rule2", "None"));
     }
 
     [TestMethod]
-    public void RoslynRuleSet_ActiveRuleAction_Warning()
+    public void Generate_ActiveRuleAction_Warning()
     {
         var context = new Context([
                 new("csharpsquid", "rule1", true),
                 new("csharpsquid", "rule2", true),
             ]);
-        context.ValidateSingleRuleList(["Warning", "Warning"]);
+        context.ValidateRuleSet(
+            new("rule1", "Warning"),
+            new("rule2", "Warning"));
     }
 
     [TestMethod]
-    public void RoslynRuleSet_InactiveRules_None()
+    public void Generate_InactiveRules_None()
     {
-        var context = new Context(
-        [
-            new("csharpsquid", "rule1", isActive: false),
-            new("csharpsquid", "rule2", isActive: false),
+        var context = new Context([
+            new("csharpsquid", "rule1", false),
+            new("csharpsquid", "rule2", false),
         ]);
-        context.ValidateSingleRuleList(["None", "None"]);
+        context.ValidateRuleSet(
+            new("rule1", "None"),
+            new("rule2", "None"));
     }
 
     [TestMethod]
-    public void RoslynRuleSet_Unsupported_Rules_Ignored()
+    public void Generate_MixedActivation()
     {
-        var context = new Context(
-        [
+        var context = new Context([
+            new("csharpsquid", "rule1", false),
+            new("csharpsquid", "rule2", true),
+        ]);
+        context.ValidateRuleSet(
+            new("rule1", "None"),
+            new("rule2", "Warning"));
+    }
+
+    [TestMethod]
+    public void Generate_OtherRules()
+    {
+        var context = new Context([
             new("other.repo", "other.rule1", isActive: true),
             new("other.repo", "other.rule2", isActive: false),
         ]);
-        context.RuleSet.Rules.Should().BeEmpty();
+        context.ValidateRuleSet(
+            new("other.rule1", "Warning"),
+            new("other.rule2", "None"));
     }
 
     [TestMethod]
-    public void RoslynRuleSet_RoslynSDK_Rules_Added()
+    public void Generate_RoslynSDKRules()
     {
-        var context = new Context(
-        [
+        var context = new Context([
             new("roslyn.custom1", "active1", true),
             new("roslyn.custom2", "active2", true),
             new("roslyn.custom1", "inactive1", false),
             new("roslyn.custom2", "inactive2", false),
-        ],
-        new()
-        {
-            ["custom1.analyzerId"] = "CustomAnalyzer1",
-            ["custom1.ruleNamespace"] = "CustomNamespace1",
-            ["custom2.analyzerId"] = "CustomAnalyzer2",
-            ["custom2.ruleNamespace"] = "CustomNamespace2",
-        });
-
-        context.ValidateRuleSet(["CustomNamespace1", "CustomNamespace2"],
-                                ["CustomAnalyzer1", "CustomAnalyzer2"],
-                                [["active1", "inactive1"], ["active2", "inactive2"]],
-                                [["Warning", "None"], ["Warning", "None"]]);
+        ]);
+        context.ValidateRuleSet(
+            new("active1", "Warning"),
+            new("active2", "Warning"),
+            new("inactive1", "None"),
+            new("inactive2", "None"));
     }
 
     [TestMethod]
-    public void RoslynRuleSet_Sonar_Rules_Added()
+    public void Generate_SonarRules()
     {
-        var context = new Context(
-            [
-                new("csharpsquid", "active1", true),
-                // Even though this rule is for VB it will be added as C#, see NOTE below
-                new("vbnet", "active2", true),
-                new("csharpsquid", "inactive1", false),
-                // Even though this rule is for VB it will be added as C#, see NOTE below
-                new("vbnet", "inactive2", false),
+        // RoslynAnalyzerProvider receives rules per language, so this will not happen in practice. The RoslynRuleSetGenerator generates all that it receives.
+        var context = new Context([
+            new("csharpsquid", "CS-active1", true),
+            new("vbnet", "VB-active2", true),
+            new("csharpsquid", "CS-inactive1", false),
+            new("vbnet", "VB-inactive2", false),
             ]);
-
-        // NOTE: The RuleNamespace and AnalyzerId are taken from the language parameter of the
-        // Generate method. The FetchArgumentsAndRulesets method will retrieve active/inactive
-        // rules from SonarQube per language/quality profile and mixture of VB-C# rules is not
-        // expected.
-        context.ValidateRuleSet(["SonarAnalyzer.CSharp"],
-                                ["SonarAnalyzer.CSharp"],
-                                [["active1", "active2", "inactive1", "inactive2"]],
-                                [["Warning", "Warning", "None", "None"]]);
+        context.ValidateRuleSet(
+            new("CS-active1", "Warning"),
+            new("VB-active2", "Warning"),
+            new("CS-inactive1", "None"),
+            new("VB-inactive2", "None"));
     }
 
-    [TestMethod]
-    public void RoslynRuleSet_Common_Parameters()
+    private sealed class Context
     {
-        var context = new Context([], []);
-        context.ValidateCommonParameters();
-    }
-
-    [TestMethod]
-    public void RoslynRuleSet_AnalyzerId_Proprety_Missing()
-    {
-        new Action(() => new Context(
-            [new("csharpsquid", "active1", true)],
-            new() { { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" } }))
-            .Should().ThrowExactly<AnalysisException>()
-            .WithMessage("Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");
-    }
-
-    [TestMethod]
-    public void RoslynRuleSet_RuleNamespace_Proprety_Missing()
-    {
-        new Action(() => new Context(
-            [new("csharpsquid", "active1", true)],
-            new() { { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" } }))
-            .Should().ThrowExactly<AnalysisException>()
-            .WithMessage("Property does not exist: sonaranalyzer-cs.ruleNamespace. This property should be set by the plugin in SonarQube.");
-    }
-
-    [TestMethod]
-    public void RoslynRuleSet_PropertyName_IsCaseSensitive()
-    {
-        new Action(() => new Context(
-            [new("csharpsquid", "active1", true)],
-            new() { { "sonaranalyzer-cs.ANALYZERId", "SonarAnalyzer.CSharp" }, { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" } }))
-            .Should().ThrowExactly<AnalysisException>()
-            .WithMessage("Property does not exist: sonaranalyzer-cs.analyzerId. This property should be set by the plugin in SonarQube.");
-    }
-
-    private class Context
-    {
-        private readonly RoslynRuleSetGenerator ruleSetGenerator;
-        private readonly List<SonarRule> sonarRules;
-        private readonly string language;
-
         public RuleSet RuleSet { get; set; }
 
-        public Context(List<SonarRule> rules, Dictionary<string, string> properties = null, bool deactivateAll = false)
+        public Context(List<SonarRule> rules, bool deactivateAll = false)
         {
-            ruleSetGenerator =  new RoslynRuleSetGenerator(new ListPropertiesProvider(
-                properties ?? new Dictionary<string, string>
-            {
-                { "sonaranalyzer-cs.analyzerId", "SonarAnalyzer.CSharp" },
-                { "sonaranalyzer-cs.ruleNamespace", "SonarAnalyzer.CSharp" },
-            }), deactivateAll);
-            sonarRules = rules;
-            language = "cs";
-            RuleSet = ruleSetGenerator.Generate(language, sonarRules);
+            var sut =  new RoslynRuleSetGenerator(deactivateAll);
+            RuleSet = sut.Generate(rules);
+            ValidateCommonParameters();
         }
 
-        public void ValidateSingleRuleList(List<string> rule)
-        {
-            RuleSet.Rules.Should().ContainSingle();
-            RuleSet.Rules[0].RuleList.Select(x => x.Action).Should().BeEquivalentTo(rule);
-        }
+        public void ValidateRuleSet(params Rule[] expected) =>
+            RuleSet.Rules.Single().RuleList.Should().BeEquivalentTo(expected);
 
-        public void ValidateRuleSet(List<string> nameSpaces, List<string> analyzerIds, List<List<string>> rulesIDs, List<List<string>> rulesWarnings)
-        {
-            for (var i = 0; i < nameSpaces.Count; i++)
-            {
-                RuleSet.Rules[i].RuleNamespace.Should().Be(nameSpaces[i]);
-                RuleSet.Rules[i].AnalyzerId.Should().Be(analyzerIds[i]);
-                RuleSet.Rules[i].RuleList.Should().HaveCount(rulesIDs[i].Count);
-                RuleSet.Rules[i].RuleList.Select(x => x.Id).Should().BeEquivalentTo(rulesIDs[i]);
-                RuleSet.Rules[i].RuleList.Select(x => x.Action).Should().BeEquivalentTo(rulesWarnings[i]);
-            }
-        }
-
-        public void ValidateCommonParameters()
+        private void ValidateCommonParameters()
         {
             RuleSet.Description.Should().Be("This rule set was automatically generated from SonarQube");
             RuleSet.ToolsVersion.Should().Be("14.0");
             RuleSet.Name.Should().Be("Rules for SonarQube");
+            var rules = RuleSet.Rules.Should().ContainSingle().Subject;
+            rules.AnalyzerId.Should().Be("SonarAnalyzerFor.NET");
+            rules.RuleNamespace.Should().Be("SonarAnalyzerFor.NET");
         }
     }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynRuleSetGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/RoslynRuleSetGeneratorTests.cs
@@ -18,12 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
 
 namespace SonarScanner.MSBuild.PreProcessor.Test;
@@ -155,8 +149,8 @@ public class RoslynRuleSetGeneratorTests
             RuleSet.ToolsVersion.Should().Be("14.0");
             RuleSet.Name.Should().Be("Rules for SonarQube");
             var rules = RuleSet.Rules.Should().ContainSingle().Subject;
-            rules.AnalyzerId.Should().Be("SonarAnalyzerFor.NET");
-            rules.RuleNamespace.Should().Be("SonarAnalyzerFor.NET");
+            rules.AnalyzerId.Should().Be("SonarScannerFor.NET");
+            rules.RuleNamespace.Should().Be("SonarScannerFor.NET");
         }
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynAnalyzerProvider.cs
@@ -65,8 +65,8 @@ public class RoslynAnalyzerProvider(IAnalyzerInstaller analyzerInstaller, ILogge
 
     private string CreateRuleSet(IEnumerable<SonarRule> rules, bool deactivateAll)
     {
-        var ruleSetGenerator = new RoslynRuleSetGenerator(sonarProperties, deactivateAll);
-        var ruleSet = ruleSetGenerator.Generate(language, rules);
+        var ruleSetGenerator = new RoslynRuleSetGenerator(deactivateAll);
+        var ruleSet = ruleSetGenerator.Generate(rules);
         var rulesetFilePath = Path.Combine(teamBuildSettings.SonarConfigDirectory, string.Format(deactivateAll ? RulesetFileNameNone : RulesetFileNameNormal, language));
         logger.LogDebug(Resources.RAP_UnpackingRuleset, rulesetFilePath);
         ruleSet.Save(rulesetFilePath);

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynRuleSetGenerator.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynRuleSetGenerator.cs
@@ -27,7 +27,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
 
 public class RoslynRuleSetGenerator(bool deactivateAll)
 {
-    private const string LegacyAttributesValue = "SonarAnalyzerFor.NET";    // Legacy, unused, but mandatory attribute
+    private const string LegacyAttributesValue = "SonarScannerFor.NET";    // Legacy, unused, but mandatory attribute
     private const string ActiveRuleText = "Warning";
     private const string InactiveRuleText = "None";
 

--- a/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynRuleSetGenerator.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Roslyn/RoslynRuleSetGenerator.cs
@@ -25,77 +25,34 @@ using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
 
-public class RoslynRuleSetGenerator(IAnalysisPropertyProvider sonarProperties, bool deactivateAll = false)
+public class RoslynRuleSetGenerator(bool deactivateAll)
 {
-    private const string LegacyServerPropertyFormat = "sonaranalyzer-{0}";
-    private const string RoslynRepoPrefix = "roslyn.";
+    private const string LegacyAttributesValue = "SonarAnalyzerFor.NET";    // Legacy, unused, but mandatory attribute
     private const string ActiveRuleText = "Warning";
     private const string InactiveRuleText = "None";
 
-    private readonly IAnalysisPropertyProvider sonarProperties = sonarProperties ?? throw new ArgumentNullException(nameof(sonarProperties));
     private readonly bool deactivateAll = deactivateAll;
 
-    /// <summary>
-    /// Generates a RuleSet that is serializable (XML).
-    /// The ruleset can be empty if there are no active rules belonging to the repo keys "vbnet", "csharpsquid" or "roslyn.*".
-    /// </summary>
-    /// <exception cref="AnalysisException">if required properties that should be associated with the repo key are missing.</exception>
-    public RuleSet Generate(string language, IEnumerable<SonarRule> rules)
+    public RuleSet Generate(IEnumerable<SonarRule> rules)
     {
-        _ = language ?? throw new ArgumentNullException(nameof(language));
         _ = rules ?? throw new ArgumentNullException(nameof(rules));
         return new RuleSet
         {
             Name = "Rules for SonarQube",
             Description = "This rule set was automatically generated from SonarQube",
             ToolsVersion = "14.0",
-            Rules = rules
-                .GroupBy(x => PartialRepoKey(x, language))
-                .Where(x => x.Key is not null)
-                .Select(CreateRules)
-                .ToList()
+            Rules = [CreateRules(rules)]
         };
     }
 
-    private static string PartialRepoKey(SonarRule rule, string language)
-    {
-        if (rule.RepoKey.StartsWith(RoslynRepoPrefix) && rule.RepoKey.Length > RoslynRepoPrefix.Length)
+    private Rules CreateRules(IEnumerable<SonarRule> analyzerRules) =>
+        new()
         {
-            return rule.RepoKey.Substring(RoslynRepoPrefix.Length);
-        }
-        else if (rule.RepoKey == "csharpsquid" || rule.RepoKey == "vbnet")
-        {
-            return string.Format(LegacyServerPropertyFormat, language);
-        }
-        else
-        {
-            return null;
-        }
-    }
-
-    private Rules CreateRules(IGrouping<string, SonarRule> analyzerRules)
-    {
-        var partialRepoKey = analyzerRules.Key;
-        return new Rules
-        {
-            AnalyzerId = GetRequiredPropertyValue($"{partialRepoKey}.analyzerId"),
-            RuleNamespace = GetRequiredPropertyValue($"{partialRepoKey}.ruleNamespace"),
+            AnalyzerId = LegacyAttributesValue,
+            RuleNamespace = LegacyAttributesValue,
             RuleList = analyzerRules.Select(CreateRule).ToList()
         };
-    }
 
     private Rule CreateRule(SonarRule sonarRule) =>
         new(sonarRule.RuleKey, sonarRule.IsActive && !deactivateAll ? ActiveRuleText : InactiveRuleText);
-
-    private string GetRequiredPropertyValue(string propertyKey)
-    {
-        if (sonarProperties.TryGetValue(propertyKey, out var propertyValue))
-        {
-            return propertyValue;
-        }
-        else
-        {
-            throw new AnalysisException($"Property does not exist: {propertyKey}. This property should be set by the plugin in SonarQube.");
-        }
-    }
 }


### PR DESCRIPTION
[SCAN4NET-221](https://sonarsource.atlassian.net/browse/SCAN4NET-221)

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->


[SCAN4NET-221]: https://sonarsource.atlassian.net/browse/SCAN4NET-221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ