### PR TITLE
SCAN4NET-229 Implement ServerCertificateCustomValidationCallback in WebClientDownloaderBuilder for self-signed certificates for direct CAs.

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -191,6 +191,110 @@ public class WebClientDownloaderBuilderTest
     }
 
     [TestMethod]
+    public async Task CASignedCertIsTrusted()
+    {
+        // Arrange
+        using var caCert = CertificateBuilder.CreateRootCA();
+        using var caCertFileName = new TempFile("pfx", x => File.WriteAllBytes(x, caCert.WithoutPrivateKey().Export(X509ContentType.Pfx)));
+        using var serverCert = CertificateBuilder.CreateWebServerCertificate(caCert);
+        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
+        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
+
+        var builder = new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
+            .AddServerCertificate(caCertFileName.FileName, string.Empty);
+        using var client = builder.Build();
+
+        // Act
+        var response = await client.Download(server.Url);
+
+        // Assert
+        response.Should().Be("Hello World");
+    }
+
+    [TestMethod]
+    public async Task CASignedCertWithCAsDifferentFromTrustStore_Fail()
+    {
+        // Arrange
+        using var caCert = CertificateBuilder.CreateRootCA();
+        using var serverCert = CertificateBuilder.CreateWebServerCertificate(caCert);
+        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
+        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
+
+        var otherCAs = CertificateBuilder.BuildCollection([
+            CertificateBuilder.CreateRootCA(name: "OtherCA1"),
+            CertificateBuilder.CreateRootCA(name: "OtherCA2"),
+            CertificateBuilder.CreateRootCA(name: "OtherCA3"),]);
+        using var trustStoreFile = new TempFile("pfx", x => File.WriteAllBytes(x, otherCAs.Export(X509ContentType.Pfx)));
+        var builder = new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
+            .AddServerCertificate(trustStoreFile.FileName, string.Empty);
+        using var client = builder.Build();
+
+        // Act
+        var download = async () => await client.Download(server.Url);
+
+        // Assert
+        (await download.Should().ThrowAsync<HttpRequestException>())
+            .WithInnerException<WebException>().WithInnerException<AuthenticationException>().WithMessage("The remote certificate is invalid according to the validation procedure.");
+    }
+
+    [TestMethod]
+    public async Task CASignedCertWithCAsDifferentFromTrustStoreButSameIssuerName_Fail()
+    {
+        // Arrange
+        using var caCert = CertificateBuilder.CreateRootCA(name: "RootCA");
+        using var serverCert = CertificateBuilder.CreateWebServerCertificate(caCert);
+        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
+        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
+
+        var otherCAs = CertificateBuilder.BuildCollection([
+            CertificateBuilder.CreateRootCA(name: "OtherCA1"),
+            CertificateBuilder.CreateRootCA(name: "RootCA"), // Same name, but different Certificate (serial number and public key)
+            CertificateBuilder.CreateRootCA(name: "OtherCA3"),]);
+        using var trustStoreFile = new TempFile("pfx", x => File.WriteAllBytes(x, otherCAs.Export(X509ContentType.Pfx)));
+        var builder = new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
+            .AddServerCertificate(trustStoreFile.FileName, string.Empty);
+        using var client = builder.Build();
+
+        // Act
+        var download = async () => await client.Download(server.Url);
+
+        // Assert
+        (await download.Should().ThrowAsync<HttpRequestException>())
+            .WithInnerException<WebException>().WithInnerException<AuthenticationException>().WithMessage("The remote certificate is invalid according to the validation procedure.");
+    }
+
+    [TestMethod]
+    public async Task CASignedCertWithCAsDifferentFromTrustStoreButSameIssuerNameAndSerialNumber_Fail()
+    {
+        // Arrange
+        var serialNumber = Guid.NewGuid();
+        using var caCert = CertificateBuilder.CreateRootCA(name: "RootCA", serialNumber: serialNumber);
+        using var serverCert = CertificateBuilder.CreateWebServerCertificate(caCert);
+        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
+        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
+
+        var otherCAs = CertificateBuilder.BuildCollection([
+            CertificateBuilder.CreateRootCA(name: "OtherCA1"),
+            CertificateBuilder.CreateRootCA(name: "RootCA", serialNumber: serialNumber), // Same name and serial number, but different Certificate (serial number and public key)
+            CertificateBuilder.CreateRootCA(name: "OtherCA3"),]);
+        using var trustStoreFile = new TempFile("pfx", x => File.WriteAllBytes(x, otherCAs.Export(X509ContentType.Pfx)));
+        var builder = new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
+            .AddServerCertificate(trustStoreFile.FileName, string.Empty);
+        using var client = builder.Build();
+
+        // Act
+        var download = async () => await client.Download(server.Url);
+
+        // Assert
+        (await download.Should().ThrowAsync<HttpRequestException>())
+            .WithInnerException<WebException>().WithInnerException<AuthenticationException>().WithMessage("The remote certificate is invalid according to the validation procedure.");
+    }
+
+    [TestMethod]
     public async Task SelfSignedServerCertificatesIsOneOfManyInTruststore_Success()
     {
         // Arrange

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -365,8 +365,7 @@ public class WebClientDownloaderBuilderTest
         using var caCert = CertificateBuilder.CreateRootCA();
         using var caCertFileName = new TempFile("pfx", x => File.WriteAllBytes(x, caCert.WithoutPrivateKey().Export(X509ContentType.Pfx)));
         using var serverCert = CertificateBuilder.CreateWebServerCertificate(caCert);
-        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
-        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
 
         var builder = new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
@@ -386,8 +385,7 @@ public class WebClientDownloaderBuilderTest
         // Arrange
         using var caCert = CertificateBuilder.CreateRootCA();
         using var serverCert = CertificateBuilder.CreateWebServerCertificate(caCert);
-        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
-        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
 
         var otherCAs = CertificateBuilder.BuildCollection([
@@ -413,8 +411,7 @@ public class WebClientDownloaderBuilderTest
         // Arrange
         using var caCert = CertificateBuilder.CreateRootCA(name: "RootCA");
         using var serverCert = CertificateBuilder.CreateWebServerCertificate(caCert);
-        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
-        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
 
         var otherCAs = CertificateBuilder.BuildCollection([
@@ -441,8 +438,7 @@ public class WebClientDownloaderBuilderTest
         var serialNumber = Guid.NewGuid();
         using var caCert = CertificateBuilder.CreateRootCA(name: "RootCA", serialNumber: serialNumber);
         using var serverCert = CertificateBuilder.CreateWebServerCertificate(caCert);
-        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
-        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
 
         var otherCAs = CertificateBuilder.BuildCollection([

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -358,7 +358,6 @@ public class WebClientDownloaderBuilderTest
         callbackWasCalled.Should().BeTrue();
     }
 
-
     [TestMethod]
     public async Task CASignedCertIsTrusted()
     {

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
@@ -146,7 +146,7 @@ public sealed class WebClientDownloaderBuilder : IDisposable
                     var foundInTrustStore = trustStore.Find(X509FindType.FindBySerialNumber, rootInChain.Certificate.SerialNumber, validOnly: false);
                     // Check if the certificates found by serial number in the trust store really contain the root certificate of the chain by doing a proper equality check
                     // see also the Remark section in https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate.equals
-                    return foundInTrustStore is not null && foundInTrustStore.Cast<X509Certificate2>().Any(x => x.RawData.SequenceEqual(rootInChain.Certificate.RawData));
+                    return foundInTrustStore.Cast<X509Certificate2>().Any(x => x.RawData.SequenceEqual(rootInChain.Certificate.RawData));
                 }
                 return false;
             }

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
@@ -120,12 +120,35 @@ public sealed class WebClientDownloaderBuilder : IDisposable
         {
             return true;
         }
-        if (errors is SslPolicyErrors.RemoteCertificateChainErrors // Don't do HasFlags. Any other errors than RemoteCertificateChainErrors should fail the handshake.
-            && chain.ChainStatus.All(x => x.Status is X509ChainStatusFlags.UntrustedRoot)) // Any other violations than UntrustedRoot should fail the handshake.
+        if (errors is SslPolicyErrors.RemoteCertificateChainErrors) // Don't do HasFlags. Any other errors than RemoteCertificateChainErrors should fail the handshake.
         {
-            if (trustStore.Find(X509FindType.FindBySerialNumber, certificate.SerialNumber, validOnly: false) is { Count: > 0 } certificatesInTrustStore)
+            if (chain.ChainStatus.All(x => x.Status is X509ChainStatusFlags.UntrustedRoot) // Self-signed certificate cause this error
+                && trustStore.Find(X509FindType.FindBySerialNumber, certificate.SerialNumber, validOnly: false) is { Count: > 0 } certificatesInTrustStore)
             {
+                // see also the Remark section in https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate.equals
                 return certificatesInTrustStore.Cast<X509Certificate2>().Any(x => x.RawData.SequenceEqual(certificate.RawData)); // public keys must match
+            }
+            if (chain.ChainStatus.All(x => x.Status is X509ChainStatusFlags.PartialChain))
+            {
+                // Build a chain of certificates including the CAs and Intermediate CAs found in the trust store
+                using var testChain = new X509Chain();
+                testChain.ChainPolicy.ExtraStore.AddRange(trustStore);
+
+                // The ExtraStore is only consulted when building the chain and the CAs in ExtraStore are not consider trustworthy CAs.
+                // .Net 5 adds testChain.ChainPolicy.CustomTrustStore which provides full support for chain validation with custom trustworthy CA roots.
+                testChain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
+                testChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck; // CRL and OCSP are not checked. Net5 is required for CRL support.
+                var valid = testChain.Build(certificate);
+                if (valid && testChain.ChainStatus.All(x => x.Status == X509ChainStatusFlags.UntrustedRoot))
+                {
+                    // The testchain should now contain a certificate from the trust store as it's root
+                    var rootInChain = testChain.ChainElements.Cast<X509ChainElement>().Last();
+                    var foundInTrustStore = trustStore.Find(X509FindType.FindBySerialNumber, rootInChain.Certificate.SerialNumber, validOnly: false);
+                    // Check if the certificates found by serial number in the trust store really contain the root certificate of the chain by doing a proper equality check
+                    // see also the Remark section in https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate.equals
+                    return foundInTrustStore is not null && foundInTrustStore.Cast<X509Certificate2>().Any(x => x.RawData.SequenceEqual(rootInChain.Certificate.RawData));
+                }
+                return false;
             }
         }
         return false;

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
@@ -144,7 +144,6 @@ public sealed class WebClientDownloaderBuilder : IDisposable
                     var rootInChain = testChain.ChainElements.Cast<X509ChainElement>().Last();
                     var foundInTrustStore = trustStore.Find(X509FindType.FindBySerialNumber, rootInChain.Certificate.SerialNumber, validOnly: false);
                     // Check if the certificates found by serial number in the trust store really contain the root certificate of the chain by doing a proper equality check
-                    // see also the Remark section in https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate.equals
                     return IsCertificateInTrustStore(rootInChain.Certificate, foundInTrustStore);
                 }
                 return false;


### PR DESCRIPTION
[SCAN4NET-229](https://sonarsource.atlassian.net/browse/SCAN4NET-229)

Part of SCAN4NET-209

[SCAN4NET-229]: https://sonarsource.atlassian.net/browse/SCAN4NET-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ