### PR TITLE
SCAN4NET-233 Implement ServerCertificateCustomValidationCallback in WebClientDownloaderBuilder for intermediate CAs

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -562,8 +562,7 @@ public class WebClientDownloaderBuilderTest
 
         // Assert
         result.Should().Be("Hello World");
-        chainSendByServer.Should().NotBeNull();
-        chainSendByServer.Should().BeEquivalentTo([serverCert, intermediateCAfromServer]);
+        chainSendByServer.Should().NotBeNull().And.BeEquivalentTo([serverCert, intermediateCAfromServer]);
     }
 
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
@@ -481,7 +482,7 @@ public class WebClientDownloaderBuilderTest
     }
 
     [TestMethod]
-    public async Task IntermediateCAWithTrustedIntermediateCA()
+    public async Task IntermediateCAWithTrustedIntermediateCA_Fail()
     {
         // Arrange
         using var caCert = CertificateBuilder.CreateRootCA();
@@ -496,14 +497,16 @@ public class WebClientDownloaderBuilderTest
         using var client = builder.Build();
 
         // Act
-        var result = await client.Download(server.Url);
+        var downloader = async () => await client.Download(server.Url);
 
         // Assert
-        result.Should().Be("Hello World");
+        // This is also how HttpClient behaves: it only trusts complete chains that end in a Root CA. An Intermediate CA is not enough
+        (await downloader.Should().ThrowAsync<HttpRequestException>())
+            .WithInnerException<WebException>().WithInnerException<AuthenticationException>().WithMessage("The remote certificate is invalid according to the validation procedure.");
     }
 
     [TestMethod]
-    public async Task IntermediateCAWithTrustedWebseverCertificate()
+    public async Task IntermediateCAWithTrustedWebseverCertificate_Fail()
     {
         // Arrange
         using var caCert = CertificateBuilder.CreateRootCA();
@@ -513,6 +516,72 @@ public class WebClientDownloaderBuilderTest
         server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
 
         using var trustStoreFile = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.WithoutPrivateKey().Export(X509ContentType.Pfx)));
+        var builder = new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
+            .AddServerCertificate(trustStoreFile.FileName, string.Empty);
+        using var client = builder.Build();
+
+        // Act
+        var downloader = async () => await client.Download(server.Url);
+
+        // Assert
+        // This is also how HttpClient behaves: If the web server certificate is not self-signed, the chain must end in a Root-CA
+        (await downloader.Should().ThrowAsync<HttpRequestException>())
+            .WithInnerException<WebException>().WithInnerException<AuthenticationException>().WithMessage("The remote certificate is invalid according to the validation procedure.");
+    }
+
+    [TestMethod]
+    public async Task IntermediateCAsWithPartialChainInTrustStore()
+    {
+        // Arrange
+        using var caCert = CertificateBuilder.CreateRootCA(); // only in TrustStore
+        using var intermediateCAfromTrustStore = CertificateBuilder.CreateIntermediateCA(caCert, name: "IntermediateTrustStore"); // only in TrustStore
+        using var intermediateCAfromServer = CertificateBuilder.CreateIntermediateCA(intermediateCAfromTrustStore, name: "IntermediateServer"); // only send by the server
+        using var serverCert = CertificateBuilder.CreateWebServerCertificate(intermediateCAfromServer);  // only send by the server
+        using var server = ServerBuilder.StartServer(CertificateBuilder.BuildCollection(serverCert, [intermediateCAfromServer]));
+        server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
+
+        using var trustStoreFile = new TempFile("pfx", x => File.WriteAllBytes(x, CertificateBuilder.BuildCollection([
+            caCert.WithoutPrivateKey(),
+            intermediateCAfromTrustStore.WithoutPrivateKey(),
+            ]).Export(X509ContentType.Pfx)));
+        var builder = new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
+            .AddServerCertificate(trustStoreFile.FileName, string.Empty);
+        using var client = builder.Build();
+        // Intercept the ServerCertificateCustomValidationCallback to assert the certificate chain send to the client
+        var handler = GetHandler(builder);
+        List<X509Certificate2> chainSendByServer = null;
+        var registeredCertificateValidationCallback = handler.ServerCertificateCustomValidationCallback;
+        handler.ServerCertificateCustomValidationCallback = (message, certificate, chain, errors) =>
+        {
+            chainSendByServer = chain.ChainElements.Cast<X509ChainElement>().Select(x => x.Certificate).ToList();
+            return registeredCertificateValidationCallback(message, certificate, chain, errors);
+        };
+
+        // Act
+        var result = await client.Download(server.Url);
+
+        // Assert
+        result.Should().Be("Hello World");
+        chainSendByServer.Should().NotBeNull();
+        chainSendByServer.Should().BeEquivalentTo([serverCert, intermediateCAfromServer]);
+    }
+
+    [TestMethod]
+    public async Task IntermediateCAsWithPartialChainInTrustStoreWithOverlaps()
+    {
+        // Arrange
+        using var caCert = CertificateBuilder.CreateRootCA(); // only in TrustStore
+        using var intermediateCAfromTrustStore = CertificateBuilder.CreateIntermediateCA(caCert, name: "IntermediateTrustStore"); // only in TrustStore
+        using var intermediateCAfromServerAndTrustStore = CertificateBuilder.CreateIntermediateCA(intermediateCAfromTrustStore, name: "IntermediateTrustStoreServer"); // in TrustStore and send by the server
+        using var serverCert = CertificateBuilder.CreateWebServerCertificate(intermediateCAfromServerAndTrustStore);  // only send by the server
+        using var server = ServerBuilder.StartServer(CertificateBuilder.BuildCollection(serverCert, [intermediateCAfromServerAndTrustStore]));
+        server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
+
+        using var trustStoreFile = new TempFile("pfx", x => File.WriteAllBytes(x, CertificateBuilder.BuildCollection([
+            caCert.WithoutPrivateKey(),
+            intermediateCAfromTrustStore.WithoutPrivateKey(),
+            intermediateCAfromServerAndTrustStore.WithoutPrivateKey(),
+            ]).Export(X509ContentType.Pfx)));
         var builder = new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
             .AddServerCertificate(trustStoreFile.FileName, string.Empty);
         using var client = builder.Build();

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
@@ -138,7 +138,7 @@ public sealed class WebClientDownloaderBuilder : IDisposable
                 testChain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
                 testChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck; // CRL and OCSP are not checked. Net5 is required for CRL support.
                 var valid = testChain.Build(certificate);
-                if (valid && testChain.ChainStatus.All(x => x.Status == X509ChainStatusFlags.UntrustedRoot))
+                if (valid && testChain.ChainStatus.All(x => x.Status is X509ChainStatusFlags.UntrustedRoot or X509ChainStatusFlags.PartialChain))
                 {
                     // The testchain should now contain a certificate from the trust store as it's root
                     var rootInChain = testChain.ChainElements.Cast<X509ChainElement>().Last();

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
@@ -138,7 +138,7 @@ public sealed class WebClientDownloaderBuilder : IDisposable
                 testChain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
                 testChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck; // CRL and OCSP are not checked. Net5 is required for CRL support.
                 var valid = testChain.Build(certificate);
-                if (valid && testChain.ChainStatus.All(x => x.Status is X509ChainStatusFlags.UntrustedRoot or X509ChainStatusFlags.PartialChain))
+                if (valid && testChain.ChainStatus.All(x => x.Status is X509ChainStatusFlags.UntrustedRoot))
                 {
                     // The testchain should now contain a certificate from the trust store as it's root
                     var rootInChain = testChain.ChainElements.Cast<X509ChainElement>().Last();


### PR DESCRIPTION
[SCAN4NET-233](https://sonarsource.atlassian.net/browse/SCAN4NET-233)

Part of SCAN4NET-209

[SCAN4NET-233]: https://sonarsource.atlassian.net/browse/SCAN4NET-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ