### PR TITLE
SCAN4NET-286 Use MsBuild from VS 2022 Professional by default

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
@@ -70,7 +70,7 @@ public class TestUtils {
   private static String token = null;
 
   public static final Long TIMEOUT_LIMIT = 60 * 1000L;
-  public static final String MSBUILD_DEFAULT_PATH = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Enterprise\\MSBuild\\15.0\\Bin\\MSBuild.exe";
+  public static final String MSBUILD_DEFAULT_PATH = "C:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\MSBuild\\Current\\Bin\\MSBuild.exe";
 
   @CheckForNull
   public static String getScannerVersion(Orchestrator orchestrator) {
@@ -400,16 +400,12 @@ public class TestUtils {
     List<Issue> results = new ArrayList<>();
     var issues = newWsClient(orchestrator).issues();
     int page = 1;
-    while(true)
-    {
+    while (true) {
       var pageResult = issues.search(new org.sonarqube.ws.client.issues.SearchRequest().setP(String.valueOf(page)));
       results.addAll(pageResult.getIssuesList());
-      if (pageResult.getPaging().getTotal() == results.size())
-      {
+      if (pageResult.getPaging().getTotal() == results.size()) {
         return results;
-      }
-      else
-      {
+      } else {
         page++;
       }
     }

--- a/scripts/build-utils.ps1
+++ b/scripts/build-utils.ps1
@@ -4,10 +4,6 @@ function Get-NuGetPath {
     return Get-ExecutablePath -name "nuget.exe" -envVar "NUGET_PATH"
 }
 
-function Get-VsWherePath {
-    return Get-ExecutablePath -name "vswhere.exe" -envVar "VSWHERE_PATH"
-}
-
 function Get-MsBuildPath() {
 
     Write-Debug "Trying to find 'msbuild.exe' using 'MSBUILD_PATH' environment variable"
@@ -18,10 +14,9 @@ function Get-MsBuildPath() {
         Write-Debug "Environment variable not found"
         Write-Debug "Trying to find path using 'vswhere.exe'"
 
-        # Sets the path to MSBuild 15 into an the MSBUILD_PATH environment variable
-        # All subsequent builds after this command will use MSBuild 15!
-        # Test if vswhere.exe is in your path. Download from: https://github.com/Microsoft/vswhere/releases
-        $path = "C:\\Program Files (x86)\Microsoft Visual Studio\2019\Community"
+        # Sets the path to MSBuild into an the MSBUILD_PATH environment variable
+        # All subsequent builds after this command will use this version of MsBuild!
+        $path = "C:\Program Files\Microsoft Visual Studio\2022\Professional"
         if ($path) {
             $msbuildPath = Join-Path $path "MSBuild\Current\Bin\MSBuild.exe"
             [environment]::SetEnvironmentVariable($msbuildEnv, $msbuildPath)


### PR DESCRIPTION
[SCAN4NET-286](https://sonarsource.atlassian.net/browse/SCAN4NET-286)

For case when MSBUILD_PATH is not set

[SCAN4NET-286]: https://sonarsource.atlassian.net/browse/SCAN4NET-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ