### PR TITLE
SCAN4NET-418 [To be reverted] Point runner to ubuntu-22.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -431,7 +431,7 @@ stages:
 
   - template: templates/unix-qa-stage.yml
     parameters:
-      vmImage: "ubuntu-latest"
+      vmImage: "ubuntu-22.04"
       name: "Linux"
 
   - template: templates/unix-qa-stage.yml

--- a/templates/unix-qa-stage.yml
+++ b/templates/unix-qa-stage.yml
@@ -20,7 +20,7 @@ stages:
             displayName: 'Run dotnet test'
             inputs:
               command: 'test'
-              arguments: '--framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=No${{ parameters.name }}"'
+              arguments: '--framework net8.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=No${{ parameters.name }}"'
               testRunTitle: UTs ${{ parameters.name }}
             env:
               ARTIFACTORY_USER: $(ARTIFACTORY_PRIVATE_READER_USERNAME)

--- a/templates/unix-qa-stage.yml
+++ b/templates/unix-qa-stage.yml
@@ -20,7 +20,7 @@ stages:
             displayName: 'Run dotnet test'
             inputs:
               command: 'test'
-              arguments: '--framework net8.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=No${{ parameters.name }}"'
+              arguments: '--framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=No${{ parameters.name }}"'
               testRunTitle: UTs ${{ parameters.name }}
             env:
               ARTIFACTORY_USER: $(ARTIFACTORY_PRIVATE_READER_USERNAME)


### PR DESCRIPTION
[SCAN4NET-418](https://sonarsource.atlassian.net/browse/SCAN4NET-418)



[SCAN4NET-418]: https://sonarsource.atlassian.net/browse/SCAN4NET-418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


`ubuntu-latest` now points to `ubuntu-24.04` which does not contain the .NET9 SDK/runtime.
We'll temporality point to `ubuntu-22.04`.
Github issue opened to solve the issue: https://github.com/actions/runner-images/issues/11965