### PR TITLE
SCAN4NET-386 Restore some IT timeouts

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
@@ -24,6 +24,7 @@ import com.sonar.it.scanner.msbuild.utils.AzureDevOps;
 import com.sonar.it.scanner.msbuild.utils.ContextExtension;
 import com.sonar.it.scanner.msbuild.utils.TempDirectory;
 import com.sonar.it.scanner.msbuild.utils.TestUtils;
+import com.sonar.it.scanner.msbuild.utils.Timeout;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
@@ -128,7 +129,7 @@ class CodeCoverageTest {
     var context = AnalysisContext.forServer("ExclusionsAndCoverage");
     context.begin.setDebugLogs();
     context.build.useDotNet();
-    context.end.setTimeout(2 * TestUtils.TIMEOUT_LIMIT);
+    context.end.setTimeout(Timeout.TWO_MINUTES);
     ORCHESTRATOR.getServer().provisionProject(context.projectKey, context.projectKey);
 
     if (!localExclusions.isEmpty()) // You cannot provide an empty /d:sonar.exclusions="" argument

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
@@ -128,6 +128,7 @@ class CodeCoverageTest {
     var context = AnalysisContext.forServer("ExclusionsAndCoverage");
     context.begin.setDebugLogs();
     context.build.useDotNet();
+    context.end.setTimeout(2 * TestUtils.TIMEOUT_LIMIT);
     ORCHESTRATOR.getServer().provisionProject(context.projectKey, context.projectKey);
 
     if (!localExclusions.isEmpty()) // You cannot provide an empty /d:sonar.exclusions="" argument

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
@@ -116,6 +116,7 @@ class MultiLanguageTest {
     // Begin step runs in MultiLanguageSupport
     // Build step runs in MultiLanguageSupport/src
     context.build.addArgument("src/MultiLanguageSupport.sln");
+    context.end.setTimeout(Timeout.TWO_MINUTES);
     // The project needs to be inside a git repository to be able to pick up files for the sonar-text-plugin analysis
     // Otherwise the files will be ignored as not part of a scm repository
     try (var ignored = new CreateGitFolder(context.projectDir)) {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
@@ -23,6 +23,7 @@ import com.sonar.it.scanner.msbuild.utils.AnalysisContext;
 import com.sonar.it.scanner.msbuild.utils.ContextExtension;
 import com.sonar.it.scanner.msbuild.utils.QualityProfiles;
 import com.sonar.it.scanner.msbuild.utils.TestUtils;
+import com.sonar.it.scanner.msbuild.utils.Timeout;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -77,7 +78,7 @@ class MultiLanguageTest {
     // For this test also the .vscode folder has been included in the project folder:
     // https://developercommunity.visualstudio.com/t/visual-studio-2022-freezes-when-opening-esproj-fil/1581344
     var context = AnalysisContext.forServer("VueWithAspBackend");
-    context.build.setTimeout(TestUtils.TIMEOUT_LIMIT * 5);  // Longer timeout because of npm install
+    context.build.setTimeout(Timeout.FIVE_MINUTES);  // Longer timeout because of npm install
     ORCHESTRATOR.getServer().provisionProject(context.projectKey, context.projectKey);
     TestUtils.runNuGet(ORCHESTRATOR, context.projectDir, true, "restore");
     context.runAnalysis();
@@ -202,8 +203,8 @@ class MultiLanguageTest {
   void checkMultiLanguageSupportReact() {
     assumeTrue(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2022")); // .Net 7 is supported by VS 2022 and above
     var context = AnalysisContext.forServer("MultiLanguageSupportReact");
-    context.build.setTimeout(TestUtils.TIMEOUT_LIMIT * 5);  // Longer timeout because of npm install
-    context.end.setTimeout(TestUtils.TIMEOUT_LIMIT * 5);    // End step was timing out, JS is slow
+    context.build.setTimeout(Timeout.FIVE_MINUTES);  // Longer timeout because of npm install
+    context.end.setTimeout(Timeout.FIVE_MINUTES);    // End step was timing out, JS is slow
     context.runAnalysis();
 
     var issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
@@ -229,8 +230,8 @@ class MultiLanguageTest {
   void checkMultiLanguageSupportAngular() {
     assumeTrue(TestUtils.getMsBuildPath(ORCHESTRATOR).toString().contains("2022")); // .Net 7 is supported by VS 2022 and above
     var context = AnalysisContext.forServer("MultiLanguageSupportAngular");
-    context.build.setTimeout(TestUtils.TIMEOUT_LIMIT * 5);  // Longer timeout because of npm install
-    context.end.setTimeout(TestUtils.TIMEOUT_LIMIT * 5);    // End step was timing out, JS is slow
+    context.build.setTimeout(Timeout.FIVE_MINUTES);  // Longer timeout because of npm install
+    context.end.setTimeout(Timeout.FIVE_MINUTES);    // End step was timing out, JS is slow
     context.runAnalysis();
 
     var issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerTest.java
@@ -25,6 +25,7 @@ import com.sonar.it.scanner.msbuild.utils.OSPlatform;
 import com.sonar.it.scanner.msbuild.utils.QualityProfiles;
 import com.sonar.it.scanner.msbuild.utils.ScannerClassifier;
 import com.sonar.it.scanner.msbuild.utils.TestUtils;
+import com.sonar.it.scanner.msbuild.utils.Timeout;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +34,6 @@ import org.sonarqube.ws.Issues.Issue;
 
 import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -116,7 +116,7 @@ class ScannerTest {
     // ensure that the Environment Variable parsing happens for .NET Core versions
     var context = AnalysisContext.forServer("DuplicateAnalyzerReferences", ScannerClassifier.NET);
     context.begin.setEnvironmentVariable("SONARQUBE_SCANNER_PARAMS", "{}");
-    context.build.addArgument("-v:m").setTimeout(5 * 60 * 1000);
+    context.build.addArgument("-v:m").setTimeout(Timeout.FIVE_MINUTES);
     var logs = context.runAnalysis().end().getLogs();
     var issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BaseCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BaseCommand.java
@@ -55,5 +55,4 @@ public abstract class BaseCommand<T extends BaseCommand<T>> {
     this.timeout = timeout;
     return self();
   }
-
 }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BaseCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BaseCommand.java
@@ -27,6 +27,7 @@ public abstract class BaseCommand<T extends BaseCommand<T>> {
 
   protected final Path projectDir;
   protected final Map<String, String> environment = new HashMap();
+  protected Timeout timeout = Timeout.ONE_MINUTE;
 
   protected abstract T self();
 
@@ -49,4 +50,10 @@ public abstract class BaseCommand<T extends BaseCommand<T>> {
     }
     return self();
   }
+
+  public T setTimeout(Timeout timeout) {
+    this.timeout = timeout;
+    return self();
+  }
+
 }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BuildCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BuildCommand.java
@@ -40,16 +40,10 @@ public class BuildCommand extends BaseCommand<BuildCommand> {
   private static final Logger LOG = LoggerFactory.getLogger(BuildCommand.class);
 
   private final ArrayList<String> arguments = new ArrayList<>();
-  private long timeout = 60 * 1000;
   private String dotnetCommand;
 
   public BuildCommand(Path projectDir) {
     super(projectDir);
-  }
-
-  public BuildCommand setTimeout(long timeout) {
-    this.timeout = timeout;
-    return this;
   }
 
   public BuildCommand useDotNet() {
@@ -70,7 +64,7 @@ public class BuildCommand extends BaseCommand<BuildCommand> {
     var command = createCommand();
     var result = new BuildResult();
     LOG.info("Build command start: '{}' in {}", command.toCommandLine(), command.getDirectory());
-    result.addStatus(CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), timeout));
+    result.addStatus(CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), timeout.miliseconds));
     assertThat(result.isSuccess()).describedAs("BUILD step failed. Logs: " + result.getLogs()).isTrue();
     LOG.info("Build command finish: '{}' in {}", command.toCommandLine(), command.getDirectory());
     return result;

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/GeneralCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/GeneralCommand.java
@@ -28,22 +28,15 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.sonar.it.scanner.msbuild.utils.TestUtils.LOG;
-import static com.sonar.it.scanner.msbuild.utils.TestUtils.TIMEOUT_LIMIT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GeneralCommand extends BaseCommand<GeneralCommand> {
   private final String command;
-  private long timeout = TIMEOUT_LIMIT;
   private final ArrayList<String> arguments = new ArrayList<>();
 
   public GeneralCommand(String command, Path workingDirectory) {
     super(workingDirectory);
     this.command = command;
-  }
-
-  public GeneralCommand setTimeout(long timeout) {
-    this.timeout = timeout;
-    return this;
   }
 
   public GeneralCommand addArgument(String arg) {
@@ -62,7 +55,7 @@ public class GeneralCommand extends BaseCommand<GeneralCommand> {
     var commandLine = command.toCommandLine();
     LOG.info("Command line start: '{}' in {}", commandLine, command.getDirectory());
     var result = new BuildResult();
-    var returnCode = CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), timeout);
+    var returnCode = CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), timeout.miliseconds);
     result.addStatus(returnCode);
     assertThat(result.isSuccess()).describedAs("Command '" + commandLine + "' failed with logs: " + result.getLogs()).isTrue();
     LOG.info("Command line finish: '{}' in {}", commandLine, command.getDirectory());

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -48,7 +48,6 @@ public class ScannerCommand extends BaseCommand<ScannerCommand> {
   private final String projectKey;
   private final Map<String, String> properties = new HashMap();
   private String organization;
-  private long timeout = TestUtils.TIMEOUT_LIMIT;
 
   private ScannerCommand(Step step, ScannerClassifier classifier, String token, Path projectDir, @Nullable String projectKey) {
     super(projectDir);
@@ -100,16 +99,11 @@ public class ScannerCommand extends BaseCommand<ScannerCommand> {
     return this;
   }
 
-  public ScannerCommand setTimeout(long timeout) {
-    this.timeout = timeout;
-    return this;
-  }
-
   public BuildResult execute(Orchestrator orchestrator) {
     var command = createCommand(orchestrator);
     var result = new BuildResult();
     LOG.info("Scanner command start: '{}' in {}", command.toCommandLine(), command.getDirectory());
-    result.addStatus(CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), timeout));
+    result.addStatus(CommandExecutor.create().execute(command, new StreamConsumer.Pipe(result.getLogsWriter()), timeout.miliseconds));
     LOG.info("Scanner command finish: '{}' in {}", command.toCommandLine(), command.getDirectory());
     if (step == Step.end) {
       if (orchestrator == null) {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
@@ -68,6 +68,7 @@ public class TestUtils {
   private static final int MSBUILD_RETRY = 3;
   private static final String NUGET_PATH = "NUGET_PATH";
 
+  // ToDo: Remove in SCAN4NET-201
   public static final long TIMEOUT_LIMIT = 60 * 1000L;
   public static final String MSBUILD_DEFAULT_PATH = "C:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\MSBuild\\Current\\Bin\\MSBuild.exe";
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/Timeout.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/Timeout.java
@@ -1,0 +1,32 @@
+/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.it.scanner.msbuild.utils;
+
+public enum Timeout {
+  ONE_MINUTE(1),
+  TWO_MINUTES(2),
+  FIVE_MINUTES(5);
+
+  public final long miliseconds;
+
+  Timeout(int minutes) {
+    this.miliseconds = minutes * 60 * 1000;
+  }
+}


### PR DESCRIPTION
[SCAN4NET-386](https://sonarsource.atlassian.net/browse/SCAN4NET-386)

SCAN4NET-12 reduced the `end` step timeout from 120sec to 60sec. Some of the ITs need to be restored back

[SCAN4NET-386]: https://sonarsource.atlassian.net/browse/SCAN4NET-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ