### PR TITLE
SCAN4NET-352 Adopt trust store exception for sonar cloud region "us"

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessorTests.cs
@@ -27,13 +27,15 @@ namespace SonarScanner.MSBuild.PreProcessor.Test.AnalysisConfigProcessing.Proces
 public class TruststorePropertiesProcessorTests
 {
     [TestMethod]
-    public void Update_TrustStorePropertiesNullValue_Mapped()
+    public void Update_TrustStorePropertiesNullValue_NotMapped_Linux()
     {
+        // See also UT Update_TrustedByTheSystem_Windows for the Windows equivalent which adds "javax.net.ssl.trustStoreType=Windows-ROOT"
         // Arrange
         var cmdLineArgs = new ListPropertiesProvider();
+        cmdLineArgs.AddProperty(SonarProperties.HostUrl, "https://localhost:9000");
         cmdLineArgs.AddProperty("sonar.scanner.truststorePath", null);
         cmdLineArgs.AddProperty("sonar.scanner.truststorePassword", null);
-        var processor = CreateProcessor(CreateProcessedArgs(cmdLineArgs), isUnix: false);
+        var processor = CreateProcessor(CreateProcessedArgs(cmdLineArgs), isUnix: true);
         var config = new AnalysisConfig
         {
             LocalSettings =

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessorTests.cs
@@ -88,6 +88,8 @@ public class TruststorePropertiesProcessorTests
     [DataRow("https://SonarQube.us", null, null)]
     [DataRow(null, "https://sonarqube.us", null)]
     [DataRow(null, "https://sonarcloud.io", null)]
+    [DataRow(null, "https://sonarqube-staging.us", null)]
+    [DataRow(null, "https://test.sonarcloud.io", null)]
     [DataRow(null, null, "us")]
     public void Update_TrustStoreProperties_SonarCloud_NotMapped(string hostUrl, string sonarCloudUrl, string region)
     {
@@ -119,31 +121,6 @@ public class TruststorePropertiesProcessorTests
         processor.Update(config);
 
         config.ScannerOptsSettings.Should().BeEmpty();
-        Property.TryGetProperty("javax.net.ssl.trustStore", config.LocalSettings, out _).Should().BeFalse();
-    }
-
-    [DataTestMethod]
-    [DataRow("https://sonarqube-staging.us")]
-    [DataRow("https://test.sonarcloud.io")]
-    public void Update_TrustStoreProperties_SonarCloud_Mapped(string sonarCloudUrl)
-    {
-        var cmdLineArgs = new ListPropertiesProvider();
-        cmdLineArgs.AddProperty("sonar.scanner.truststorePath", @"C:\path\to\truststore.pfx");
-        cmdLineArgs.AddProperty("sonar.scanner.truststorePassword", "itchange");
-        cmdLineArgs.AddProperty(SonarProperties.SonarcloudUrl, sonarCloudUrl);
-        var processor = CreateProcessor(CreateProcessedArgs(cmdLineArgs), isUnix: false);
-        var config = new AnalysisConfig
-        {
-            LocalSettings =
-            [
-                new Property("sonar.scanner.truststorePath", @"C:\path\to\truststore.pfx"),
-                new Property("sonar.scanner.truststorePassword", "itchange")
-            ]
-        };
-
-        processor.Update(config);
-
-        config.ScannerOptsSettings.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Id = "javax.net.ssl.trustStore", Value = @"""C:/path/to/truststore.pfx""" });
         Property.TryGetProperty("javax.net.ssl.trustStore", config.LocalSettings, out _).Should().BeFalse();
     }
 


### PR DESCRIPTION
[SCAN4NET-352](https://sonarsource.atlassian.net/browse/SCAN4NET-352)

Part of [SCAN4NET-351](https://sonarsource.atlassian.net/browse/SCAN4NET-351)

Based on #2400

[SCAN4NET-351]: https://sonarsource.atlassian.net/browse/SCAN4NET-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SCAN4NET-352]: https://sonarsource.atlassian.net/browse/SCAN4NET-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ