### PR TITLE
SCAN4NET-230 ServerBuilder.StartServer takes certificates instead of filename

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
@@ -40,8 +40,7 @@ public class CertificateBuilderTests
     public async Task MockServerReturnsSelfSignedCertificate()
     {
         using var selfSigned = CertificateBuilder.CreateWebServerCertificate();
-        using var selfSignedFile = new TempFile("pfx", x => File.WriteAllBytes(x, selfSigned.Export(X509ContentType.Pkcs12)));
-        using var server = ServerBuilder.StartServer(selfSignedFile.FileName);
+        using var server = ServerBuilder.StartServer(selfSigned);
         server.Given(Request.Create().WithPath("/").UsingGet()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
         using var handler = new HttpClientHandler();
         using var client = new HttpClient(handler);
@@ -63,8 +62,7 @@ public class CertificateBuilderTests
         using var rootCA = CertificateBuilder.CreateRootCA();
         using var webServerCert = CertificateBuilder.CreateWebServerCertificate(rootCA);
         var collection = CertificateBuilder.BuildCollection(webServerCert, [rootCA]);
-        using var webServerCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, collection.Export(X509ContentType.Pkcs12)));
-        using var server = ServerBuilder.StartServer(webServerCertFile.FileName);
+        using var server = ServerBuilder.StartServer(collection);
         server.Given(Request.Create().WithPath("/").UsingGet()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
         using var handler = new HttpClientHandler();
         using var client = new HttpClient(handler);
@@ -88,8 +86,7 @@ public class CertificateBuilderTests
         using var intermediate = CertificateBuilder.CreateIntermediateCA(rootCA);
         using var webServerCert = CertificateBuilder.CreateWebServerCertificate(intermediate);
         var collection = CertificateBuilder.BuildCollection(webServerCert, [intermediate, rootCA]);
-        using var webServerCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, collection.Export(X509ContentType.Pkcs12)));
-        using var server = ServerBuilder.StartServer(webServerCertFile.FileName);
+        using var server = ServerBuilder.StartServer(collection);
         server.Given(Request.Create().WithPath("/").UsingGet()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
         using var handler = new HttpClientHandler();
         using var client = new HttpClient(handler);
@@ -119,8 +116,7 @@ public class CertificateBuilderTests
             alternatives.AddDnsName(additionalHostName);
         }
         using var selfSigned = CertificateBuilder.CreateWebServerCertificate(serverName: "dummy.org", subjectAlternativeNames: alternatives);
-        using var selfSignedFile = new TempFile("pfx", x => File.WriteAllBytes(x, selfSigned.Export(X509ContentType.Pkcs12)));
-        using var server = ServerBuilder.StartServer(selfSignedFile.FileName);
+        using var server = ServerBuilder.StartServer(selfSigned);
         server.Given(Request.Create().WithPath("/").UsingGet()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
         using var handler = new HttpClientHandler();
         using var client = new HttpClient(handler);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/ServerBuilder.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/ServerBuilder.cs
@@ -40,9 +40,13 @@ internal static class ServerBuilder
 
     /// <summary>
     /// Runs an SSL mock server on the next available port with the given webserver certificates.
+    /// The actual server certificate needs to be the first certificate in the collection. Use <see cref="CertificateBuilder.BuildCollection(X509Certificate2, X509Certificate2[])"/>
+    /// to build such a collection.
     /// </summary>
     public static WireMockServer StartServer(X509Certificate2Collection certificates)
     {
+        // The certificates need to be stored in the certificate store because we need the mock server to return
+        // the intermediate certificates along with the server certificate when the client initiates the SSL handshake.
         var newCertificates = AddCertificatesToStore(certificates);
         var port = GetNextAvailablePort();
         var settings = new WireMockServerSettings

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -159,7 +159,7 @@ public class WebClientDownloaderBuilderTest
         // Arrange
         using var serverCert = CertificateBuilder.CreateWebServerCertificate();
         using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
-        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
 
         using var clientCert = CertificateBuilder.CreateClientCertificate("test.user@sonarsource.com");
@@ -195,8 +195,7 @@ public class WebClientDownloaderBuilderTest
     {
         // Arrange
         using var serverCert = CertificateBuilder.CreateWebServerCertificate();
-        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
-        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
 
         // Some other unrelated certificates are also in the truststore
@@ -220,8 +219,7 @@ public class WebClientDownloaderBuilderTest
     {
         // Arrange
         using var serverCert = CertificateBuilder.CreateWebServerCertificate();
-        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
-        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
 
         using var trustCert1 = CertificateBuilder.CreateWebServerCertificate().WithoutPrivateKey();
@@ -257,8 +255,7 @@ public class WebClientDownloaderBuilderTest
             subjectAlternativeNames.AddDnsName(domain);
         }
         using var serverCert = CertificateBuilder.CreateWebServerCertificate(serverName: "NotLocalHost", subjectAlternativeNames: subjectAlternativeNames);
-        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
-        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
 
         using var trustStore = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.WithoutPrivateKey().Export(X509ContentType.Pfx)));
@@ -333,8 +330,7 @@ public class WebClientDownloaderBuilderTest
         var today = DateTimeOffset.Now;
         // Arrange
         using var serverCert = CertificateBuilder.CreateWebServerCertificate(notBefore: today.AddDays(notBeforeDays), notAfter: today.AddDays(notAfterDays));
-        using var serverCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.Export(X509ContentType.Pfx)));
-        using var server = ServerBuilder.StartServer(serverCertFile.FileName);
+        using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
 
         using var trustStore = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.WithoutPrivateKey().Export(X509ContentType.Pfx)));


### PR DESCRIPTION
[SCAN4NET-230](https://sonarsource.atlassian.net/browse/SCAN4NET-230)

Part of SCAN4NET-209

`ServerBuilder.StartServer` does not really need a file as input since we moved to the certificate store as the source for the mock server certificates. This change makes starting the server a bit easier and the file indirection is avoided.

[SCAN4NET-230]: https://sonarsource.atlassian.net/browse/SCAN4NET-230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ