### PR TITLE
SCAN4NET-279 Remove verbose log from Angular & React ITs

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -1132,7 +1132,6 @@ class ScannerMSBuildTest {
       .setProjectName(folderName)
       .setProjectVersion("1.0")
       .setProperty("sonar.sourceEncoding", "UTF-8")
-      .setProperty("sonar.verbose", "true")
       // Overriding environment variables to fallback to projectBaseDir detection
       // This can be removed once we move to Cirrus CI.
       .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "")
@@ -1195,7 +1194,6 @@ class ScannerMSBuildTest {
       .setProjectName(folderName)
       .setProjectVersion("1.0")
       .setProperty("sonar.sourceEncoding", "UTF-8")
-      .setProperty("sonar.verbose", "true")
       // Overriding environment variables to fallback to projectBaseDir detection
       // This can be removed once we move to Cirrus CI.
       .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "")


### PR DESCRIPTION
[SCAN4NET-279](https://sonarsource.atlassian.net/browse/SCAN4NET-279)

Testing theory that the logs produced by these two ITs are so big they make the `Finalize Job` step timeout.

Context: https://sonarsource.slack.com/archives/C03HVJQ53M2/p1741099602888699



[SCAN4NET-279]: https://sonarsource.atlassian.net/browse/SCAN4NET-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ