### PR TITLE
SCAN4NET-394 Fix SonarScanner.MSBuild.PreProcessor.Test.CertificateBuilderTests UTs on Linux/MacOS

### DIFF
--- a/SonarScanner.MSBuild.sln
+++ b/SonarScanner.MSBuild.sln
@@ -43,6 +43,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NuGet.Config = NuGet.Config
 		README.md = README.md
 		StylingAnalyzers.targets = StylingAnalyzers.targets
+		templates\its-jobs.yml = templates\its-jobs.yml
+		templates\unix-qa-stage.yml = templates\unix-qa-stage.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogArgs", "Tests\LogArgs\LogArgs.csproj", "{25334485-0BF1-4A3D-A1B6-E646D89D15DB}"

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilder.Net.Tests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilder.Net.Tests.cs
@@ -29,6 +29,7 @@ namespace SonarScanner.MSBuild.PreProcessor.Test.Certificates;
 
 public partial class CertificateBuilderTests
 {
+    [TestCategory(TestCategories.NoMacOS)]
     [TestMethod]
     public async Task CrlListIsRequestedWithCustomTrustStore()
     {
@@ -59,6 +60,7 @@ public partial class CertificateBuilderTests
         crlServer.LogEntries.Should().Contain(x => x.RequestMessage.Path == $"/Revoked.crl");
     }
 
+    [TestCategory(TestCategories.NoMacOS)]
     [TestMethod]
     public async Task CrlListIsRequestedAndRevokedCertificateIsDetected()
     {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilder.Net.Tests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilder.Net.Tests.cs
@@ -20,11 +20,7 @@
 
 #if NET
 
-using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -33,7 +29,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test.Certificates;
 
 public partial class CertificateBuilderTests
 {
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public async Task CrlListIsRequestedWithCustomTrustStore()
     {
@@ -48,7 +43,7 @@ public partial class CertificateBuilderTests
         using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingGet()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
         using var handler = new HttpClientHandler();
-        handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+        handler.ServerCertificateCustomValidationCallback = (_, cert, _, _) =>
         {
             using var testChain = new X509Chain();
             testChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
@@ -64,7 +59,6 @@ public partial class CertificateBuilderTests
         crlServer.LogEntries.Should().Contain(x => x.RequestMessage.Path == $"/Revoked.crl");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public async Task CrlListIsRequestedAndRevokedCertificateIsDetected()
     {
@@ -81,7 +75,7 @@ public partial class CertificateBuilderTests
         using var server = ServerBuilder.StartServer(serverCert);
         server.Given(Request.Create().WithPath("/").UsingGet()).RespondWith(Response.Create().WithStatusCode(200).WithBody("Hello World"));
         using var handler = new HttpClientHandler();
-        handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+        handler.ServerCertificateCustomValidationCallback = (_, cert, _, _) =>
         {
             using var testChain = new X509Chain();
             testChain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilder.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilder.cs
@@ -83,7 +83,7 @@ internal static partial class CertificateBuilder
         using var rsa = RSA.Create(keyLength);
         var keyToUse = privateKey ?? rsa;
         var request = new CertificateRequest($"CN={name}", keyToUse, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(certificateAuthority: true, false, 0, true));
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(certificateAuthority: true, false, 0, false));
         request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
         request.CertificateExtensions.Add(new X509KeyUsageExtension(keyUsage, true));
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilder.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilder.cs
@@ -83,7 +83,7 @@ internal static partial class CertificateBuilder
         using var rsa = RSA.Create(keyLength);
         var keyToUse = privateKey ?? rsa;
         var request = new CertificateRequest($"CN={name}", keyToUse, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(certificateAuthority: true, false, 0, false));
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(certificateAuthority: true, false, 0, true));
         request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
         request.CertificateExtensions.Add(new X509KeyUsageExtension(keyUsage, true));
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
@@ -64,6 +64,7 @@ public partial class CertificateBuilderTests
         handler.ServerCertificateCustomValidationCallback = (_, cert, chain, _) =>
         {
             cert.Should().BeEquivalentTo(webServerCert);
+            // On MacOS, the server serves the Root CA, and the certificate.
             chain.ChainElements.Count.Should().Be(RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 2 : 1, because: "A web server only serves the certificate, intermediate CAs, but not the Root CA.");
             serverCertificateValidation = true;
             return true;
@@ -88,6 +89,7 @@ public partial class CertificateBuilderTests
         handler.ServerCertificateCustomValidationCallback = (_, cert, chain, _) =>
         {
             cert.Should().BeEquivalentTo(webServerCert);
+            // On MacOS, the server serves the Root CA, Intermediate CA, and the certificate.
             chain.ChainElements.Count.Should().Be(RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 3 : 2,
                 because: "A web server serves the certificate and the intermediate CAs. Can also be confirmed via 'openssl.exe s_client -connect localhost:8443'");
             serverCertificateValidation = true;

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
@@ -72,7 +72,6 @@ public partial class CertificateBuilderTests
         serverCertificateValidation.Should().BeTrue();
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public async Task MockServerReturnsIntermediateCASignedCert()
     {
@@ -97,7 +96,6 @@ public partial class CertificateBuilderTests
         serverCertificateValidation.Should().BeTrue();
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [DataTestMethod]
     [DataRow("localhost", false)]
     [DataRow(null, true)]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
@@ -49,7 +49,6 @@ public partial class CertificateBuilderTests
         serverCertificateValidation.Should().BeTrue();
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public async Task MockServerReturnsRootCASignedCert()
     {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
@@ -18,12 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 
@@ -33,7 +29,6 @@ namespace SonarScanner.MSBuild.PreProcessor.Test.Certificates;
 [DoNotParallelize]
 public partial class CertificateBuilderTests
 {
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public async Task MockServerReturnsSelfSignedCertificate()
     {
@@ -43,7 +38,7 @@ public partial class CertificateBuilderTests
         using var handler = new HttpClientHandler();
         using var client = new HttpClient(handler);
         bool serverCertificateValidation = false;
-        handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+        handler.ServerCertificateCustomValidationCallback = (_, cert, _, _) =>
         {
             cert.Should().BeEquivalentTo(selfSigned);
             serverCertificateValidation = true;
@@ -66,7 +61,7 @@ public partial class CertificateBuilderTests
         using var handler = new HttpClientHandler();
         using var client = new HttpClient(handler);
         bool serverCertificateValidation = false;
-        handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+        handler.ServerCertificateCustomValidationCallback = (_, cert, chain, _) =>
         {
             cert.Should().BeEquivalentTo(webServerCert);
             chain.ChainElements.Count.Should().Be(1, because: "A web server only serves the certificate, intermediate CAs, but not the Root CA.");
@@ -91,7 +86,7 @@ public partial class CertificateBuilderTests
         using var handler = new HttpClientHandler();
         using var client = new HttpClient(handler);
         bool serverCertificateValidation = false;
-        handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+        handler.ServerCertificateCustomValidationCallback = (_, cert, chain, _) =>
         {
             cert.Should().BeEquivalentTo(webServerCert);
             chain.ChainElements.Count.Should().Be(2, because: "A web server serves the certificate and the intermediate CAs. Can also be confirmed via 'openssl.exe s_client -connect localhost:8443'");
@@ -122,7 +117,7 @@ public partial class CertificateBuilderTests
         using var handler = new HttpClientHandler();
         using var client = new HttpClient(handler);
         bool serverCertificateValidation = false;
-        handler.ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
+        handler.ServerCertificateCustomValidationCallback = (_, cert, _, errors) =>
         {
             cert.Should().BeEquivalentTo(selfSigned);
             errors.HasFlag(SslPolicyErrors.RemoteCertificateChainErrors).Should().BeTrue();

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/ServerBuilder.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/ServerBuilder.cs
@@ -21,6 +21,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using WireMock.Server;
@@ -81,7 +82,10 @@ internal static class ServerBuilder
 #endif
         foreach (var newCertificate in newCertificates)
         {
-            newCertificate.FriendlyName = FriendlyNameIdentifier; // This is used to identify the certificate later so we can remove it
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                newCertificate.FriendlyName = FriendlyNameIdentifier; // This is used to identify the certificate later so we can remove it
+            }
             var isCA = newCertificate.Extensions.OfType<X509BasicConstraintsExtension>().Any(x => x.CertificateAuthority);
             if (isCA)
             {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -422,7 +422,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStore.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged("""
-            The webserver returned an invalid certificate which could not be validated against the truststore file specified in sonar.scanner.truststorePath. The validation failed with these errors:
+            The webserver returned an invalid certificate which could not be validated against the truststore file specified in sonar.scanner.truststorePath. The validation failed with these errors: 
             * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
             * A required certificate is not within its validity period when verifying against the current system clock or the timestamp in the signed file.
             """);
@@ -481,7 +481,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are
+            The certificate chain of the web server certificate is invalid. The validation errors are 
             * A certificate chain could not be built to a trusted root authority.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
             """);
@@ -515,7 +515,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are
+            The certificate chain of the web server certificate is invalid. The validation errors are 
             * The signature of the certificate cannot be verified.
             * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
@@ -551,7 +551,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are
+            The certificate chain of the web server certificate is invalid. The validation errors are 
             * The signature of the certificate cannot be verified.
             * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
@@ -587,7 +587,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are
+            The certificate chain of the web server certificate is invalid. The validation errors are 
             * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
             * A required certificate is not within its validity period when verifying against the current system clock or the timestamp in the signed file.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
@@ -646,7 +646,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are
+            The certificate chain of the web server certificate is invalid. The validation errors are 
             * A certificate chain could not be built to a trusted root authority.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
             """);
@@ -678,7 +678,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are
+            The certificate chain of the web server certificate is invalid. The validation errors are 
             * A certificate chain could not be built to a trusted root authority.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
             """);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -422,7 +422,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStore.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged("""
-            The webserver returned an invalid certificate which could not be validated against the truststore file specified in sonar.scanner.truststorePath. The validation failed with these errors: 
+            The webserver returned an invalid certificate which could not be validated against the truststore file specified in sonar.scanner.truststorePath. The validation failed with these errors:
             * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
             * A required certificate is not within its validity period when verifying against the current system clock or the timestamp in the signed file.
             """);
@@ -481,7 +481,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are 
+            The certificate chain of the web server certificate is invalid. The validation errors are
             * A certificate chain could not be built to a trusted root authority.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
             """);
@@ -515,7 +515,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are 
+            The certificate chain of the web server certificate is invalid. The validation errors are
             * The signature of the certificate cannot be verified.
             * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
@@ -551,7 +551,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are 
+            The certificate chain of the web server certificate is invalid. The validation errors are
             * The signature of the certificate cannot be verified.
             * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
@@ -587,7 +587,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are 
+            The certificate chain of the web server certificate is invalid. The validation errors are
             * A certificate chain processed, but terminated in a root certificate which is not trusted by the trust provider.
             * A required certificate is not within its validity period when verifying against the current system clock or the timestamp in the signed file.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
@@ -646,7 +646,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are 
+            The certificate chain of the web server certificate is invalid. The validation errors are
             * A certificate chain could not be built to a trusted root authority.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
             """);
@@ -678,7 +678,7 @@ public partial class WebClientDownloaderBuilderTest
             The remote server certificate is not trusted by the operating system. The scanner is checking the certificate against the certificates provided by the file '{trustStoreFile.FileName}' (specified via the sonar.scanner.truststorePath parameter or its default value).
             """);
         logger.AssertWarningLogged($"""
-            The certificate chain of the web server certificate is invalid. The validation errors are 
+            The certificate chain of the web server certificate is invalid. The validation errors are
             * A certificate chain could not be built to a trusted root authority.
             Check the certificates in the truststore file '{trustStoreFile.FileName}' specified via the sonar.scanner.truststorePath parameter or its default value.
             """);

--- a/Tests/TestUtilities/TestCategories.cs
+++ b/Tests/TestUtilities/TestCategories.cs
@@ -23,4 +23,5 @@ namespace TestUtilities;
 public static class TestCategories
 {
    public const string NoUnixNeedsReview = nameof(NoUnixNeedsReview);
+   public const string NoMacOS = nameof(NoMacOS);
 }

--- a/scripts/run-test-docker.ps1
+++ b/scripts/run-test-docker.ps1
@@ -2,7 +2,9 @@ param (
     [switch]
     $BuildImage = $false,
     [switch]
-    $Its = $False
+    $Its = $False,
+    [string]
+    $TestToRun
 )
 
 # Define the image name and tag
@@ -30,6 +32,8 @@ else {
     Write-Host "Docker image '$fullImageName' already exists."
 }
 
+$TestToRun =  $null -ne $TestToRun ? $TestToRun : ($Its ? "IT" : "UT")
+
 # Run the container
 docker run `
     --tty `
@@ -44,4 +48,4 @@ docker run `
     --env ARTIFACTORY_USER=$env:ARTIFACTORY_USER `
     --env ARTIFACTORY_PASSWORD=$env:ARTIFACTORY_PASSWORD `
     $fullImageName `
-    ./scripts/run-test-linux.ps1 -TestToRun ($Its ? "IT" : "UT")
+    ./scripts/run-test-linux.ps1 -TestToRun $TestToRun

--- a/scripts/run-test-wsl.ps1
+++ b/scripts/run-test-wsl.ps1
@@ -1,6 +1,8 @@
 param (
     [switch]
-    $Its = $false
+    $Its = $false,
+    [string]
+    $TestToRun
 )
 
 # Check if running in WSL
@@ -59,4 +61,6 @@ if ($MissingDeps.Count -gt 0) {
     exit 1
 }
 
-pwsh scripts/run-test-linux.ps1 -TestToRun ($Its ? "IT" : "UT")
+$TestToRun =  $null -ne $TestToRun ? $TestToRun : ($Its ? "IT" : "UT")
+
+pwsh scripts/run-test-linux.ps1 -TestToRun $TestToRun

--- a/templates/unix-qa-stage.yml
+++ b/templates/unix-qa-stage.yml
@@ -19,7 +19,7 @@ stages:
           - task: DotNetCoreCLI@2
             inputs:
               command: 'test'
-              arguments: '--framework net9.0  --filter "Testcategory!=NoUnixNeedsReview"'
+              arguments: '--framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=No${{ parameters.name }}"'
               testRunTitle: UTs ${{ parameters.name }}
             env:
               ARTIFACTORY_USER: $(ARTIFACTORY_PRIVATE_READER_USERNAME)


### PR DESCRIPTION
[SCAN4NET-394](https://sonarsource.atlassian.net/browse/SCAN4NET-394)

Part of SCAN4NET-311

[SCAN4NET-394]: https://sonarsource.atlassian.net/browse/SCAN4NET-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ