### PR TITLE
SCAN4NET-365 Fix flaky whenMajorityOfProjectsIsOnSameDrive_AnalysisSucceeds

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
@@ -149,14 +149,17 @@ public class TestUtils {
   }
 
   public static void createVirtualDrive(String drive, Path projectDir, String subDirectory) {
+    var absolutePath = projectDir.resolve(subDirectory).toAbsolutePath().toString();
     int setupStatus = CommandExecutor.create().execute(
       Command.create("SUBST")
         .addArguments(drive)
-        .addArguments(projectDir.resolve(subDirectory).toAbsolutePath().toString())
+        .addArguments(absolutePath)
         .setDirectory(projectDir.toFile()),
       s -> TestUtils.LOG.info("SUBST create: {}", s),
       TIMEOUT_LIMIT);
-    assertThat(setupStatus).isZero();
+    assertThat(setupStatus)
+      .withFailMessage("SUBST mapping of folder %s to drive %s failed. Look for 'SUBST create:' messages in the logs for details.", absolutePath, drive)
+      .isZero();
   }
 
   public static void deleteVirtualDrive(String drive) {
@@ -164,7 +167,9 @@ public class TestUtils {
       Command.create("SUBST").addArguments(drive).addArguments("/D"),
       s -> TestUtils.LOG.info("SUBST delete: {}", s),
       TIMEOUT_LIMIT);
-    assertThat(cleanupStatus).isZero();
+    assertThat(cleanupStatus)
+      .withFailMessage("SUBST un-mapping of drive %s failed. Look for 'SUBST delete:' messages in the logs for details.", drive)
+      .isZero();
   }
 
   public static Path projectDir(Path temp, String projectName) {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
@@ -40,6 +40,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
@@ -159,7 +160,11 @@ public class TestUtils {
       s -> TestUtils.LOG.info("SUBST create: {}", s),
       TIMEOUT_LIMIT);
     assertThat(setupStatus)
-      .withFailMessage("SUBST mapping of folder %s to drive %s failed. Look for 'SUBST create:' messages in the logs for details.", absolutePath, drive)
+      .withFailMessage("SUBST mapping of folder %s to drive %s failed. Look for 'SUBST create:' messages in the logs for details. Content of the drive%n%s",
+        absolutePath,
+        drive,
+        Stream.of(new File(drive).listFiles()).map(File::getName).collect(Collectors.joining(System.lineSeparator()))
+      )
       .isZero();
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
@@ -150,6 +150,7 @@ public class TestUtils {
 
   public static void createVirtualDrive(String drive, Path projectDir, String subDirectory) {
     var absolutePath = projectDir.resolve(subDirectory).toAbsolutePath().toString();
+    TestUtils.LOG.info("SUBST create: Start for folder {} mapping to drive {}", absolutePath, drive);
     int setupStatus = CommandExecutor.create().execute(
       Command.create("SUBST")
         .addArguments(drive)
@@ -163,6 +164,7 @@ public class TestUtils {
   }
 
   public static void deleteVirtualDrive(String drive) {
+    TestUtils.LOG.info("SUBST delete: Start for drive {}", drive);
     int cleanupStatus = CommandExecutor.create().execute(
       Command.create("SUBST").addArguments(drive).addArguments("/D"),
       s -> TestUtils.LOG.info("SUBST delete: {}", s),

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
@@ -154,6 +154,7 @@ public class TestUtils {
         .addArguments(drive)
         .addArguments(projectDir.resolve(subDirectory).toAbsolutePath().toString())
         .setDirectory(projectDir.toFile()),
+      s -> TestUtils.LOG.info("SUBST create: {}", s),
       TIMEOUT_LIMIT);
     assertThat(setupStatus).isZero();
   }
@@ -161,6 +162,7 @@ public class TestUtils {
   public static void deleteVirtualDrive(String drive) {
     int cleanupStatus = CommandExecutor.create().execute(
       Command.create("SUBST").addArguments(drive).addArguments("/D"),
+      s -> TestUtils.LOG.info("SUBST delete: {}", s),
       TIMEOUT_LIMIT);
     assertThat(cleanupStatus).isZero();
   }

--- a/templates/its-jobs.yml
+++ b/templates/its-jobs.yml
@@ -90,6 +90,7 @@ jobs:
             --settings $(mavenSettings.secureFilePath)
             -Denable-repo=qa
             -DtestInclude=$(TEST_INCLUDE)
+            -Dtest="BaseDirTest#whenMajorityOfProjectsIsOnSameDrive_AnalysisSucceeds,BaseDirTest#whenEachProjectIsOnDifferentDrives_AnalysisFails"
             -Dsonar.csharpplugin.version=$(DOTNET_VERSION)
             -Dsonar.vbnetplugin.version=$(DOTNET_VERSION)
             -Dsonar.cfamilyplugin.version=$(CFAMILY_VERSION)


### PR DESCRIPTION
[SCAN4NET-365](https://sonarsource.atlassian.net/browse/SCAN4NET-365)

One successfull failure revealed [these logs](https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=111301&view=logs&j=9d5f9aea-fbdd-5fd0-0370-b640974916b8&t=17905f5b-2ac9-51e6-d6b7-fe793920f4a1&l=1603)
```
13:26:16.981 INFO  SUBST create: Start for folder C:\Windows\Temp\junit-15676771345489048525\TwoDrivesThreeProjects\DriveY mapping to drive Y:
13:26:17.013 INFO  SUBST create: Drive already SUBSTed
13:26:17.020 INFO  SUBST delete: Start for drive Y:
13:26:17.083 INFO  SUBST create: Start for folder C:\Windows\Temp\junit-5503472094324171527\TwoDrivesTwoProjects\DriveZ mapping to drive Z:
```

So drive y: already exists. I try to `dir /s` the content of it to see what is on the that drive.

[SCAN4NET-365]: https://sonarsource.atlassian.net/browse/SCAN4NET-365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

The other timings for the others runs for drive Y:
| Run | Timing |
|--- | --- |
| Run ITs LTA-89 (failing run) | 13:26:16.981 INFO  SUBST create: |
| Run ITs LTA-99 | 13:26:19.773 INFO  SUBST create: |
| Run ITs LTA-2025 | 13:26:45.516 INFO  SUBST create: |
| Run ITs LATEST_RELEASE | 13:27:03.309 INFO  SUBST create: |
| Run ITs DEV_MsBuild15 | 13:26:31.095 INFO  SUBST create: |
| Run ITs DEV_MsBuild16 | 13:26:44.505 INFO  SUBST create: |
| Run ITs DEV_MsBuild17 | 13:26:57.149 INFO  SUBST create: |
