### PR TITLE
SCAN4NET-347 Rename Cloud and Server utilities

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/CloudConstants.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/CloudConstants.java
@@ -19,7 +19,7 @@
  */
 package com.sonar.it.scanner.msbuild.sonarcloud;
 
-public class Constants {
+public class CloudConstants {
   public static final Integer COMMAND_TIMEOUT = 2 * 60 * 1000;
   public static final String SCANNER_PATH = "../build/sonarscanner-net-framework/SonarScanner.MSBuild.exe";
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/CloudUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/CloudUtils.java
@@ -40,8 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class SonarCloudUtils {
-  private final static Logger LOG = LoggerFactory.getLogger(SonarCloudUtils.class);
+public class CloudUtils {
+  private final static Logger LOG = LoggerFactory.getLogger(CloudUtils.class);
 
   public static String runAnalysis(Path projectDir, String projectKey, Property... properties) {
     var logs = new StringBuilder();
@@ -52,10 +52,10 @@ public class SonarCloudUtils {
   }
 
   public static BuildResult runBeginStep(Path projectDir, String projectKey, Property... properties) {
-    var beginCommand = ScannerCommand.createBeginStep(ScannerClassifier.NET_FRAMEWORK, Constants.SONARCLOUD_TOKEN, projectDir, projectKey)
-      .setOrganization(Constants.SONARCLOUD_ORGANIZATION)
-      .setProperty("sonar.scanner.sonarcloudUrl", Constants.SONARCLOUD_URL)
-      .setProperty("sonar.scanner.apiBaseUrl", Constants.SONARCLOUD_API_URL)
+    var beginCommand = ScannerCommand.createBeginStep(ScannerClassifier.NET_FRAMEWORK, CloudConstants.SONARCLOUD_TOKEN, projectDir, projectKey)
+      .setOrganization(CloudConstants.SONARCLOUD_ORGANIZATION)
+      .setProperty("sonar.scanner.sonarcloudUrl", CloudConstants.SONARCLOUD_URL)
+      .setProperty("sonar.scanner.apiBaseUrl", CloudConstants.SONARCLOUD_API_URL)
       .setDebugLogs(true);
 
     for (var property : properties) {
@@ -68,7 +68,7 @@ public class SonarCloudUtils {
   }
 
   public static BuildResult runEndStep(Path projectDir) {
-    var result = ScannerCommand.createEndStep(ScannerClassifier.NET_FRAMEWORK, Constants.SONARCLOUD_TOKEN, projectDir).execute(null);
+    var result = ScannerCommand.createEndStep(ScannerClassifier.NET_FRAMEWORK, CloudConstants.SONARCLOUD_TOKEN, projectDir).execute(null);
     assertTrue(result.isSuccess());
     waitForTaskProcessing(result.getLogs());
     return result;

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/IncrementalPRAnalysisTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/IncrementalPRAnalysisTest.java
@@ -50,7 +50,7 @@ class IncrementalPRAnalysisTest {
   @Test
   void master_emptyCache() throws IOException {
     var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
-    var result = SonarCloudUtils.runBeginStep(projectDir, SONARCLOUD_PROJECT_KEY);
+    var result = CloudUtils.runBeginStep(projectDir, SONARCLOUD_PROJECT_KEY);
     assertThat(result.getLogs()).contains(
       "Processing analysis cache",
       "Incremental PR analysis: Base branch parameter was not provided.",
@@ -61,8 +61,8 @@ class IncrementalPRAnalysisTest {
   void prWithoutChanges_producesUnchangedFilesWithAllFiles() throws IOException {
     var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
 
-    SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY); // Initial build - master.
-    var logs = SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY, prArguments); // PR analysis.
+    CloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY); // Initial build - master.
+    var logs = CloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY, prArguments); // PR analysis.
 
     // Verify that the file hashes are considered and all of them will be skipped.
     // We do not know the total number of cache entries because other plugin can cache as well.
@@ -75,9 +75,9 @@ class IncrementalPRAnalysisTest {
   void prWithChanges_detectsUnchangedFile() throws IOException {
     var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
 
-    SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY); // Initial build - master.
+    CloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY); // Initial build - master.
     changeFile(projectDir, "IncrementalPRAnalysis\\WithChanges.cs"); // Change a file to force analysis.
-    SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY, prArguments); // PR analysis.
+    CloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY, prArguments); // PR analysis.
 
     assertOnlyWithChangesFileIsConsideredChanged(projectDir);
   }
@@ -86,10 +86,10 @@ class IncrementalPRAnalysisTest {
   void prWithChanges_basedOnDifferentBranchThanMaster_detectsUnchangedFiles() throws IOException {
     var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
 
-    SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY,
+    CloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY,
       new Property("sonar.branch.name", "different-branch")); // Initial build - different branch.
     changeFile(projectDir, "IncrementalPRAnalysis\\WithChanges.cs"); // Change a file to force analysis.
-    SonarCloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY,
+    CloudUtils.runAnalysis(projectDir, SONARCLOUD_PROJECT_KEY,
       new Property("sonar.pullrequest.base", "different-branch"),
       new Property("sonar.pullrequest.branch", "second-pull-request-branch"),
       new Property("sonar.pullrequest.key", "second-pull-request-key"));

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/RegionTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/RegionTest.java
@@ -45,7 +45,7 @@ public class RegionTest {
     var projectDir = TestUtils.projectDir(basePath, PROJECT_NAME);
 
     var result = ScannerCommand.createBeginStep(ScannerClassifier.NET_FRAMEWORK, null, projectDir, SONARCLOUD_PROJECT_KEY)
-      .setOrganization(Constants.SONARCLOUD_ORGANIZATION)
+      .setOrganization(CloudConstants.SONARCLOUD_ORGANIZATION)
       .setProperty("sonar.region", "us")
       .setDebugLogs(true)
       .execute(null);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
@@ -39,12 +39,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.sonarqube.ws.Issues;
 
-import static com.sonar.it.scanner.msbuild.sonarqube.Tests.ORCHESTRATOR;
+import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(Tests.class)
+@ExtendWith(ServerTests.class)
 class CodeCoverageTest {
   @TempDir
   public Path basePath;

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CppTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CppTest.java
@@ -35,14 +35,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonarqube.ws.Issues.Issue;
 
-import static com.sonar.it.scanner.msbuild.sonarqube.Tests.ORCHESTRATOR;
+import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Only cpp, without C# plugin
  */
 // See task https://github.com/SonarSource/sonar-scanner-msbuild/issues/789
-@ExtendWith(Tests.class)
+@ExtendWith(ServerTests.class)
 class CppTest {
 
   @TempDir

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/JreProvisioningTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/JreProvisioningTest.java
@@ -28,11 +28,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
-import static com.sonar.it.scanner.msbuild.sonarqube.Tests.ORCHESTRATOR;
+import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@ExtendWith(Tests.class)
+@ExtendWith(ServerTests.class)
 public class JreProvisioningTest {
   private static final String PROJECT_NAME = "JreProvisioning";
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
@@ -41,14 +41,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonarqube.ws.Issues.Issue;
 
-import static com.sonar.it.scanner.msbuild.sonarqube.Tests.ORCHESTRATOR;
+import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@ExtendWith(Tests.class)
+@ExtendWith(ServerTests.class)
 class MultiLanguageTest {
   private static final String SONAR_RULES_PREFIX = "csharpsquid:";
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/OrchestratorState.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/OrchestratorState.java
@@ -27,7 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 
-import static com.sonar.it.scanner.msbuild.sonarqube.Tests.ORCHESTRATOR;
+import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OrchestratorState {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SQLServerTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SQLServerTest.java
@@ -27,10 +27,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonarqube.ws.Issues.Issue;
 
-import static com.sonar.it.scanner.msbuild.sonarqube.Tests.ORCHESTRATOR;
+import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(Tests.class)
+@ExtendWith(ServerTests.class)
 class SQLServerTest {
 
   @TempDir

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerMSBuildTest.java
@@ -82,7 +82,7 @@ import org.sonarqube.ws.Issues.Issue;
 import org.sonarqube.ws.client.WsClient;
 import org.sonarqube.ws.client.components.ShowRequest;
 
-import static com.sonar.it.scanner.msbuild.sonarqube.Tests.ORCHESTRATOR;
+import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.awaitility.Awaitility.await;
@@ -90,7 +90,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-@ExtendWith(Tests.class)
+@ExtendWith(ServerTests.class)
 class ScannerMSBuildTest {
   final static Logger LOG = LoggerFactory.getLogger(ScannerMSBuildTest.class);
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
-public class Tests implements BeforeAllCallback, AfterAllCallback {
+public class ServerTests implements BeforeAllCallback, AfterAllCallback {
 
   public static final Orchestrator ORCHESTRATOR = createOrchestrator();
   private static final OrchestratorState ORCHESTRATOR_STATE = new OrchestratorState(ORCHESTRATOR);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
@@ -37,13 +37,13 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.sonar.it.scanner.msbuild.sonarqube.Tests.ORCHESTRATOR;
+import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(Tests.class)
+@ExtendWith(ServerTests.class)
 class SslTest {
   private static final Logger LOG = LoggerFactory.getLogger(SslTest.class);
   private static final String SSL_KEYSTORE_PASSWORD_ENV = "SSL_KEYSTORE_PASSWORD";

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerClassifier.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerClassifier.java
@@ -19,7 +19,7 @@
  */
 package com.sonar.it.scanner.msbuild.utils;
 
-import com.sonar.it.scanner.msbuild.sonarcloud.Constants;
+import com.sonar.it.scanner.msbuild.sonarcloud.CloudConstants;
 import com.sonar.orchestrator.locator.FileLocation;
 import com.sonar.orchestrator.locator.Location;
 import com.sonar.orchestrator.util.Command;
@@ -29,7 +29,7 @@ import java.nio.file.Paths;
 public enum ScannerClassifier {
   // ToDo: SCAN4NET-200 Unify, cleanup
   NET("net", "dotnet", new File("../build/sonarscanner-net/SonarScanner.MSBuild.dll").getAbsolutePath().toString()),
-  NET_FRAMEWORK("net-framework", new File(Constants.SCANNER_PATH).getAbsolutePath().toString(), null);
+  NET_FRAMEWORK("net-framework", new File(CloudConstants.SCANNER_PATH).getAbsolutePath().toString(), null);
 
   private final String classifier;
   private final String executable;

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -19,7 +19,7 @@
  */
 package com.sonar.it.scanner.msbuild.utils;
 
-import com.sonar.it.scanner.msbuild.sonarcloud.Constants;
+import com.sonar.it.scanner.msbuild.sonarcloud.CloudConstants;
 import com.sonar.orchestrator.Orchestrator;
 import com.sonar.orchestrator.build.BuildResult;
 import com.sonar.orchestrator.build.SynchronousAnalyzer;
@@ -114,7 +114,7 @@ public class ScannerCommand {
     var command = createCommand(orchestrator);
     var result = new BuildResult();
     LOG.info("Command line: {}", command.toCommandLine());
-    result.addStatus(CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), Constants.COMMAND_TIMEOUT));
+    result.addStatus(CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), CloudConstants.COMMAND_TIMEOUT));
     if (step == Step.end && orchestrator != null) {
       new SynchronousAnalyzer(orchestrator.getServer()).waitForDone();  // Wait for Compute Engine to finish processing (all) analysis
     }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
@@ -57,7 +57,7 @@ import org.sonarqube.ws.client.measures.ComponentRequest;
 import org.sonarqube.ws.client.settings.SetRequest;
 import org.sonarqube.ws.client.usertokens.GenerateRequest;
 
-import static com.sonar.it.scanner.msbuild.sonarqube.Tests.ORCHESTRATOR;
+import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestUtils {


### PR DESCRIPTION
[SCAN4NET-347](https://sonarsource.atlassian.net/browse/SCAN4NET-347)

Part of SCAN4NET-197

Prerequisite for [SCAN4NET-346](https://sonarsource.atlassian.net/browse/SCAN4NET-346)

[SCAN4NET-347]: https://sonarsource.atlassian.net/browse/SCAN4NET-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SCAN4NET-346]: https://sonarsource.atlassian.net/browse/SCAN4NET-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Rename Cloud-specific files to `Cloud` prefix.
Rename `Tests.java` to `ServerTests.java`, as there will be `CloudTests.java` and we already had issues in sonar-dotnet due to similar confusion in the past of having multiple `Tests.java`