### PR TITLE
SCAN4NET-358 host.url = sonarqube.us should infer the us region

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -227,9 +227,9 @@ public class ArgumentProcessorTests
     [DataRow(null, null, "https://SONARCLOUD.io/", null, typeof(CloudHostInfo), "https://SONARCLOUD.io/", "https://api.sonarcloud.io")]
     [DataRow(null, "https://sonarcloud.io", null, "https://api", typeof(CloudHostInfo), "https://sonarcloud.io", "https://api")]
     [DataRow(null, null, "https://sonarcloud.io", "https://api", typeof(CloudHostInfo), "https://sonarcloud.io", "https://api")]
-    [DataRow("us", "https://sonarcloud.io", null, null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarqube.us",
+    [DataRow("us", "https://sonarcloud.io", null, null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarcloud.io",
         @"The sonar.region parameter is set to ""us"". The setting will be overriden by one or more of the properties sonar.host.url, sonar.scanner.sonarcloudUrl, or sonar.scanner.apiBaseUrl.")]
-    [DataRow("us", null, "https://sonarcloud.io", null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarqube.us",
+    [DataRow("us", null, "https://sonarcloud.io", null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarcloud.io",
         @"The sonar.region parameter is set to ""us"". The setting will be overriden by one or more of the properties sonar.host.url, sonar.scanner.sonarcloudUrl, or sonar.scanner.apiBaseUrl.")]
     public void PreArgProc_Region_Overrides(string region, string hostOverride, string sonarClourUrlOverride, string apiOverride, Type expectedHostInfoType, string expectedHostUri, string expectedApiUri, params string[] expectedWarnings)
     {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -217,22 +217,20 @@ public class ArgumentProcessorTests
         @"The arguments 'sonar.host.url' and 'sonar.scanner.sonarcloudUrl' are both set. Please set only 'sonar.scanner.sonarcloudUrl'.")]
     [DataRow(null, "https://host", null, "https://api", typeof(ServerHostInfo), "https://host", "https://api")]
     [DataRow(null, "https://host", null, null, typeof(ServerHostInfo), "https://host", "https://host/api/v2")]
-    [DataRow(null, "https://sonarqube.us", null, null, typeof(CloudHostInfo), "https://sonarqube.us", "https://api.sonarqube.us")]
     [DataRow(null, "https://SONARQUBE.us/", null, null, typeof(CloudHostInfo), "https://SONARQUBE.us/", "https://api.sonarqube.us")]
-    [DataRow(null, null, "https://sonarqube.us", null, typeof(CloudHostInfo), "https://sonarqube.us", "https://api.sonarqube.us")]
     [DataRow(null, null, "https://SONARQUBE.us/", null, typeof(CloudHostInfo), "https://SONARQUBE.us/", "https://api.sonarqube.us")]
     [DataRow(null, "https://sonarqube.us", null, "https://api", typeof(CloudHostInfo), "https://sonarqube.us", "https://api")]
     [DataRow(null, null, "https://sonarqube.us", "https://api", typeof(CloudHostInfo), "https://sonarqube.us", "https://api")]
-    [DataRow("us", "https://sonarqube.us", null, null, typeof(CloudHostInfo), "https://sonarqube.us", "https://api.sonarqube.us",
-        @"The sonar.region parameter is set to ""us"". The setting will be overriden by one or more of the properties sonar.host.url, sonar.scanner.sonarcloudUrl, or sonar.scanner.apiBaseUrl.")]
     [DataRow("US", "https://SONARQUBE.us/", null, null, typeof(CloudHostInfo), "https://SONARQUBE.us/", "https://api.sonarqube.us",
         @"The sonar.region parameter is set to ""US"". The setting will be overriden by one or more of the properties sonar.host.url, sonar.scanner.sonarcloudUrl, or sonar.scanner.apiBaseUrl.")]
-    [DataRow(null, "https://sonarcloud.io", null, null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarcloud.io")]
     [DataRow(null, "https://SONARCLOUD.io/", null, null, typeof(CloudHostInfo), "https://SONARCLOUD.io/", "https://api.sonarcloud.io")]
-    [DataRow(null, null, "https://sonarcloud.io", null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarcloud.io")]
     [DataRow(null, null, "https://SONARCLOUD.io/", null, typeof(CloudHostInfo), "https://SONARCLOUD.io/", "https://api.sonarcloud.io")]
     [DataRow(null, "https://sonarcloud.io", null, "https://api", typeof(CloudHostInfo), "https://sonarcloud.io", "https://api")]
     [DataRow(null, null, "https://sonarcloud.io", "https://api", typeof(CloudHostInfo), "https://sonarcloud.io", "https://api")]
+    [DataRow("us", "https://sonarcloud.io", null, null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarqube.us",
+        @"The sonar.region parameter is set to ""us"". The setting will be overriden by one or more of the properties sonar.host.url, sonar.scanner.sonarcloudUrl, or sonar.scanner.apiBaseUrl.")]
+    [DataRow("us", null, "https://sonarcloud.io", null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarqube.us",
+        @"The sonar.region parameter is set to ""us"". The setting will be overriden by one or more of the properties sonar.host.url, sonar.scanner.sonarcloudUrl, or sonar.scanner.apiBaseUrl.")]
     public void PreArgProc_Region_Overrides(string region, string hostOverride, string sonarClourUrlOverride, string apiOverride, Type expectedHostInfoType, string expectedHostUri, string expectedApiUri, params string[] expectedWarnings)
     {
         var logger = new TestLogger();

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -217,7 +217,6 @@ public class ArgumentProcessorTests
         @"The arguments 'sonar.host.url' and 'sonar.scanner.sonarcloudUrl' are both set. Please set only 'sonar.scanner.sonarcloudUrl'.")]
     [DataRow(null, "https://host", null, "https://api", typeof(ServerHostInfo), "https://host", "https://api")]
     [DataRow(null, "https://host", null, null, typeof(ServerHostInfo), "https://host", "https://host/api/v2")]
-
     [DataRow(null, "https://sonarqube.us", null, null, typeof(CloudHostInfo), "https://sonarqube.us", "https://api.sonarqube.us")]
     [DataRow(null, "https://SONARQUBE.us/", null, null, typeof(CloudHostInfo), "https://SONARQUBE.us/", "https://api.sonarqube.us")]
     [DataRow(null, null, "https://sonarqube.us", null, typeof(CloudHostInfo), "https://sonarqube.us", "https://api.sonarqube.us")]
@@ -228,7 +227,6 @@ public class ArgumentProcessorTests
         @"The sonar.region parameter is set to ""us"". The setting will be overriden by one or more of the properties sonar.host.url, sonar.scanner.sonarcloudUrl, or sonar.scanner.apiBaseUrl.")]
     [DataRow("US", "https://SONARQUBE.us/", null, null, typeof(CloudHostInfo), "https://SONARQUBE.us/", "https://api.sonarqube.us",
         @"The sonar.region parameter is set to ""US"". The setting will be overriden by one or more of the properties sonar.host.url, sonar.scanner.sonarcloudUrl, or sonar.scanner.apiBaseUrl.")]
-
     [DataRow(null, "https://sonarcloud.io", null, null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarcloud.io")]
     [DataRow(null, "https://SONARCLOUD.io/", null, null, typeof(CloudHostInfo), "https://SONARCLOUD.io/", "https://api.sonarcloud.io")]
     [DataRow(null, null, "https://sonarcloud.io", null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarcloud.io")]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -217,7 +217,25 @@ public class ArgumentProcessorTests
         @"The arguments 'sonar.host.url' and 'sonar.scanner.sonarcloudUrl' are both set. Please set only 'sonar.scanner.sonarcloudUrl'.")]
     [DataRow(null, "https://host", null, "https://api", typeof(ServerHostInfo), "https://host", "https://api")]
     [DataRow(null, "https://host", null, null, typeof(ServerHostInfo), "https://host", "https://host/api/v2")]
-    public void PreArgProc_Region_Overrides(string region, string hostOverride, string sonarClourUrlOverride, string apiOverride, Type expectedHostInforType, string expectedHostUri, string expectedApiUri, params string[] expectedWarnings)
+
+    [DataRow(null, "https://sonarqube.us", null, null, typeof(CloudHostInfo), "https://sonarqube.us", "https://api.sonarqube.us")]
+    [DataRow(null, "https://SONARQUBE.us/", null, null, typeof(CloudHostInfo), "https://SONARQUBE.us/", "https://api.sonarqube.us")]
+    [DataRow(null, null, "https://sonarqube.us", null, typeof(CloudHostInfo), "https://sonarqube.us", "https://api.sonarqube.us")]
+    [DataRow(null, null, "https://SONARQUBE.us/", null, typeof(CloudHostInfo), "https://SONARQUBE.us/", "https://api.sonarqube.us")]
+    [DataRow(null, "https://sonarqube.us", null, "https://api", typeof(CloudHostInfo), "https://sonarqube.us", "https://api")]
+    [DataRow(null, null, "https://sonarqube.us", "https://api", typeof(CloudHostInfo), "https://sonarqube.us", "https://api")]
+    [DataRow("us", "https://sonarqube.us", null, null, typeof(CloudHostInfo), "https://sonarqube.us", "https://api.sonarqube.us",
+        @"The sonar.region parameter is set to ""us"". The setting will be overriden by one or more of the properties sonar.host.url, sonar.scanner.sonarcloudUrl, or sonar.scanner.apiBaseUrl.")]
+    [DataRow("US", "https://SONARQUBE.us/", null, null, typeof(CloudHostInfo), "https://SONARQUBE.us/", "https://api.sonarqube.us",
+        @"The sonar.region parameter is set to ""US"". The setting will be overriden by one or more of the properties sonar.host.url, sonar.scanner.sonarcloudUrl, or sonar.scanner.apiBaseUrl.")]
+
+    [DataRow(null, "https://sonarcloud.io", null, null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarcloud.io")]
+    [DataRow(null, "https://SONARCLOUD.io/", null, null, typeof(CloudHostInfo), "https://SONARCLOUD.io/", "https://api.sonarcloud.io")]
+    [DataRow(null, null, "https://sonarcloud.io", null, typeof(CloudHostInfo), "https://sonarcloud.io", "https://api.sonarcloud.io")]
+    [DataRow(null, null, "https://SONARCLOUD.io/", null, typeof(CloudHostInfo), "https://SONARCLOUD.io/", "https://api.sonarcloud.io")]
+    [DataRow(null, "https://sonarcloud.io", null, "https://api", typeof(CloudHostInfo), "https://sonarcloud.io", "https://api")]
+    [DataRow(null, null, "https://sonarcloud.io", "https://api", typeof(CloudHostInfo), "https://sonarcloud.io", "https://api")]
+    public void PreArgProc_Region_Overrides(string region, string hostOverride, string sonarClourUrlOverride, string apiOverride, Type expectedHostInfoType, string expectedHostUri, string expectedApiUri, params string[] expectedWarnings)
     {
         var logger = new TestLogger();
         var args = CheckProcessingSucceeds(
@@ -232,8 +250,8 @@ public class ArgumentProcessorTests
                 .. apiOverride is null ? Array.Empty<string>() : [$"/d:{SonarProperties.ApiBaseUrl}={apiOverride}"],
             ]);
 
-        args.ServerInfo.Should().BeOfType(expectedHostInforType);
-        args.ServerInfo.Should().BeEquivalentTo(new { ServerUrl = expectedHostUri, ApiBaseUrl = expectedApiUri, IsSonarCloud = expectedHostInforType == typeof(CloudHostInfo) });
+        args.ServerInfo.Should().BeOfType(expectedHostInfoType);
+        args.ServerInfo.Should().BeEquivalentTo(new { ServerUrl = expectedHostUri, ApiBaseUrl = expectedApiUri, IsSonarCloud = expectedHostInfoType == typeof(CloudHostInfo) });
         logger.AssertDebugLogged($"Server Url: {expectedHostUri}");
         logger.AssertDebugLogged($"Api Url: {expectedApiUri}");
         logger.AssertDebugLogged($"Is SonarCloud: {args.ServerInfo.IsSonarCloud}");

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
@@ -304,26 +304,32 @@ public class ProcessedArgsTests
     }
 
     [DataTestMethod]
-    [DataRow("https://sonarcloud.io")]
-    [DataRow("https://SonarCloud.io")]
-    [DataRow("https://SONARCLOUD.IO")]
-    [DataRow("https://sonarcloud.io/")]
-    [DataRow("https://sonarcloud.io///")]
-    [DataRow("https://sonarqube.us")]
-    [DataRow("https://SonarQube.us")]
-    [DataRow("https://SONARQUBE.US")]
-    [DataRow("https://sonarqube.us/")]
-    [DataRow("https://sonarqube.us///")]
-    public void ProcArgs_HostUrl_SonarCloudUrl_HostUrlIsAnySonarCloud(string hostUrl)
+    [DataRow("https://sonarcloud.io", "https://api.sonarcloud.io")]
+    [DataRow("https://SonarCloud.io", "https://api.sonarcloud.io")]
+    [DataRow("https://SONARCLOUD.IO", "https://api.sonarcloud.io")]
+    [DataRow("https://sonarcloud.io/", "https://api.sonarcloud.io")]
+    [DataRow("https://sonarcloud.io///", "https://api.sonarcloud.io")]
+    [DataRow("https://sonarqube.us", "https://api.sonarqube.us")]
+    [DataRow("https://SonarQube.us", "https://api.sonarqube.us")]
+    [DataRow("https://SONARQUBE.US", "https://api.sonarqube.us")]
+    [DataRow("https://sonarqube.us/", "https://api.sonarqube.us")]
+    [DataRow("https://sonarqube.us///", "https://api.sonarqube.us")]
+    public void ProcArgs_HostUrl_SonarCloudUrl_HostUrlIsAnySonarCloud(string hostUrl, string expectedApiBaseUrl)
     {
         var sut = CreateDefaultArgs(new ListPropertiesProvider([new Property(SonarProperties.HostUrl, hostUrl)]));
 
-        sut.ServerInfo.Should().NotBeNull();
-        sut.ServerInfo.IsSonarCloud.Should().BeTrue();
-        sut.ServerInfo.ServerUrl.Should().Be(hostUrl);
+        sut.Should().BeEquivalentTo(new
+        {
+            IsValid = true,
+            ServerInfo = new
+            {
+                IsSonarCloud = true,
+                ServerUrl = hostUrl,
+                ApiBaseUrl = expectedApiBaseUrl,
+            },
+        });
         logger.Warnings.Should().BeEmpty();
         logger.Errors.Should().BeEmpty();
-        sut.IsValid.Should().BeTrue();
     }
 
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
@@ -304,17 +304,17 @@ public class ProcessedArgsTests
     }
 
     [DataTestMethod]
-    [DataRow("https://sonarcloud.io", "https://api.sonarcloud.io")]
-    [DataRow("https://SonarCloud.io", "https://api.sonarcloud.io")]
-    [DataRow("https://SONARCLOUD.IO", "https://api.sonarcloud.io")]
-    [DataRow("https://sonarcloud.io/", "https://api.sonarcloud.io")]
-    [DataRow("https://sonarcloud.io///", "https://api.sonarcloud.io")]
-    [DataRow("https://sonarqube.us", "https://api.sonarqube.us")]
-    [DataRow("https://SonarQube.us", "https://api.sonarqube.us")]
-    [DataRow("https://SONARQUBE.US", "https://api.sonarqube.us")]
-    [DataRow("https://sonarqube.us/", "https://api.sonarqube.us")]
-    [DataRow("https://sonarqube.us///", "https://api.sonarqube.us")]
-    public void ProcArgs_HostUrl_SonarCloudUrl_HostUrlIsAnySonarCloud(string hostUrl, string expectedApiBaseUrl)
+    [DataRow("https://sonarcloud.io", "https://api.sonarcloud.io", "")]
+    [DataRow("https://SonarCloud.io", "https://api.sonarcloud.io", "")]
+    [DataRow("https://SONARCLOUD.IO", "https://api.sonarcloud.io", "")]
+    [DataRow("https://sonarcloud.io/", "https://api.sonarcloud.io", "")]
+    [DataRow("https://sonarcloud.io///", "https://api.sonarcloud.io", "")]
+    [DataRow("https://sonarqube.us", "https://api.sonarqube.us", "us")]
+    [DataRow("https://SonarQube.us", "https://api.sonarqube.us", "us")]
+    [DataRow("https://SONARQUBE.US", "https://api.sonarqube.us", "us")]
+    [DataRow("https://sonarqube.us/", "https://api.sonarqube.us", "us")]
+    [DataRow("https://sonarqube.us///", "https://api.sonarqube.us", "us")]
+    public void ProcArgs_HostUrl_SonarCloudUrl_HostUrlIsAnySonarCloud(string hostUrl, string expectedApiBaseUrl, string expectedRegion)
     {
         var sut = CreateDefaultArgs(new ListPropertiesProvider([new Property(SonarProperties.HostUrl, hostUrl)]));
 
@@ -326,6 +326,7 @@ public class ProcessedArgsTests
                 IsSonarCloud = true,
                 ServerUrl = hostUrl,
                 ApiBaseUrl = expectedApiBaseUrl,
+                Region = expectedRegion,
             },
         });
         logger.Warnings.Should().BeEmpty();

--- a/src/SonarScanner.MSBuild.PreProcessor/HostInfo.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/HostInfo.cs
@@ -85,7 +85,7 @@ public record CloudHostInfo(string ServerUrl, string ApiBaseUrl, string Region) 
     public static new CloudHostInfo FromProperties(ILogger logger, string sonarHostUrl, string sonarCloudUrl, string apiBaseUrl, string region)
     {
         region = region?.Trim().ToLower() ?? string.Empty;
-        var regionFromUrl = region == string.Empty ? KnownRegions.SingleOrDefault(x => UrlEquals(x.ServerUrl, sonarHostUrl) || UrlEquals(x.ServerUrl, sonarCloudUrl)) : null;
+        var regionFromUrl = region == string.Empty ? (KnownRegionByUrl(sonarHostUrl) ?? KnownRegionByUrl(sonarCloudUrl)) : null;
         var knownRegion = regionFromUrl ?? KnownRegions.SingleOrDefault(x => x.Region == region);
         if (knownRegion is not null)
         {
@@ -101,12 +101,11 @@ public record CloudHostInfo(string ServerUrl, string ApiBaseUrl, string Region) 
     }
 
     public static bool IsKnownUrl(string url) =>
-        KnownRegions.Any(x => UrlEquals(x.ServerUrl, url));
+        KnownRegionByUrl(url) is not null;
 
-    private static bool UrlEquals(string url1, string url2)
+    private static CloudHostInfo KnownRegionByUrl(string url)
     {
-        url1 = url1?.TrimEnd('/');
-        url2 = url2?.TrimEnd('/');
-        return string.Equals(url1, url2, StringComparison.InvariantCultureIgnoreCase);
+        url = url?.TrimEnd('/');
+        return KnownRegions.SingleOrDefault(x => string.Equals(x.ServerUrl, url, StringComparison.InvariantCultureIgnoreCase));
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/HostInfo.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/HostInfo.cs
@@ -85,8 +85,7 @@ public record CloudHostInfo(string ServerUrl, string ApiBaseUrl, string Region) 
     public static new CloudHostInfo FromProperties(ILogger logger, string sonarHostUrl, string sonarCloudUrl, string apiBaseUrl, string region)
     {
         region = region?.Trim().ToLower() ?? string.Empty;
-        var knownRegion = KnownRegionByUrl(sonarHostUrl) ?? KnownRegionByUrl(sonarCloudUrl) ?? KnownRegions.SingleOrDefault(x => x.Region == region);
-        if (knownRegion is not null)
+        if ((KnownRegionByUrl(sonarHostUrl) ?? KnownRegionByUrl(sonarCloudUrl) ?? KnownRegions.SingleOrDefault(x => x.Region == region)) is { } knownRegion)
         {
             var serverUrl = sonarCloudUrl ?? sonarHostUrl ?? knownRegion.ServerUrl;
             var apiUrl = apiBaseUrl ?? knownRegion.ApiBaseUrl;

--- a/src/SonarScanner.MSBuild.PreProcessor/HostInfo.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/HostInfo.cs
@@ -85,7 +85,7 @@ public record CloudHostInfo(string ServerUrl, string ApiBaseUrl, string Region) 
     public static new CloudHostInfo FromProperties(ILogger logger, string sonarHostUrl, string sonarCloudUrl, string apiBaseUrl, string region)
     {
         region = region?.Trim().ToLower() ?? string.Empty;
-        var regionFromUrl = region == string.Empty ? KnownRegions.FirstOrDefault(x => UrlEquals(x.ServerUrl, sonarHostUrl) || UrlEquals(x.ServerUrl, sonarCloudUrl)) : null;
+        var regionFromUrl = region == string.Empty ? KnownRegions.SingleOrDefault(x => UrlEquals(x.ServerUrl, sonarHostUrl) || UrlEquals(x.ServerUrl, sonarCloudUrl)) : null;
         var knownRegion = regionFromUrl ?? KnownRegions.SingleOrDefault(x => x.Region == region);
         if (knownRegion is not null)
         {

--- a/src/SonarScanner.MSBuild.PreProcessor/HostInfo.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/HostInfo.cs
@@ -85,8 +85,7 @@ public record CloudHostInfo(string ServerUrl, string ApiBaseUrl, string Region) 
     public static new CloudHostInfo FromProperties(ILogger logger, string sonarHostUrl, string sonarCloudUrl, string apiBaseUrl, string region)
     {
         region = region?.Trim().ToLower() ?? string.Empty;
-        var regionFromUrl = region == string.Empty ? (KnownRegionByUrl(sonarHostUrl) ?? KnownRegionByUrl(sonarCloudUrl)) : null;
-        var knownRegion = regionFromUrl ?? KnownRegions.SingleOrDefault(x => x.Region == region);
+        var knownRegion = KnownRegionByUrl(sonarHostUrl) ?? KnownRegionByUrl(sonarCloudUrl) ?? KnownRegions.SingleOrDefault(x => x.Region == region);
         if (knownRegion is not null)
         {
             var serverUrl = sonarCloudUrl ?? sonarHostUrl ?? knownRegion.ServerUrl;
@@ -106,6 +105,8 @@ public record CloudHostInfo(string ServerUrl, string ApiBaseUrl, string Region) 
     private static CloudHostInfo KnownRegionByUrl(string url)
     {
         url = url?.TrimEnd('/');
-        return KnownRegions.SingleOrDefault(x => string.Equals(x.ServerUrl, url, StringComparison.InvariantCultureIgnoreCase));
+        return string.IsNullOrWhiteSpace(url)
+            ? null
+            : KnownRegions.SingleOrDefault(x => string.Equals(x.ServerUrl, url, StringComparison.InvariantCultureIgnoreCase));
     }
 }


### PR DESCRIPTION
[SCAN4NET-358](https://sonarsource.atlassian.net/browse/SCAN4NET-358)

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->


[SCAN4NET-358]: https://sonarsource.atlassian.net/browse/SCAN4NET-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ