### PR TITLE
Add IT run configuration for IDEA

### DIFF
--- a/.run/Template JUnit.run.xml
+++ b/.run/Template JUnit.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="JUnit" factoryName="JUnit">
+    <option name="MAIN_CLASS_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="class" />
+    <option name="VM_PARAMETERS" value="-ea -Djava.net.preferIPv4Stack=true -Dsonar.css.version=NONE" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
Without `-Dsonar.css.version=NONE` the ITs fail to start because the orchestrator tries to add the out-dated css plugin along the new javascript/css plugin which fails.
To make it easier, the run configuration template includes the settings for the "DEV" ITs.
The template UI can be found in "Run->Edit configurations->Edit configuration templates"
The IPv4 setting is a workaround needed for the new VPN. See [here for details](https://xtranet-sonarsource.atlassian.net/wiki/spaces/HELPDESK/pages/2968191014/FortiClient+Advanced+Installation+Options#FortiClient-with-ZTNA).
![image](https://github.com/user-attachments/assets/05ede236-033c-4354-9712-4d3ee813631f)
