### PR TITLE
SCAN4NET-244 Add logging for ServerCertificateValidationChain

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -768,7 +768,7 @@ public partial class WebClientDownloaderBuilderTest
         logger.AssertDebugLogged($"""
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
-        logger.Warnings.Should().HaveCount(1, because: "the warning is either WARN_TrustStore_Chain_Invalid or WARN_TrustStore_OtherChainStatus depending on the environment.");
+        logger.Warnings.Should().ContainSingle(because: "the warning is either WARN_TrustStore_Chain_Invalid or WARN_TrustStore_OtherChainStatus depending on the environment.");
     }
 
     private static string GetHeader(WebClientDownloader downloader, string header)

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -31,6 +31,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using SonarScanner.MSBuild.Common;
@@ -767,8 +768,7 @@ public partial class WebClientDownloaderBuilderTest
         logger.AssertDebugLogged($"""
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
-        // The warning is either WARN_TrustStore_Chain_Invalid or WARN_TrustStore_OtherChainStatus depending on the environment.
-        logger.Warnings.Should().HaveCount(1);
+        logger.Warnings.Should().HaveCount(1, because: "the warning is either WARN_TrustStore_Chain_Invalid or WARN_TrustStore_OtherChainStatus depending on the environment.");
     }
 
     private static string GetHeader(WebClientDownloader downloader, string header)

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -432,13 +432,13 @@ public partial class WebClientDownloaderBuilderTest
     {
         // Arrange
         using var caCert = CertificateBuilder.CreateRootCA();
-        using var caCertFileName = new TempFile("pfx", x => File.WriteAllBytes(x, caCert.WithoutPrivateKey().Export(X509ContentType.Pfx)));
+        using var caCertFile = new TempFile("pfx", x => File.WriteAllBytes(x, caCert.WithoutPrivateKey().Export(X509ContentType.Pfx)));
         using var serverCert = CertificateBuilder.CreateWebServerCertificate(caCert);
         using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
 
         var builder = new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
-            .AddServerCertificate(caCertFileName.FileName, string.Empty);
+            .AddServerCertificate(caCertFile.FileName, string.Empty);
         using var client = builder.Build();
 
         // Act
@@ -446,6 +446,9 @@ public partial class WebClientDownloaderBuilderTest
 
         // Assert
         response.Should().Be("Hello World");
+        logger.AssertDebugLogged($"""
+            The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{caCertFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
+            """);
     }
 
     [TestMethod]
@@ -471,6 +474,14 @@ public partial class WebClientDownloaderBuilderTest
 
         // Assert
         await ShouldThrowServerValidationFailed(download);
+        logger.AssertDebugLogged($"""
+            The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
+            """);
+        logger.AssertWarningLogged($"""
+            The certificate chain of the web server certificate is invalid. The validation errors are 
+            * A certificate chain could not be built to a trusted root authority.
+            Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
+            """);
     }
 
     [TestMethod]
@@ -496,6 +507,15 @@ public partial class WebClientDownloaderBuilderTest
 
         // Assert
         await ShouldThrowServerValidationFailed(download);
+        logger.AssertDebugLogged($"""
+            The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
+            """);
+        logger.AssertWarningLogged($"""
+            The certificate chain of the web server certificate is invalid. The validation errors are 
+            * The signature of the certificate cannot be verified.
+            * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
+            Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
+            """);
     }
 
     [TestMethod]
@@ -522,6 +542,50 @@ public partial class WebClientDownloaderBuilderTest
 
         // Assert
         await ShouldThrowServerValidationFailed(download);
+        logger.AssertDebugLogged($"""
+            The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
+            """);
+        logger.AssertWarningLogged($"""
+            The certificate chain of the web server certificate is invalid. The validation errors are 
+            * The signature of the certificate cannot be verified.
+            * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
+            Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
+            """);
+    }
+
+    [TestMethod]
+    public async Task CASignedCertWithInvalidCA_Fail()
+    {
+        // Arrange
+        var now = DateTimeOffset.Now;
+        using var rsa = RSA.Create(2048);
+        using var caCert = CertificateBuilder.CreateRootCA(name: "RootCA", privateKey: rsa); // Used for creating the webserver certificate
+        // caCertInvalid is the same CA (same private key) but with an invalid timespan. This is used in the truststore.
+        // It can not be used to create the web server certificate, because we want the webserver certificate to have a valid timespan here.
+        using var caCertInvalid = CertificateBuilder.CreateRootCA(name: "RootCA", privateKey: rsa, notBefore: now.AddDays(1), notAfter: now.AddDays(2));
+        using var serverCert = CertificateBuilder.CreateWebServerCertificate(caCert);
+        using var server = ServerBuilder.StartServer(serverCert);
+        server.Given(Request.Create().WithPath("/").UsingAnyMethod()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
+
+        using var trustStoreFile = new TempFile("pfx", x => File.WriteAllBytes(x, caCertInvalid.Export(X509ContentType.Pfx)));
+        var builder = new WebClientDownloaderBuilder(BaseAddress, httpTimeout, logger)
+            .AddServerCertificate(trustStoreFile.FileName, string.Empty);
+        using var client = builder.Build();
+
+        // Act
+        var download = async () => await client.Download(server.Url);
+
+        // Assert
+        await ShouldThrowServerValidationFailed(download);
+        logger.AssertDebugLogged($"""
+            The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
+            """);
+        logger.AssertWarningLogged($"""
+            The certificate chain of the web server certificate is invalid. The validation errors are 
+            * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
+            * A required certificate is not within its validity period when verifying against the current system clock or the timestamp in the signed file.
+            Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
+            """);
     }
 
     [TestMethod]
@@ -544,6 +608,9 @@ public partial class WebClientDownloaderBuilderTest
 
         // Assert
         result.Should().Be("Hello World");
+        logger.AssertDebugLogged($"""
+            The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
+            """);
     }
 
     [TestMethod]
@@ -567,6 +634,14 @@ public partial class WebClientDownloaderBuilderTest
         // Assert
         // This is also how HttpClient behaves: it only trusts complete chains that end in a Root CA. An Intermediate CA is not enough
         await ShouldThrowServerValidationFailed(downloader);
+        logger.AssertDebugLogged($"""
+            The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
+            """);
+        logger.AssertWarningLogged($"""
+            The certificate chain of the web server certificate is invalid. The validation errors are 
+            * A certificate chain could not be built to a trusted root authority.
+            Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
+            """);
     }
 
     [TestMethod]
@@ -590,6 +665,14 @@ public partial class WebClientDownloaderBuilderTest
         // Assert
         // This is also how HttpClient behaves: If the web server certificate is not self-signed, the chain must end in a Root-CA
         await ShouldThrowServerValidationFailed(downloader);
+        logger.AssertDebugLogged($"""
+            The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
+            """);
+        logger.AssertWarningLogged($"""
+            The certificate chain of the web server certificate is invalid. The validation errors are 
+            * A certificate chain could not be built to a trusted root authority.
+            Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
+            """);
     }
 
     [TestMethod]
@@ -681,6 +764,15 @@ public partial class WebClientDownloaderBuilderTest
         // A trusted chain can not be build, because intermediateCAServer is not send by the server. The intermediateCATrustStore found in the trust store is used to build
         // the chain, but the chain status contains the error "The signature of the certificate cannot be verified.".
         await ShouldThrowServerValidationFailed(downloader);
+        logger.AssertDebugLogged($"""
+            The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
+            """);
+        logger.AssertWarningLogged($"""
+            The certificate chain of the web server certificate is invalid. The validation errors are 
+            * The signature of the certificate cannot be verified.
+            * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
+            Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
+            """);
     }
 
     private static string GetHeader(WebClientDownloader downloader, string header)

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -767,7 +767,7 @@ public partial class WebClientDownloaderBuilderTest
         logger.AssertDebugLogged($"""
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
-        // The warning is either WARN_TrustStore_Chain_Invalid or WARN_TrustStore_OtherChainStatus
+        // The warning is either WARN_TrustStore_Chain_Invalid or WARN_TrustStore_OtherChainStatus depending on the environment.
         logger.Warnings.Should().HaveCount(1);
     }
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -767,12 +767,8 @@ public partial class WebClientDownloaderBuilderTest
         logger.AssertDebugLogged($"""
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
-        logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are 
-            * The signature of the certificate cannot be verified.
-            * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
-            Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
-            """);
+        // The warning is either WARN_TrustStore_Chain_Invalid or WARN_TrustStore_OtherChainStatus
+        logger.Warnings.Should().HaveCount(1);
     }
 
     private static string GetHeader(WebClientDownloader downloader, string header)

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -1318,6 +1318,25 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The certificate chain of the web server certificate is invalid. The validation errors are {0}
+        ///Check the certificates in the truststore file &apos;{1}&apos; specified via the {2} parameter or its default value..
+        /// </summary>
+        internal static string WARN_TrustStore_Chain_Invalid {
+            get {
+                return ResourceManager.GetString("WARN_TrustStore_Chain_Invalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The certificate trust chain ended in a root certificate (Issuer: {0} Thumbprint: {1}) which could not be found in the trust store file &apos;{2}&apos; specified in the parameter {3} or its default value..
+        /// </summary>
+        internal static string WARN_TrustStore_Chain_RootCertificateNotFound {
+            get {
+                return ResourceManager.GetString("WARN_TrustStore_Chain_RootCertificateNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The webserver returned an invalid certificate which could not be validated against the truststore file specified in {0}. The validation failed with these errors: {1}.
         /// </summary>
         internal static string WARN_TrustStore_OtherChainStatus {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -561,4 +561,11 @@ If you already have a compatible java version installed, please add either the p
   <data name="WARN_TrustStore_PolicyErrors" xml:space="preserve">
     <value>The webserver returned an invalid certificate. Error details: {0}</value>
   </data>
+  <data name="WARN_TrustStore_Chain_Invalid" xml:space="preserve">
+    <value>The certificate chain of the web server certificate is invalid. The validation errors are {0}
+Check the certificates in the truststore file '{1}' specified via the {2} parameter or its default value.</value>
+  </data>
+  <data name="WARN_TrustStore_Chain_RootCertificateNotFound" xml:space="preserve">
+    <value>The certificate trust chain ended in a root certificate (Issuer: {0} Thumbprint: {1}) which could not be found in the trust store file '{2}' specified in the parameter {3} or its default value.</value>
+  </data>
 </root>

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
@@ -142,14 +142,11 @@ public sealed class WebClientDownloaderBuilder : IDisposable
             }
             else if (chain.ChainStatus.All(x => x.Status is X509ChainStatusFlags.PartialChain))
             {
-                return ServerCertificateValidationChain(trustStore, certificate);
+                return ServerCertificateValidationChain(trustStore, logger, trustStoreFile, certificate);
             }
             else
             {
-                logger.LogWarning(Resources.WARN_TrustStore_OtherChainStatus, SonarProperties.TruststorePath, chain.ChainStatus.Aggregate(new StringBuilder(), (sb, x) => sb.Append($"""
-
-                    * {x.StatusInformation.TrimEnd()}
-                    """), x => x.ToString()));
+                logger.LogWarning(Resources.WARN_TrustStore_OtherChainStatus, SonarProperties.TruststorePath, ChainStatusAsBulletList(chain));
                 return false;
             }
         }
@@ -160,7 +157,13 @@ public sealed class WebClientDownloaderBuilder : IDisposable
         }
     }
 
-    private static bool ServerCertificateValidationChain(X509Certificate2Collection trustStore, X509Certificate2 certificate)
+    private static string ChainStatusAsBulletList(X509Chain chain) =>
+        chain.ChainStatus.Aggregate(new StringBuilder(), (sb, x) => sb.Append($"""
+
+            * {x.StatusInformation.TrimEnd()}
+            """), x => x.ToString());
+
+    private static bool ServerCertificateValidationChain(X509Certificate2Collection trustStore, ILogger logger, string trustStoreFile, X509Certificate2 certificate)
     {
         // Build a chain of certificates including the CAs and Intermediate CAs found in the trust store
         using var testChain = new X509Chain();
@@ -177,10 +180,23 @@ public sealed class WebClientDownloaderBuilder : IDisposable
             var rootInChain = testChain.ChainElements.Cast<X509ChainElement>().Last();
             var foundInTrustStore = trustStore.Find(X509FindType.FindBySerialNumber, rootInChain.Certificate.SerialNumber, validOnly: false);
             // Check if the certificates found by serial number in the trust store really contain the root certificate of the chain by doing a proper equality check
-            return IsCertificateInTrustStore(rootInChain.Certificate, foundInTrustStore);
+            if (IsCertificateInTrustStore(rootInChain.Certificate, foundInTrustStore))
+            {
+                return true;
+            }
+            else
+            {
+                logger.LogWarning(Resources.WARN_TrustStore_Chain_RootCertificateNotFound,
+                                  rootInChain.Certificate.Issuer,
+                                  rootInChain.Certificate.Thumbprint,
+                                  trustStoreFile,
+                                  SonarProperties.TruststorePath);
+                return false;
+            }
         }
         else
         {
+            logger.LogWarning(Resources.WARN_TrustStore_Chain_Invalid, ChainStatusAsBulletList(testChain), trustStoreFile, SonarProperties.TruststorePath);
             return false;
         }
     }

--- a/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebClientDownloaderBuilder.cs
@@ -186,6 +186,10 @@ public sealed class WebClientDownloaderBuilder : IDisposable
             }
             else
             {
+                // Untestable code path. The combination of ChainStatus.All(PartialChain) in ServerCertificateCustomValidationCallback
+                // and ChainStatus.All(UntrustedRoot) here require the root certificate being in the trust store file.
+                // If we ever end up here, something very unique happened. The logging was tested once manually so we know the logging
+                // does not throw.
                 logger.LogWarning(Resources.WARN_TrustStore_Chain_RootCertificateNotFound,
                                   rootInChain.Certificate.Issuer,
                                   rootInChain.Certificate.Thumbprint,


### PR DESCRIPTION
[SCAN4NET-244](https://sonarsource.atlassian.net/browse/SCAN4NET-244)

Part of  SCAN4NET-209

[SCAN4NET-244]: https://sonarsource.atlassian.net/browse/SCAN4NET-244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ