### PR TITLE
SCAN4NET-198 Create minimal ScannerCommand class

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
@@ -92,8 +92,8 @@ class CodeCoverageTest {
     assertThat(endStepResult.getLogs()).contains("Coverage report conversion completed successfully.");
     assertThat(endStepResult.getLogs()).containsPattern("Converting coverage file '.*.coverage' to '.*.coveragexml'.");
     assertThat(endStepResult.getLogs()).containsPattern("Parsing the Visual Studio coverage XML report .*coveragexml");
-    assertThat(endStepResult.getLogs()).contains("Coverage Report Statistics: 2 files, 1 main files, 1 main files with coverage, 1 test files, 0 project excluded files, 0 other " +
-      "language files.");
+    assertThat(endStepResult.getLogs()).contains(
+      "Coverage Report Statistics: 2 files, 1 main files, 1 main files with coverage, 1 test files, 0 project excluded files, 0 other language files.");
   }
 
   @Test

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
@@ -111,7 +111,7 @@ class CodeCoverageTest {
       .setProperty("sonar.verbose", "true")
       .setProperty("sonar.cs.dotcover.reportsPaths", "dotCover.Output.html")
       .setProjectVersion("1.0");
-    var beginStepResult = ORCHESTRATOR.executeBuild(scanner);
+    var beginStepResult = scanner.execute(ORCHESTRATOR);
     assertTrue(beginStepResult.isSuccess());
 
     TestUtils.runDotnetCommand(projectDir, "build", "--no-incremental");
@@ -182,7 +182,7 @@ class CodeCoverageTest {
       TestUtils.updateSetting(ORCHESTRATOR, projectKey, "sonar.cs.vscoveragexml.reportsPaths", List.of(serverCoverageReportPath));
     }
 
-    var beginStepResult = ORCHESTRATOR.executeBuild(scanner);
+    var beginStepResult = scanner.execute(ORCHESTRATOR);
     assertTrue(beginStepResult.isSuccess());
 
     TestUtils.runDotnetCommand(projectDir, "build", "--no-incremental");
@@ -212,7 +212,7 @@ class CodeCoverageTest {
     for (var environmentVariable : environmentVariables) {
       scanner.setEnvironmentVariable(environmentVariable.getName(), environmentVariable.getValue());
     }
-    var beginStepResult = ORCHESTRATOR.executeBuild(scanner);
+    var beginStepResult = scanner.execute(ORCHESTRATOR);
     assertTrue(beginStepResult.isSuccess());
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CppTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CppTest.java
@@ -63,13 +63,14 @@ class CppTest {
 
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(projectKey)
       .setProjectName("Cpp")
       .setProjectVersion("1.0")
       .setProperty("sonar.cfamily.build-wrapper-output", wrapperOutDir.toString())
-      .setProperty("sonar.projectBaseDir", Paths.get(projectDir.toAbsolutePath().toString(), "ConsoleApp").toString()));
+      .setProperty("sonar.projectBaseDir", Paths.get(projectDir.toAbsolutePath().toString(), "ConsoleApp").toString())
+      .execute(ORCHESTRATOR);
 
     File buildWrapperZip = new File(basePath.toString(), "build-wrapper-win-x86.zip");
     File buildWrapperDir = basePath.toFile();
@@ -111,13 +112,14 @@ class CppTest {
 
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(projectKey)
       .setProjectName("Cpp")
       .setProjectVersion("1.0")
       .setProperty("sonar.cfamily.build-wrapper-output", wrapperOutDir.toString())
-      .setProperty("sonar.projectBaseDir", projectDir.toAbsolutePath().toString()));
+      .setProperty("sonar.projectBaseDir", projectDir.toAbsolutePath().toString())
+      .execute(ORCHESTRATOR);
 
     File buildWrapperZip = new File(basePath.toString(), "build-wrapper-win-x86.zip");
     File buildWrapperDir = Files.createDirectories(basePath).toFile();
@@ -131,7 +133,6 @@ class CppTest {
       wrapperOutDir, "/t:Rebuild",
       String.format("/p:WindowsTargetPlatformVersion=%s", windowsSdk),
       String.format("/p:PlatformToolset=%s", platformToolset));
-    ;
 
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, projectKey, token);
     assertThat(result.isSuccess()).isTrue();

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/JreProvisioningTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/JreProvisioningTest.java
@@ -123,12 +123,13 @@ public class JreProvisioningTest {
   }
 
   private static BuildResult BeginStep(Path projectDir, String token) {
-    return ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    return TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(PROJECT_KEY)
       .setProjectName(PROJECT_NAME)
       .setProperty("sonar.projectBaseDir", Paths.get(projectDir.toAbsolutePath().toString(), PROJECT_NAME).toString())
       .setProperty("sonar.userHome", projectDir.toAbsolutePath().toString())
-      .setProperty("sonar.verbose", "true"));
+      .setProperty("sonar.verbose", "true")
+      .execute(ORCHESTRATOR);
   }
 }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/OrchestratorState.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/OrchestratorState.java
@@ -61,7 +61,7 @@ public class OrchestratorState {
   private void analyzeEmptyProject() throws Exception {
     Path temp = Files.createTempDirectory("OrchestratorStartup." + Thread.currentThread().getName());
     String token = TestUtils.getNewToken(ORCHESTRATOR);
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, "Empty", temp, token, ScannerClassifier.NET_FRAMEWORK));
+    TestUtils.newScannerBegin(ORCHESTRATOR, "Empty", temp, token, ScannerClassifier.NET_FRAMEWORK).execute(ORCHESTRATOR);
     TestUtils.buildMSBuild(ORCHESTRATOR, temp);
     TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, temp, "Empty", token);
     // Some have Directory.Delete(temp, true), others have different mentality

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SQLServerTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SQLServerTest.java
@@ -42,12 +42,13 @@ class SQLServerTest {
   void should_find_issues_in_cs_files() throws Exception {
     Path projectDir = TestUtils.projectDir(basePath, "SQLServerSolution");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
-    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(PROJECT_KEY)
       .setProjectName("sample")
       .setProperty("sonar.projectBaseDir", Paths.get(projectDir.toAbsolutePath().toString(), "Database1").toString())
-      .setProjectVersion("1.0"));
+      .setProjectVersion("1.0")
+      .execute(ORCHESTRATOR);
 
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild");
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -1539,9 +1539,9 @@ class ScannerMSBuildTest {
       // will take precedence, so then the key for the shared file is what is expected by
       // the tests.
       if (projectName.isEmpty()) {
-        scanner.addArgument("/d:sonar.projectBaseDir=" + projectDir.toAbsolutePath());
+        scanner.setProperty("sonar.projectBaseDir", projectDir.toAbsolutePath().toString());
       } else {
-        scanner.addArgument("/d:sonar.projectBaseDir=" + Paths.get(projectDir.toAbsolutePath().toString(), projectName));
+        scanner.setProperty("sonar.projectBaseDir", projectDir.toAbsolutePath().resolve(projectName).toString());
       }
 
     }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -1444,7 +1444,7 @@ class ScannerMSBuildTest {
       .setProjectKey(folderName)
       .setProjectName(folderName)
       .setProjectVersion("1.0")
-      // do NOT set "sonar.projectBaseDir" for this test
+      .setProperty("sonar.projectBaseDir", null)  // Do NOT set "sonar.projectBaseDir" for this test. We need to remove the default value
       .setScannerVersion(TestUtils.developmentScannerVersion())
       .setEnvironmentVariable(AzureDevOpsUtils.ENV_SOURCES_DIRECTORY, "")
       .setProperty("sonar.verbose", "true")

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -182,7 +182,7 @@ class ScannerMSBuildTest {
     BuildResult result = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("end")
       .setEnvironmentVariable("SONAR_SCANNER_OPTS", "-Dhttp.nonProxyHosts= -Dhttp.proxyHost=localhost -Dhttp.proxyPort=" + httpProxyPort)
-      .executeQuietly(ORCHESTRATOR);
+      .execute(ORCHESTRATOR);
 
     assertThat(result.getLastStatus()).isNotZero();
     assertThat(result.getLogs()).contains("407");
@@ -506,7 +506,7 @@ class ScannerMSBuildTest {
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Restore,Rebuild", "/p:ExcludeProjectsFromAnalysis=true");
     BuildResult result = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("end")
-      .executeQuietly(ORCHESTRATOR);
+      .execute(ORCHESTRATOR);
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.getLogs()).contains("The exclude flag has been set so the project will not be analyzed.");
@@ -1462,7 +1462,7 @@ class ScannerMSBuildTest {
       // simulate it's not on Azure Pipelines (otherwise, it will take the projectBaseDir from there)
       .setEnvironmentVariable(AzureDevOpsUtils.ENV_SOURCES_DIRECTORY, "")
       .setScannerVersion(TestUtils.developmentScannerVersion())
-      .executeQuietly(ORCHESTRATOR);
+      .execute(ORCHESTRATOR);
   }
 
   private void assertProjectFileContains(String projectName, String textToLookFor) throws IOException {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -1512,7 +1512,7 @@ class ScannerMSBuildTest {
   private BuildResult runBeginBuildAndEndForStandardProject(Path projectDir, String projectName, Boolean setProjectBaseDirExplicitly, Boolean useNuGet) {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     String folderName = projectDir.getFileName().toString();
-    ScannerCommand scanner = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    ScannerCommand scanner = TestUtils.newScannerBegin(ORCHESTRATOR, folderName, projectDir, token, ScannerClassifier.NET_FRAMEWORK)
       .addArgument("begin")
       .setProjectKey(folderName)
       .setProjectName(folderName)

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -33,7 +33,6 @@ import com.sonar.orchestrator.locator.FileLocation;
 import com.sonar.orchestrator.util.Command;
 import com.sonar.orchestrator.util.CommandExecutor;
 import com.sonar.orchestrator.util.NetworkUtils;
-import com.sonar.orchestrator.version.Version;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -1395,27 +1394,17 @@ class ScannerMSBuildTest {
 
   private void assertUIWarnings(BuildResult buildResult) {
     // AnalysisWarningsSensor was implemented starting from analyzer version 8.39.0.47922 (https://github.com/SonarSource/sonar-dotnet-enterprise/commit/39baabb01799aa1945ac5c80d150f173e6ada45f)
-    var analyzerVersion = TestUtils.getAnalyzerVersion(ORCHESTRATOR);
-    if (!TestUtils.isDevOrLatestRelease(analyzerVersion)
-      && !Version.create(analyzerVersion).isGreaterThan(8, 39)) {
-      return;
-    }
-    var warnings = TestUtils.getAnalysisWarningsTask(ORCHESTRATOR, buildResult);
-    assertThat(warnings.getStatus()).isEqualTo(Ce.TaskStatus.SUCCESS);
-    var warningsList = warnings.getWarningsList();
-    assertThat(warningsList.stream().anyMatch(
-      // The warning is appended to the timestamp, we want to assert only the message
-      x -> x.endsWith("Multi-Language analysis is enabled. If this was not intended and you have issues such as hitting your LOC limit or analyzing unwanted files, please set " +
-        "\"/d:sonar.scanner.scanAll=false\" in the begin step.")
-    )).isTrue();
+    // So it's available from SQ 9.9 onwards
     if (ORCHESTRATOR.getServer().version().isGreaterThanOrEquals(9, 9)) {
-      assertThat(warningsList.size()).isEqualTo(1);
-    } else {
+      var warnings = TestUtils.getAnalysisWarningsTask(ORCHESTRATOR, buildResult);
+      assertThat(warnings.getStatus()).isEqualTo(Ce.TaskStatus.SUCCESS);
+      var warningsList = warnings.getWarningsList();
       assertThat(warningsList.stream().anyMatch(
         // The warning is appended to the timestamp, we want to assert only the message
-        x -> x.endsWith("Starting in January 2025, the SonarScanner for .NET will not support SonarQube versions below 9.9. Please upgrade to a newer version.")
+        x -> x.endsWith("Multi-Language analysis is enabled. If this was not intended and you have issues such as hitting your LOC limit or analyzing unwanted files, please set " +
+          "\"/d:sonar.scanner.scanAll=false\" in the begin step.")
       )).isTrue();
-      assertThat(warningsList.size()).isEqualTo(2);
+      assertThat(warningsList.size()).isEqualTo(1);
     }
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -24,6 +24,7 @@ import com.sonar.it.scanner.msbuild.utils.AzureDevOpsUtils;
 import com.sonar.it.scanner.msbuild.utils.EnvironmentVariable;
 import com.sonar.it.scanner.msbuild.utils.ProxyAuthenticator;
 import com.sonar.it.scanner.msbuild.utils.ScannerClassifier;
+import com.sonar.it.scanner.msbuild.utils.ScannerCommand;
 import com.sonar.it.scanner.msbuild.utils.TestUtils;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.ScannerForMSBuild;
@@ -76,7 +77,6 @@ import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Credential;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -142,12 +142,13 @@ class ScannerMSBuildTest {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
     Path projectDir = TestUtils.projectDir(basePath, "ProjectUnderTest");
-    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(localProjectKey)
       .setProjectName("sample")
       .setProperty("sonar.projectBaseDir", Paths.get(projectDir.toAbsolutePath().toString(), "ProjectUnderTest").toString())
-      .setProjectVersion("1.0"));
+      .setProjectVersion("1.0")
+      .execute(ORCHESTRATOR);
 
     TestUtils.buildMSBuild(ORCHESTRATOR, projectDir);
 
@@ -169,27 +170,30 @@ class ScannerMSBuildTest {
 
     Path projectDir = TestUtils.projectDir(basePath, "ProjectUnderTest");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
-    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(localProjectKey)
       .setProjectName("sample")
       .setProperty("sonar.projectBaseDir", Paths.get(projectDir.toAbsolutePath().toString(), "ProjectUnderTest").toString())
-      .setProjectVersion("1.0"));
+      .setProjectVersion("1.0")
+      .execute(ORCHESTRATOR);
 
     TestUtils.buildMSBuild(ORCHESTRATOR, projectDir);
 
-    BuildResult result = ORCHESTRATOR.executeBuildQuietly(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    BuildResult result = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("end")
-      .setEnvironmentVariable("SONAR_SCANNER_OPTS", "-Dhttp.nonProxyHosts= -Dhttp.proxyHost=localhost -Dhttp.proxyPort=" + httpProxyPort));
+      .setEnvironmentVariable("SONAR_SCANNER_OPTS", "-Dhttp.nonProxyHosts= -Dhttp.proxyHost=localhost -Dhttp.proxyPort=" + httpProxyPort)
+      .executeQuietly(ORCHESTRATOR);
 
     assertThat(result.getLastStatus()).isNotZero();
     assertThat(result.getLogs()).contains("407");
     assertThat(seenByProxy).isEmpty();
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("end")
       .setEnvironmentVariable("SONAR_SCANNER_OPTS",
-        "-Dhttp.nonProxyHosts= -Dhttp.proxyHost=localhost -Dhttp.proxyPort=" + httpProxyPort + " -Dhttp.proxyUser=" + PROXY_USER + " -Dhttp.proxyPassword=" + PROXY_PASSWORD));
+        "-Dhttp.nonProxyHosts= -Dhttp.proxyHost=localhost -Dhttp.proxyPort=" + httpProxyPort + " -Dhttp.proxyUser=" + PROXY_USER + " -Dhttp.proxyPassword=" + PROXY_PASSWORD)
+      .execute(ORCHESTRATOR);
 
     TestUtils.dumpComponentList(ORCHESTRATOR, localProjectKey);
     TestUtils.dumpProjectIssues(ORCHESTRATOR, localProjectKey);
@@ -226,10 +230,11 @@ class ScannerMSBuildTest {
 
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProperty("sonar.projectBaseDir", Paths.get(projectDir.toAbsolutePath().toString(), "ProjectUnderTest").toString())
-      .setProjectKey(localProjectKey));
+      .setProjectKey(localProjectKey)
+      .execute(ORCHESTRATOR);
 
     TestUtils.buildMSBuild(ORCHESTRATOR, projectDir);
 
@@ -251,7 +256,7 @@ class ScannerMSBuildTest {
   void testExcludedAndTest_AnalyzeTestProject() throws Exception {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     Path projectDir = TestUtils.projectDir(basePath, "ExcludedTest");
-    ScannerForMSBuild build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_False", projectDir, token, ScannerClassifier.NET_FRAMEWORK)
+    ScannerCommand build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_False", projectDir, token, ScannerClassifier.NET_FRAMEWORK)
       // don't exclude test projects
       .setProperty("sonar.dotnet.excludeTestProjects", "false");
 
@@ -262,7 +267,7 @@ class ScannerMSBuildTest {
   void testExcludedAndTest_ExcludeTestProject() throws Exception {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     Path projectDir = TestUtils.projectDir(basePath, "ExcludedTest");
-    ScannerForMSBuild build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_True", projectDir, token, ScannerClassifier.NET_FRAMEWORK)
+    ScannerCommand build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_True", projectDir, token, ScannerClassifier.NET_FRAMEWORK)
       // exclude test projects
       .setProperty("sonar.dotnet.excludeTestProjects", "true");
 
@@ -274,7 +279,7 @@ class ScannerMSBuildTest {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     Path projectDir = TestUtils.projectDir(basePath, "ExcludedTest");
     EnvironmentVariable sonarQubeScannerParams = new EnvironmentVariable("SONARQUBE_SCANNER_PARAMS", "{\"sonar.dotnet.excludeTestProjects\":\"true\",\"sonar.verbose\":\"true\"}");
-    ScannerForMSBuild build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_True_FromAzureDevOps", projectDir, token, ScannerClassifier.NET_FRAMEWORK);
+    ScannerCommand build = TestUtils.newScannerBegin(ORCHESTRATOR, "ExcludedTest_True_FromAzureDevOps", projectDir, token, ScannerClassifier.NET_FRAMEWORK);
 
     testExcludedAndTest(build, "ExcludedTest_True_FromAzureDevOps", projectDir, token, 0, Collections.singletonList(sonarQubeScannerParams));
   }
@@ -288,8 +293,8 @@ class ScannerMSBuildTest {
     ORCHESTRATOR.getServer().provisionProject(projectKeyName, projectKeyName);
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(projectKeyName, "cs", "ProfileForTest");
 
-    ScannerForMSBuild beginStep = TestUtils.newScannerBegin(ORCHESTRATOR, projectKeyName, projectDir, token, ScannerClassifier.NET_FRAMEWORK);
-    ORCHESTRATOR.executeBuild(beginStep);
+    ScannerCommand beginStep = TestUtils.newScannerBegin(ORCHESTRATOR, projectKeyName, projectDir, token, ScannerClassifier.NET_FRAMEWORK);
+    beginStep.execute(ORCHESTRATOR);
 
     EnvironmentVariable sonarQubeScannerParams = new EnvironmentVariable("SONARQUBE_SCANNER_PARAMS", "{\"sonar.dotnet.excludeTestProjects\" }");
     BuildResult msBuildResult = TestUtils.runMSBuild(ORCHESTRATOR, projectDir, Collections.singletonList(sonarQubeScannerParams), 60 * 1000, "/t:Restore,Rebuild");
@@ -311,7 +316,7 @@ class ScannerMSBuildTest {
       .toString();
     var sonarQubeScannerParams = new EnvironmentVariable("SONARQUBE_SCANNER_PARAMS", scannerParamsValue);
 
-    var beginStep = TestUtils.newScanner(ORCHESTRATOR, projectDir, ScannerClassifier.NET_FRAMEWORK, token)
+    var beginStep = TestUtils.newScannerBegin(ORCHESTRATOR, projectKeyName, projectDir, token, ScannerClassifier.NET_FRAMEWORK)
       // do NOT set sonar.projectBaseDir here, only from SONARQUBE_SCANNER_PARAMS.
       .addArgument("begin")
       .setProjectKey(projectKeyName)
@@ -319,7 +324,7 @@ class ScannerMSBuildTest {
       .setProperty("sonar.verbose", "true")
       .setProjectVersion("1.0");
     beginStep.setEnvironmentVariable(sonarQubeScannerParams.getName(), sonarQubeScannerParams.getValue());
-    var beginResult = ORCHESTRATOR.executeBuild(beginStep);
+    var beginResult = beginStep.execute(ORCHESTRATOR);
     assertThat(beginResult.isSuccess()).isTrue();
 
     TestUtils.buildMSBuild(ORCHESTRATOR, projectDir);
@@ -366,9 +371,9 @@ class ScannerMSBuildTest {
     // Without the .git folder the scanner would pick up file that are ignored in the .gitignore
     // Resulting in an incorrect number of lines of code.
     try (var ignored = new CreateGitFolder(projectDir)) {
-      var scannerBuild = TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK);
-      scannerBuild.setProperty("sonar.scm.disabled", "false");
-      ORCHESTRATOR.executeBuild(scannerBuild);
+      TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK)
+        .setProperty("sonar.scm.disabled", "false")
+        .execute(ORCHESTRATOR);
       TestUtils.buildMSBuild(ORCHESTRATOR, projectDir);
       BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);
 
@@ -400,7 +405,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "ExternalIssues.VB");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
+    TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK).execute(ORCHESTRATOR);
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild");
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);
 
@@ -437,12 +442,13 @@ class ScannerMSBuildTest {
 
     Path projectDir = TestUtils.projectDir(basePath, "ProjectUnderTest");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
-    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(localProjectKey)
       .setProjectName("parameters")
       .setProperty("sonar.projectBaseDir", Paths.get(projectDir.toAbsolutePath().toString(), "ProjectUnderTest").toString())
-      .setProjectVersion("1.0"));
+      .setProjectVersion("1.0")
+      .execute(ORCHESTRATOR);
 
     TestUtils.buildMSBuild(ORCHESTRATOR, projectDir);
 
@@ -465,13 +471,14 @@ class ScannerMSBuildTest {
 
     Path projectDir = TestUtils.projectDir(basePath, "ProjectUnderTest");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
-    BuildResult result = ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    BuildResult result = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(localProjectKey)
       .setProjectName("verbose")
       .setProjectVersion("1.0")
       .setProperty("sonar.projectBaseDir", Paths.get(projectDir.toAbsolutePath().toString(), "ProjectUnderTest").toString())
-      .setProperty("sonar.verbose", "true"));
+      .setProperty("sonar.verbose", "true")
+      .execute(ORCHESTRATOR);
 
     assertThat(result.getLogs()).contains("Downloading from http://");
     assertThat(result.getLogs()).contains("sonar.verbose=true was specified - setting the log verbosity to 'Debug'");
@@ -496,10 +503,11 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "ProjectUnderTest");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
+    TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK).execute(ORCHESTRATOR);
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Restore,Rebuild", "/p:ExcludeProjectsFromAnalysis=true");
-    BuildResult result = ORCHESTRATOR.executeBuildQuietly(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
-      .addArgument("end"));
+    BuildResult result = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+      .addArgument("end")
+      .executeQuietly(ORCHESTRATOR);
 
     assertThat(result.isSuccess()).isFalse();
     assertThat(result.getLogs()).contains("The exclude flag has been set so the project will not be analyzed.");
@@ -516,7 +524,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "ProjectUnderTest");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
+    TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK).execute(ORCHESTRATOR);
     TestUtils.buildMSBuild(ORCHESTRATOR, projectDir);
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);
 
@@ -536,7 +544,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "AssemblyAttribute");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
+    TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK).execute(ORCHESTRATOR);
     TestUtils.buildMSBuild(ORCHESTRATOR, projectDir);
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);
 
@@ -554,7 +562,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "ExternalIssues.CS");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
+    TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK).execute(ORCHESTRATOR);
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Rebuild");
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);
 
@@ -649,9 +657,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "VueWithAspBackend");
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(
-      TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
-
+    TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK).execute(ORCHESTRATOR);
     TestUtils.runNuGet(ORCHESTRATOR, projectDir, true, "restore");
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, Collections.emptyList(), 180 * 1000, "/t:Rebuild", "/nr:false");
 
@@ -867,11 +873,9 @@ class ScannerMSBuildTest {
 
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ScannerForMSBuild scanner = TestUtils.newScannerBegin(ORCHESTRATOR, projectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK)
-      .setProperty("sonar.cs.roslyn.ignoreIssues", "true");
-
-    ORCHESTRATOR.executeBuild(scanner);
-
+    TestUtils.newScannerBegin(ORCHESTRATOR, projectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK)
+      .setProperty("sonar.cs.roslyn.ignoreIssues", "true")
+      .execute(ORCHESTRATOR);
     TestUtils.buildMSBuild(ORCHESTRATOR, projectDir);
 
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, projectKey, token);
@@ -948,12 +952,13 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, "IncrementalPRAnalysis");
     File unexpectedUnchangedFiles = new File(projectDir.resolve(".sonarqube\\conf\\UnchangedFiles.txt").toString());
     String token = TestUtils.getNewToken(ORCHESTRATOR);
-    BuildResult result = ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    BuildResult result = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(projectKey)
       .setProperty("sonar.projectBaseDir", projectDir.toAbsolutePath().toString())
       .setDebugLogs(true) // To assert debug logs too
-      .setProperty("sonar.pullrequest.base", "base-branch"));
+      .setProperty("sonar.pullrequest.base", "base-branch")
+      .execute(ORCHESTRATOR);
 
     assertTrue(result.isSuccess());
     assertThat(unexpectedUnchangedFiles).doesNotExist();
@@ -976,12 +981,13 @@ class ScannerMSBuildTest {
 
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProperty("sonar.projectBaseDir", projectDir.toAbsolutePath().toString())
-      .setProjectVersion("1.0"));
+      .setProjectVersion("1.0")
+      .execute(ORCHESTRATOR);
 
     TestUtils.buildMSBuild(ORCHESTRATOR, projectDir);
 
@@ -995,12 +1001,13 @@ class ScannerMSBuildTest {
     writer.append(' ');
     writer.close();
 
-    BuildResult result = ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    BuildResult result = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(projectKey)
       .setProperty("sonar.projectBaseDir", projectDir.toAbsolutePath().toString())
       .setDebugLogs(true) // To assert debug logs too
-      .setProperty("sonar.pullrequest.base", baseBranch));
+      .setProperty("sonar.pullrequest.base", baseBranch)
+      .execute(ORCHESTRATOR);
 
     assertTrue(result.isSuccess());
     assertThat(result.getLogs()).contains("Processing analysis cache");
@@ -1029,7 +1036,7 @@ class ScannerMSBuildTest {
       String token = TestUtils.getNewToken(ORCHESTRATOR);
       String folderName = projectDir.getFileName().toString();
       // Begin step in MultiLanguageSupport folder
-      ScannerForMSBuild scanner = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+      TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
         .addArgument("begin")
         .setProjectDir(projectDir.toFile()) // this sets the working directory, not sonar.projectBaseDir
         .setProjectKey(folderName)
@@ -1040,8 +1047,8 @@ class ScannerMSBuildTest {
         // Overriding environment variables to fallback to projectBaseDir detection
         // This can be removed once we move to Cirrus CI.
         .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "")
-        .setEnvironmentVariable("BUILD_SOURCESDIRECTORY", "");
-      ORCHESTRATOR.executeBuild(scanner);
+        .setEnvironmentVariable("BUILD_SOURCESDIRECTORY", "")
+        .execute(ORCHESTRATOR);
       // Build solution inside MultiLanguageSupport/src folder
       TestUtils.runMSBuild(
         ORCHESTRATOR,
@@ -1056,13 +1063,14 @@ class ScannerMSBuildTest {
         "src/MultiLanguageSupport.sln"
       );
       // End step in MultiLanguageSupport folder
-      var result = ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+      var result = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
         .addArgument("end")
         .setProjectDir(projectDir.toFile()) // this sets the working directory, not sonar.projectBaseDir
         // Overriding environment variables to fallback to projectBaseDir detection
         // This can be removed once we move to Cirrus CI.
         .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "")
-        .setEnvironmentVariable("BUILD_SOURCESDIRECTORY", ""));
+        .setEnvironmentVariable("BUILD_SOURCESDIRECTORY", "")
+        .execute(ORCHESTRATOR);
       assertTrue(result.isSuccess());
       TestUtils.dumpComponentList(ORCHESTRATOR, folderName);
       TestUtils.dumpProjectIssues(ORCHESTRATOR, folderName);
@@ -1142,7 +1150,7 @@ class ScannerMSBuildTest {
         .containsExactlyInAnyOrder(expectedIssues.toArray(new Tuple[]{}));
       var log = result.getLogs();
       assertThat(log).contains("MultiLanguageSupport/src/MultiLanguageSupport/Php/Composer/vendor/autoload.php] is excluded by 'sonar.php.exclusions' " +
-                               "property and will not be analyzed");
+        "property and will not be analyzed");
     }
   }
 
@@ -1153,7 +1161,7 @@ class ScannerMSBuildTest {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     String folderName = projectDir.getFileName().toString();
     // Begin step in MultiLanguageSupport folder
-    ScannerForMSBuild scanner = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    ScannerCommand scanner = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectDir(projectDir.toFile()) // this sets the working directory, not sonar.projectBaseDir
       .setProjectKey(folderName)
@@ -1164,7 +1172,7 @@ class ScannerMSBuildTest {
       // This can be removed once we move to Cirrus CI.
       .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "")
       .setEnvironmentVariable("BUILD_SOURCESDIRECTORY", "");
-    ORCHESTRATOR.executeBuild(scanner);
+    scanner.execute(ORCHESTRATOR);
     // Build solution inside MultiLanguageSupport/src folder
     TestUtils.runMSBuild(
       ORCHESTRATOR,
@@ -1179,13 +1187,15 @@ class ScannerMSBuildTest {
       "MultiLanguageSupportReact.csproj"
     );
     // End step in MultiLanguageSupport folder
-    var result = ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    var result = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("end")
       .setProjectDir(projectDir.toFile()) // this sets the working directory, not sonar.projectBaseDir
       // Overriding environment variables to fallback to projectBaseDir detection
       // This can be removed once we move to Cirrus CI.
       .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "")
-      .setEnvironmentVariable("BUILD_SOURCESDIRECTORY", ""));
+      .setEnvironmentVariable("BUILD_SOURCESDIRECTORY", "")
+      .execute(ORCHESTRATOR);
+
     assertTrue(result.isSuccess());
     TestUtils.dumpComponentList(ORCHESTRATOR, folderName);
     TestUtils.dumpProjectIssues(ORCHESTRATOR, folderName);
@@ -1215,7 +1225,7 @@ class ScannerMSBuildTest {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     String folderName = projectDir.getFileName().toString();
     // Begin step in MultiLanguageSupport folder
-    ScannerForMSBuild scanner = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    ScannerCommand scanner = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectDir(projectDir.toFile()) // this sets the working directory, not sonar.projectBaseDir
       .setProjectKey(folderName)
@@ -1226,7 +1236,7 @@ class ScannerMSBuildTest {
       // This can be removed once we move to Cirrus CI.
       .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "")
       .setEnvironmentVariable("BUILD_SOURCESDIRECTORY", "");
-    ORCHESTRATOR.executeBuild(scanner);
+    scanner.execute(ORCHESTRATOR);
     // Build solution inside MultiLanguageSupport/src folder
     TestUtils.runMSBuild(
       ORCHESTRATOR,
@@ -1241,13 +1251,14 @@ class ScannerMSBuildTest {
       "MultiLanguageSupportAngular.csproj"
     );
     // End step in MultiLanguageSupport folder
-    var result = ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    var result = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("end")
       .setProjectDir(projectDir.toFile()) // this sets the working directory, not sonar.projectBaseDir
       // Overriding environment variables to fallback to projectBaseDir detection
       // This can be removed once we move to Cirrus CI.
       .setEnvironmentVariable("AGENT_BUILDDIRECTORY", "")
-      .setEnvironmentVariable("BUILD_SOURCESDIRECTORY", ""));
+      .setEnvironmentVariable("BUILD_SOURCESDIRECTORY", "")
+      .execute(ORCHESTRATOR);
     assertTrue(result.isSuccess());
     TestUtils.dumpComponentList(ORCHESTRATOR, folderName);
     TestUtils.dumpProjectIssues(ORCHESTRATOR, folderName);
@@ -1335,10 +1346,11 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, projectName);
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, projectName, projectDir, token, ScannerClassifier.NET)
+    TestUtils.newScannerBegin(ORCHESTRATOR, projectName, projectDir, token, ScannerClassifier.NET)
       .setScannerVersion(TestUtils.developmentScannerVersion())
       .setProperty("sonar.sources", "Program.cs") // user-defined sources and tests are not passed to the cli.
-      .setProperty("sonar.tests", "Program.cs")); // If they were passed, it results to double-indexing error.
+      .setProperty("sonar.tests", "Program.cs")   // If they were passed, it results to double-indexing error.
+      .execute(ORCHESTRATOR);
     TestUtils.runDotnetCommand(projectDir, "build", "--no-incremental");
     var result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, projectName, token);
 
@@ -1413,13 +1425,14 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, folderName);
 
     String token = TestUtils.getNewToken(ORCHESTRATOR);
-    ORCHESTRATOR.executeBuild(TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(folderName)
       .setProjectName(folderName)
       .setProjectVersion("1.0")
       .setProperty("sonar.projectBaseDir", getProjectBaseDir.apply(projectDir))
-      .setDebugLogs(true));
+      .setDebugLogs(true)
+      .execute(ORCHESTRATOR);
 
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, "/t:Restore,Rebuild");
 
@@ -1437,7 +1450,7 @@ class ScannerMSBuildTest {
   private BuildResult runAnalysisWithoutProjectBasedDir(Path projectDir) {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     String folderName = projectDir.getFileName().toString();
-    ScannerForMSBuild scanner = TestUtils.newScanner(ORCHESTRATOR, projectDir, ScannerClassifier.NET, token)
+    ScannerCommand scanner = TestUtils.newScannerBegin(ORCHESTRATOR, folderName, projectDir, token, ScannerClassifier.NET)
       .addArgument("begin")
       .setProjectKey(folderName)
       .setProjectName(folderName)
@@ -1448,18 +1461,19 @@ class ScannerMSBuildTest {
       .setProperty("sonar.verbose", "true")
       .setProperty("sonar.sourceEncoding", "UTF-8");
 
-    ORCHESTRATOR.executeBuild(scanner);
+    scanner.execute(ORCHESTRATOR);
 
     BuildResult buildResult = TestUtils.runDotnetCommand(projectDir, "build", folderName + ".sln", "--no-incremental");
 
     assertThat(buildResult.getLastStatus()).isZero();
 
     // use executeBuildQuietly to allow for failure
-    return ORCHESTRATOR.executeBuildQuietly(TestUtils.newScanner(ORCHESTRATOR, projectDir, ScannerClassifier.NET, token)
+    return TestUtils.newScannerEnd(ORCHESTRATOR, projectDir, ScannerClassifier.NET, token)
       .addArgument("end")
       // simulate it's not on Azure Pipelines (otherwise, it will take the projectBaseDir from there)
       .setEnvironmentVariable(AzureDevOpsUtils.ENV_SOURCES_DIRECTORY, "")
-      .setScannerVersion(TestUtils.developmentScannerVersion()));
+      .setScannerVersion(TestUtils.developmentScannerVersion())
+      .executeQuietly(ORCHESTRATOR);
   }
 
   private void assertProjectFileContains(String projectName, String textToLookFor) throws IOException {
@@ -1482,14 +1496,14 @@ class ScannerMSBuildTest {
   private BuildResult runNetCoreBeginBuildAndEnd(Path projectDir, ScannerClassifier classifier) {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     String folderName = projectDir.getFileName().toString();
-    ScannerForMSBuild scanner = TestUtils.newScannerBegin(ORCHESTRATOR, folderName, projectDir, token, classifier)
+    ScannerCommand scanner = TestUtils.newScannerBegin(ORCHESTRATOR, folderName, projectDir, token, classifier)
       .setUseDotNetCore(Boolean.TRUE)
       .setScannerVersion(TestUtils.developmentScannerVersion())
       // ensure that the Environment Variable parsing happens for .NET Core versions
       .setEnvironmentVariable("SONARQUBE_SCANNER_PARAMS", "{}")
       .setProperty("sonar.sourceEncoding", "UTF-8");
 
-    ORCHESTRATOR.executeBuild(scanner);
+    scanner.execute(ORCHESTRATOR);
 
     // build project
     String[] arguments = new String[]{"build", folderName + ".sln"};
@@ -1509,7 +1523,7 @@ class ScannerMSBuildTest {
   private BuildResult runBeginBuildAndEndForStandardProject(Path projectDir, String projectName, Boolean setProjectBaseDirExplicitly, Boolean useNuGet) {
     String token = TestUtils.getNewToken(ORCHESTRATOR);
     String folderName = projectDir.getFileName().toString();
-    ScannerForMSBuild scanner = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
+    ScannerCommand scanner = TestUtils.newScanner(ORCHESTRATOR, projectDir, token)
       .addArgument("begin")
       .setProjectKey(folderName)
       .setProjectName(folderName)
@@ -1532,7 +1546,7 @@ class ScannerMSBuildTest {
 
     }
 
-    ORCHESTRATOR.executeBuild(scanner);
+    scanner.execute(ORCHESTRATOR);
     if (useNuGet) {
       TestUtils.runNuGet(ORCHESTRATOR, projectDir, false, "restore");
     }
@@ -1551,7 +1565,7 @@ class ScannerMSBuildTest {
     Path projectDir = TestUtils.projectDir(basePath, projectName);
     String token = TestUtils.getNewToken(ORCHESTRATOR);
 
-    ORCHESTRATOR.executeBuild(TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK));
+    TestUtils.newScannerBegin(ORCHESTRATOR, localProjectKey, projectDir, token, ScannerClassifier.NET_FRAMEWORK).execute(ORCHESTRATOR);
     TestUtils.runNuGet(ORCHESTRATOR, projectDir, false, "restore");
     TestUtils.runDotnetCommand(projectDir, "build", "--no-incremental");
     BuildResult result = TestUtils.executeEndStepAndDumpResults(ORCHESTRATOR, projectDir, localProjectKey, token);
@@ -1568,11 +1582,11 @@ class ScannerMSBuildTest {
     assertThat(TestUtils.getMeasureAsInteger(localProjectKey, "files", ORCHESTRATOR)).isEqualTo(2);
   }
 
-  private void testExcludedAndTest(ScannerForMSBuild build, String projectKeyName, Path projectDir, String token, int expectedTestProjectIssues) {
+  private void testExcludedAndTest(ScannerCommand build, String projectKeyName, Path projectDir, String token, int expectedTestProjectIssues) {
     testExcludedAndTest(build, projectKeyName, projectDir, token, expectedTestProjectIssues, Collections.EMPTY_LIST);
   }
 
-  private void testExcludedAndTest(ScannerForMSBuild build, String projectKeyName, Path projectDir, String token, int expectedTestProjectIssues,
+  private void testExcludedAndTest(ScannerCommand scanner, String projectKeyName, Path projectDir, String token, int expectedTestProjectIssues,
     List<EnvironmentVariable> environmentVariables) {
     String normalProjectKey = TestUtils.hasModules(ORCHESTRATOR)
       ? String.format("%1$s:%1$s:B93B287C-47DB-4406-9EAB-653BCF7D20DC", projectKeyName)
@@ -1585,7 +1599,7 @@ class ScannerMSBuildTest {
     ORCHESTRATOR.getServer().provisionProject(projectKeyName, projectKeyName);
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(projectKeyName, "cs", "ProfileForTest");
 
-    ORCHESTRATOR.executeBuild(build);
+    scanner.execute(ORCHESTRATOR);
 
     TestUtils.runMSBuild(ORCHESTRATOR, projectDir, environmentVariables, 60 * 1000, "/t:Restore,Rebuild");
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
@@ -443,15 +443,11 @@ class SslTest {
         .setProperty("sonar.projectBaseDir", projectDir.toAbsolutePath().toString())
         .setProjectVersion("1.0");
 
-      try {
-        scanner.execute(ORCHESTRATOR);
-        fail("Expecting to fail during the begin with an SSL error");
-      } catch (BuildFailureException e) {
-        assertFalse(e.getResult().isSuccess());
-        assertThat(e.getResult().getLogs())
-          .contains("Failed to import the sonar.scanner.truststorePath file " + server.getKeystorePath() + ": The specified network password is not correct.")
-          .contains("System.Security.Cryptography.CryptographicException: The specified network password is not correct.");
-      }
+      var result = scanner.execute(ORCHESTRATOR);
+      assertFalse(result.isSuccess());
+      assertThat(result.getLogs())
+        .contains("Failed to import the sonar.scanner.truststorePath file " + server.getKeystorePath() + ": The specified network password is not correct.")
+        .contains("System.Security.Cryptography.CryptographicException: The specified network password is not correct.");
     }
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerClassifier.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerClassifier.java
@@ -19,19 +19,34 @@
  */
 package com.sonar.it.scanner.msbuild.utils;
 
+import com.sonar.it.scanner.msbuild.sonarcloud.Constants;
 import com.sonar.orchestrator.locator.FileLocation;
 import com.sonar.orchestrator.locator.Location;
-
+import com.sonar.orchestrator.util.Command;
+import java.io.File;
 import java.nio.file.Paths;
 
 public enum ScannerClassifier {
-  NET("net"),
-  NET_FRAMEWORK("net-framework");
+  // ToDo: SCAN4NET-200 Unify, cleanup
+  NET("net", "dotnet", new File("../build/sonarscanner-net/SonarScanner.MSBuild.dll").getAbsolutePath().toString()),
+  NET_FRAMEWORK("net-framework", new File(Constants.SCANNER_PATH).getAbsolutePath().toString(), null);
 
   private final String classifier;
+  private final String executable;
+  private final String firstArgument;
 
-  ScannerClassifier(String classifier) {
+  ScannerClassifier(String classifier, String executable, String firstArgument) {
     this.classifier = classifier;
+    this.executable = executable;
+    this.firstArgument = firstArgument;
+  }
+
+  public Command createBaseCommand() {
+    var command = Command.create(executable);
+    if (firstArgument != null) {
+      command.addArgument(firstArgument);
+    }
+    return command;
   }
 
   public String toString() {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -45,7 +45,7 @@ public class ScannerCommand {
   private final ScannerClassifier classifier;
   private final String token;
   private final Path projectDir;
-  private final String projectKey;
+  private String projectKey;  // ToDo: Make final in SCAN4NET-201.
   private final Map<String, String> properties = new HashMap();
   private final Map<String, String> environment = new HashMap();
 
@@ -105,9 +105,9 @@ public class ScannerCommand {
   }
 
   @Deprecated
-  public ScannerCommand setProjectKey(String key) {
+  public ScannerCommand setProjectKey(String projectKey) {
     // ToDo: Remove in SCAN4NET-201.
-    // It's no-op in-place replacement for now.
+    this.projectKey = projectKey;
     return this;
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -60,12 +60,11 @@ public class ScannerCommand {
   }
 
   public static ScannerCommand createBeginStep(ScannerClassifier classifier, String token, Path projectDir, String projectKey) {
-    var scanner = new ScannerCommand(Step.begin, classifier, token, projectDir, projectKey);
-    scanner.setProperty("sonar.projectBaseDir", projectDir.toAbsolutePath().toString());
-    // Default values provided by Orchestrator to ScannerForMSBuild in adjustedProperties
-    scanner.setProperty("sonar.scm.disabled", "true");
-    scanner.setProperty("sonar.branch.autoconfig.disabled", "true");
-    return scanner;
+    return new ScannerCommand(Step.begin, classifier, token, projectDir, projectKey)
+      .setProperty("sonar.projectBaseDir", projectDir.toAbsolutePath().toString())
+      // Default values provided by Orchestrator to ScannerForMSBuild in adjustedProperties
+      .setProperty("sonar.scm.disabled", "true")
+      .setProperty("sonar.branch.autoconfig.disabled", "true");
   }
 
   public static ScannerCommand createEndStep(ScannerClassifier classifier, String token, Path projectDir) {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -155,7 +155,7 @@ public class ScannerCommand {
     LOG.info("Command line: {}", command.toCommandLine());
     result.addStatus(CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), Constants.COMMAND_TIMEOUT));
     if (step == Step.end) {
-      new SynchronousAnalyzer(orchestrator.getServer()).waitForDone();  // Wait for CE to finish processing (all) analysis
+      new SynchronousAnalyzer(orchestrator.getServer()).waitForDone();  // Wait for Compute Engine to finish processing (all) analysis
     }
     return result;
   }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -1,0 +1,219 @@
+/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.it.scanner.msbuild.utils;
+
+import com.sonar.it.scanner.msbuild.sonarcloud.Constants;
+import com.sonar.orchestrator.Orchestrator;
+import com.sonar.orchestrator.build.BuildResult;
+import com.sonar.orchestrator.util.Command;
+import com.sonar.orchestrator.util.CommandExecutor;
+import com.sonar.orchestrator.util.StreamConsumer;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ScannerCommand {
+
+  private enum Step {
+    begin,
+    end
+  }
+
+  private final static Logger LOG = LoggerFactory.getLogger(ScannerCommand.class);
+  private Step step;  // ToDo: Make final in SCAN4NET-201.
+  private final ScannerClassifier classifier;
+  private final String token;
+  private final Path projectDir;
+  private final String projectKey;
+  private final Map<String, String> properties = new HashMap();
+  private final Map<String, String> environment = new HashMap();
+
+
+  private ScannerCommand(Step step, ScannerClassifier classifier, String token, Path projectDir, @Nullable String projectKey) {
+    this.step = step;
+    this.classifier = classifier;
+    this.token = token;
+    this.projectDir = projectDir;
+    this.projectKey = projectKey;
+  }
+
+  public static ScannerCommand createBeginStep(ScannerClassifier classifier, String token, Path projectDir, String projectKey) {
+    var scanner = new ScannerCommand(Step.begin, classifier, token, projectDir, projectKey);
+    scanner.setProperty("sonar.projectBaseDir", projectDir.toAbsolutePath().toString());
+    return scanner;
+  }
+
+  public static ScannerCommand createEndStep(ScannerClassifier classifier, String token, Path projectDir) {
+    return new ScannerCommand(Step.end, classifier, token, projectDir, null);
+  }
+
+  public ScannerCommand setProperty(String key, @Nullable String value) {
+    if (value == null) {
+      this.properties.remove(key);
+    } else {
+      this.properties.put(key, value);
+    }
+    return this;
+  }
+
+  public ScannerCommand setDebugLogs(boolean verbose) {
+    return setProperty("sonar.verbose", Boolean.toString(verbose));
+  }
+
+  public ScannerCommand setEnvironmentVariable(String name, String value) {
+    if (value == null) {
+      environment.remove(name);
+    } else {
+      environment.put(name, value);
+    }
+    return this;
+  }
+
+  @Deprecated
+  public ScannerCommand addArgument(String argument) {
+    // ToDo: Remove in SCAN4NET-201.
+    if (argument == "begin") {
+      step = Step.begin;
+    } else if (argument == "end") {
+      step = Step.end;
+    } else {
+      throw new IllegalArgumentException();
+    }
+
+    return this;
+  }
+
+  @Deprecated
+  public ScannerCommand setProjectKey(String key) {
+    // ToDo: Remove in SCAN4NET-201.
+    // It's no-op in-place replacement for now.
+    return this;
+  }
+
+  @Deprecated
+  public ScannerCommand setProjectName(String name) {
+    // ToDo: Remove in SCAN4NET-201.
+    // It's no-op in-place replacement for now.
+    return this;
+  }
+
+  @Deprecated
+  public ScannerCommand setProjectVersion(String version) {
+    // ToDo: Remove in SCAN4NET-201.
+    // It's no-op in-place replacement for now.
+    return this;
+  }
+
+  @Deprecated
+  public ScannerCommand setProjectDir(File dir) {
+    // ToDo: Remove in SCAN4NET-201.
+    // It's no-op in-place replacement for now.
+    return this;
+  }
+
+  @Deprecated
+  public ScannerCommand setScannerVersion(String version) {
+    // ToDo: Remove in SCAN4NET-201.
+    // It's no-op in-place replacement for now.
+    return this;
+  }
+
+  @Deprecated
+  public ScannerCommand setUseDotNetCore(boolean value) {
+    // ToDo: Remove in SCAN4NET-201.
+    // It's no-op in-place replacement for now.
+    return this;
+  }
+
+  public BuildResult executeQuietly(Orchestrator orchestrator) {
+    // FIXME: Figure out what's the difference and if it's even needed
+    return execute(orchestrator);
+  }
+
+  public BuildResult execute(Orchestrator orchestrator) {
+    // FIXME: Inherit Build and execute self against orchestrator, and then override the Build.execute to deal with that?
+    // FIXME: Crate command
+    // FIXME: Add step
+    // FIXME: Add projectKey
+    // FIXME: set token based on orchestrator version
+    //    if (orchestrator.getServer().version().isGreaterThanOrEquals(10, 0)) {
+    //      // The `sonar.token` property was introduced in SonarQube 10.0
+    //      scanner.setProperty("sonar.token", token);
+    //    } else {
+    //      scanner.setProperty("sonar.login", token);
+    //    }
+
+//    String scannerVersion = getScannerVersion(orchestrator);
+//
+//    Location scannerLocation;
+//    if (scannerVersion != null) {
+//      LOG.info("Using Scanner for MSBuild " + scannerVersion);
+//      scannerLocation = getScannerMavenLocation(scannerVersion, classifier);
+//    } else {
+//      String scannerLocationEnv = System.getenv("SCANNER_LOCATION");
+//      if (scannerLocationEnv != null) {
+//        LOG.info("Using Scanner for MSBuild specified by %SCANNER_LOCATION%: " + scannerLocationEnv);
+//        scannerLocation = classifier.toLocation(scannerLocationEnv);
+//      } else {
+//        // run locally
+//        LOG.info("Using Scanner for MSBuild from the local build");
+//        scannerLocation = classifier.toLocation("../build");
+//      }
+//    }
+//    LOG.info("Scanner location: " + scannerLocation);
+    //.setScannerLocation(scannerLocation).setUseDotNetCore(classifier.isDotNetCore())
+
+    var tokenProperty = orchestrator.getServer().version().isGreaterThanOrEquals(10, 0)
+      ? "/d:sonar.token=" + token   // The `sonar.token` property was introduced in SonarQube 10.0
+      : "/d:sonar.login=" + token;  // sonar.login is obsolete
+    // FIXME: classifier vs. SCANNER_PATH vs. dotnet, etc
+    //    LOG.info("Scanner location: " + scannerLocation);
+    var command = Command.create(new File(Constants.SCANNER_PATH).getAbsolutePath())
+      .setDirectory(projectDir.toFile())
+      .addArgument(step.toString())
+      .addArgument(tokenProperty);
+
+    if (step == Step.begin) {
+      command
+        .addArgument("/k:" + projectKey)
+        .addArgument("/d:sonar.host.url=" + orchestrator.getServer().getUrl());
+
+      for (var entry : properties.entrySet()) {
+        command.addArgument("/d:" + entry.getKey() + "=" + entry.getValue());
+      }
+    }
+    LOG.info("Command line: {}", command.toCommandLine());
+
+    // FIXME: Environment variables
+
+    var result = new BuildResult();
+    result.addStatus(CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), Constants.COMMAND_TIMEOUT));
+    return result;
+  }
+
+//  BuildResult execute(Configuration config, Map<String, String> adjustedProperties) {
+//    throw new NotImplementedException();
+//  }
+
+}

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -22,6 +22,7 @@ package com.sonar.it.scanner.msbuild.utils;
 import com.sonar.it.scanner.msbuild.sonarcloud.Constants;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
+import com.sonar.orchestrator.build.SynchronousAnalyzer;
 import com.sonar.orchestrator.util.Command;
 import com.sonar.orchestrator.util.CommandExecutor;
 import com.sonar.orchestrator.util.StreamConsumer;
@@ -209,6 +210,9 @@ public class ScannerCommand {
 
     var result = new BuildResult();
     result.addStatus(CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), Constants.COMMAND_TIMEOUT));
+    if (step == Step.end) {
+      new SynchronousAnalyzer(orchestrator.getServer()).waitForDone();  // Wait for CE to finish processing (all) analysis
+    }
     return result;
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -170,17 +170,15 @@ public class ScannerCommand {
     var tokenProperty = orchestrator.getServer().version().isGreaterThanOrEquals(10, 0)
       ? "/d:sonar.token=" + token   // The `sonar.token` property was introduced in SonarQube 10.0
       : "/d:sonar.login=" + token;  // sonar.login is obsolete
-    // FIXME: classifier vs. SCANNER_PATH vs. dotnet, etc
-    //    LOG.info("Scanner location: " + scannerLocation);
     var command = classifier.createBaseCommand()
       .setDirectory(projectDir.toFile())
       .addArgument(step.toString())
       .addArgument(tokenProperty);
     if (step == Step.begin) {
-      command
-        .addArgument("/k:" + projectKey)
-        .addArgument("/d:sonar.host.url=" + orchestrator.getServer().getUrl());
-
+      command.addArgument("/k:" + projectKey);
+      if (!properties.containsKey("sonar.host.url")) {
+        command.addArgument("/d:sonar.host.url=" + orchestrator.getServer().getUrl());
+      }
       for (var entry : properties.entrySet()) {
         command.addArgument("/d:" + entry.getKey() + "=" + entry.getValue());
       }
@@ -190,9 +188,4 @@ public class ScannerCommand {
     }
     return command;
   }
-
-//  BuildResult execute(Configuration config, Map<String, String> adjustedProperties) {
-//    throw new NotImplementedException();
-//  }
-
 }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -149,11 +149,6 @@ public class ScannerCommand {
     return this;
   }
 
-  public BuildResult executeQuietly(Orchestrator orchestrator) {
-    // FIXME: Figure out what's the difference and if it's even needed
-    return execute(orchestrator);
-  }
-
   public BuildResult execute(Orchestrator orchestrator) {
     var command = createCommand(orchestrator);
     var result = new BuildResult();

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -172,7 +172,7 @@ public class ScannerCommand {
       : "/d:sonar.login=" + token;  // sonar.login is obsolete
     // FIXME: classifier vs. SCANNER_PATH vs. dotnet, etc
     //    LOG.info("Scanner location: " + scannerLocation);
-    var command = Command.create(new File(Constants.SCANNER_PATH).getAbsolutePath())
+    var command = classifier.createBaseCommand()
       .setDirectory(projectDir.toFile())
       .addArgument(step.toString())
       .addArgument(tokenProperty);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -173,9 +173,9 @@ public class ScannerCommand {
       if (!properties.containsKey("sonar.host.url")) {
         command.addArgument("/d:sonar.host.url=" + orchestrator.getServer().getUrl());
       }
-      for (var entry : properties.entrySet()) {
-        command.addArgument("/d:" + entry.getKey() + "=" + entry.getValue());
-      }
+    }
+    for (var entry : properties.entrySet()) {
+      command.addArgument("/d:" + entry.getKey() + "=" + entry.getValue());
     }
     for (var entry : this.environment.entrySet()) {
       command.setEnvironmentVariable(entry.getKey(), entry.getValue());


### PR DESCRIPTION
[SCAN4NET-198](https://sonarsource.atlassian.net/browse/SCAN4NET-198)

Key changes are:
* Adding `ScannerCommand`
* Updating `TestUtils` to use `ScannerCommand`

That required changes in tests:
* `ORCHESTRATOR.execute(scanner)` is changed to `scanner.execute(ORCHESTRATOR)` so we can centralize the behavior and eventually simplify the usages
* `SslTest` no longer throws an exception => mechanical refactoring of assertions. Please make sure I did not delete any `server.stop();` calls by accident

Plus there's a bit of auto-formatting noise.

This PR does as few changes as possible, without CaYC to keep it as small as possible. Bunch of methods in `ScannerCommand` are no-op and will be removed later just to enable the new `ScannerCommand` to serve as a in-place replacement with minimal additional refactorings - those will come later.

Also `ScannerClassifier` is ugly and will be cleaned up later.



[SCAN4NET-198]: https://sonarsource.atlassian.net/browse/SCAN4NET-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ