### PR TITLE
SCAN4NET-388 Provide testRunTitle to Linux/MacOS UT

### DIFF
--- a/templates/unix-qa-stage.yml
+++ b/templates/unix-qa-stage.yml
@@ -20,6 +20,7 @@ stages:
             inputs:
               command: 'test'
               arguments: '--framework net9.0  --filter "Testcategory!=NoUnixNeedsReview"'
+              testRunTitle: UTs ${{ parameters.name }}
             env:
               ARTIFACTORY_USER: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
               ARTIFACTORY_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)


### PR DESCRIPTION
[SCAN4NET-388]

UTs in the overview are displayed like this now:
![image](https://github.com/user-attachments/assets/366db61f-f73c-4db0-a817-e99d0c57a68a)
instead of:
![image](https://github.com/user-attachments/assets/3853f1a2-c9a5-42b9-9679-630212133fce)


[SCAN4NET-388]: https://sonarsource.atlassian.net/browse/SCAN4NET-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ