### PR TITLE
SCAN4NET-330 Rename ScannerMsBuildTest

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @ExtendWith(ServerTests.class)
-class ScannerMSBuildTest {
+class ScannerTest {
   private static final String SONAR_RULES_PREFIX = "csharpsquid:";
 
   @TempDir


### PR DESCRIPTION
[SCAN4NET-330](https://sonarsource.atlassian.net/browse/SCAN4NET-330)

Part of SCAN4NET-291

Red CI is due to canceled jobs => not worth restarting, as a rebase will be needed anyway

[SCAN4NET-330]: https://sonarsource.atlassian.net/browse/SCAN4NET-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ