### PR TITLE
SCAN4NET-377 Dump logs on failed ITs in AnalysisContext

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/AnalysisContext.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/AnalysisContext.java
@@ -26,8 +26,7 @@ import java.nio.file.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AnalysisContext {
   final static Logger LOG = LoggerFactory.getLogger(AnalysisContext.class);
@@ -78,19 +77,19 @@ public class AnalysisContext {
 
   public AnalysisResult runAnalysis() {
     var result = runAnalysisInternal();
-    assertTrue(result.isSuccess(), "Analysis END step failed.");
+    assertThat(result.isSuccess()).describedAs("Analysis END step failed. Logs: " + result.logs()).isTrue();
     return result;
   }
 
   public AnalysisResult runFailedAnalysis() {
     var result = runAnalysisInternal();
-    assertFalse(result.isSuccess(), "Analysis END step should have failed, but didn't.");
+    assertThat(result.isSuccess()).describedAs("Analysis END step should have failed, but didn't. Logs: " + result.logs()).isFalse();
     return result;
   }
 
   private AnalysisResult runAnalysisInternal() {
     var beginResult = begin.execute(orchestrator);
-    assertTrue(beginResult.isSuccess(), "Analysis BEGIN step failed.");
+    assertThat(beginResult.isSuccess()).describedAs("Analysis BEGIN step failed. Logs: " + beginResult.getLogs()).isTrue();
     var buildResult = build.execute();
     var endResult = end.execute(orchestrator);
     if (endResult.isSuccess()) {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BuildCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BuildCommand.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BuildCommand extends BaseCommand<BuildCommand> {
 
@@ -71,7 +71,7 @@ public class BuildCommand extends BaseCommand<BuildCommand> {
     var result = new BuildResult();
     LOG.info("Command line: {}", command.toCommandLine());
     result.addStatus(CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), timeout));
-    assertTrue(result.isSuccess(), "BUILD step failed.");
+    assertThat(result.isSuccess()).describedAs("BUILD step failed. Logs: " + result.getLogs()).isTrue();
     return result;
   }
 
@@ -99,7 +99,7 @@ public class BuildCommand extends BaseCommand<BuildCommand> {
     Path path = Paths.get(input).toAbsolutePath();
     if (!Files.exists(path)) {
       throw new IllegalStateException("Unable to find MSBuild at " + path
-                                      + ". Please configure property 'msbuild.path' or 'MSBUILD_PATH' environment variable to the full path to MSBuild.exe.");
+        + ". Please configure property 'msbuild.path' or 'MSBUILD_PATH' environment variable to the full path to MSBuild.exe.");
     }
     return path.toString();
   }


### PR DESCRIPTION
[SCAN4NET-377](https://sonarsource.atlassian.net/browse/SCAN4NET-377)

The `describeAs("Lorem ipsum\n Dolor sit amet` produces this in the middle of the logs
```
[ERROR] com.sonar.it.scanner.msbuild.sonarcloud.IncrementalPRAnalysisTest.debug_assertThat_describedAs -- Time elapsed: 0 s <<< FAILURE!
org.opentest4j.AssertionFailedError: 
[Lorem ipsum
Dolor sit amet] 
Expecting value to be true but was false
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at com.sonar.it.scanner.msbuild.sonarcloud.IncrementalPRAnalysisTest.debug_assertThat_describedAs(IncrementalPRAnalysisTest.java:65)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```
and mainly this at the end
```
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   IncrementalPRAnalysisTest.debug_assertThat_describedAs:65 [Lorem ipsum
Dolor sit amet] 
Expecting value to be true but was false
```

Real-life example is here: https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=111385&view=logs&j=21a012b9-6e54-5f5d-0883-cb16010e0111&t=92d9d6f7-5371-510e-7671-50af4de4e7c6&l=13571

[SCAN4NET-377]: https://sonarsource.atlassian.net/browse/SCAN4NET-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ