### PR TITLE
SCAN4NET-241 Add logging for file I/O errors in AddServerCertifcate

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -157,6 +157,51 @@ public class WebClientDownloaderBuilderTest
         FluentActions.Invoking(() => new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger).AddServerCertificate("missingcert.pfx", "password")).Should().Throw<CryptographicException>();
 
     [TestMethod]
+    public void AddServerCertificate_InvalidPassword()
+    {
+        using var serverCert = CertificateBuilder.CreateWebServerCertificate();
+        using var trustStore = new TempFile("pfx", x => File.WriteAllBytes(x, serverCert.WithoutPrivateKey().Export(X509ContentType.Pfx, "trustStoreCredential")));
+        var builder = () => new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
+            .AddServerCertificate(trustStore.FileName, "wrongTrustStoreCredential");
+        builder.Should().Throw<CryptographicException>().WithMessage("The specified network password is not correct.");
+        logger.AssertErrorLogged($"Failed to import the sonar.scanner.truststorePath file {trustStore.FileName}: The specified network password is not correct.");
+    }
+
+    [TestMethod]
+    public void AddServerCertificate_InvalidFileFormat()
+    {
+        using var brokenTrustStore = new TempFile("pfx", x => File.WriteAllText(x, "InvalidDummyContent"));
+        var builder = () => new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
+            .AddServerCertificate(brokenTrustStore.FileName, string.Empty);
+        builder.Should().Throw<CryptographicException>().WithMessage("Cannot find the requested object.");
+        logger.AssertErrorLogged($"Failed to import the sonar.scanner.truststorePath file {brokenTrustStore.FileName}: Cannot find the requested object.");
+    }
+
+#if NET
+
+    [TestMethod]
+    public void AddServerCertificate_PemFormatSupportedInNet()
+    {
+        using var serverCert = CertificateBuilder.CreateWebServerCertificate();
+        using var trustStore = new TempFile("pfx", x => File.WriteAllText(x, serverCert.WithoutPrivateKey().ExportCertificatePem()));
+        var builder = () => new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
+            .AddServerCertificate(trustStore.FileName, string.Empty);
+        builder.Should().NotThrow<CryptographicException>();
+    }
+
+#endif
+
+    [TestMethod]
+    public void AddServerCertificate_FileNotFound()
+    {
+        var nonExisitentFile = Path.GetRandomFileName();
+        var builder = () => new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
+            .AddServerCertificate(nonExisitentFile, string.Empty);
+        builder.Should().Throw<CryptographicException>().WithMessage("The system cannot find the file specified.");
+        logger.AssertErrorLogged($"Failed to import the sonar.scanner.truststorePath file {nonExisitentFile}: The system cannot find the file specified.");
+    }
+
+    [TestMethod]
     public async Task SelfSignedClientAndServerCertificatesAreSupported()
     {
         // Arrange

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
@@ -100,7 +100,7 @@ public sealed class WebClientDownloaderBuilder : IDisposable
         }
         catch (CryptographicException ex)
         {
-            logger.LogError($"Failed to import the {SonarProperties.TruststorePath} file {{0}}: {{1}}", serverCertPath, ex.Message);
+            logger.LogError($"Failed to import the {SonarProperties.TruststorePath} file {{0}}: {{1}}", serverCertPath, ex.Message?.TrimEnd());
             throw;
         }
         handler.ServerCertificateCustomValidationCallback = (message, certificate, chain, errors) =>

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
@@ -100,7 +100,7 @@ public sealed class WebClientDownloaderBuilder : IDisposable
         }
         catch (CryptographicException ex)
         {
-            logger.LogError($"Failed to import the {SonarProperties.TruststorePath} file {{0}}: {{1}}", serverCertPath, ex.Message?.TrimEnd());
+            logger.LogError($"Failed to import the {SonarProperties.TruststorePath} file {{0}}: {{1}}", serverCertPath, ex.Message.TrimEnd());
             throw;
         }
         handler.ServerCertificateCustomValidationCallback = (message, certificate, chain, errors) =>


### PR DESCRIPTION
[SCAN4NET-241](https://sonarsource.atlassian.net/browse/SCAN4NET-241)

Part of SCAN4NET-209

[SCAN4NET-241]: https://sonarsource.atlassian.net/browse/SCAN4NET-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ