### PR TITLE
SCAN4NET-419 Fix SlackNotification runner

### DIFF
--- a/.github/workflows/SlackNotification.yml
+++ b/.github/workflows/SlackNotification.yml
@@ -13,7 +13,7 @@ jobs:
   slack-notifications:
     if: >-
       contains(fromJSON('["main", "master"]'), github.event.check_suite.head_branch) || startsWith(github.event.check_suite.head_branch, 'dogfood-') || startsWith(github.event.check_suite.head_branch, 'branch-')
-    runs-on: sonar-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Send Slack Notification
         env:


### PR DESCRIPTION
[SCAN4NET-419](https://sonarsource.atlassian.net/browse/SCAN4NET-419)

sonar-runner is not available to public repos

[SCAN4NET-419]: https://sonarsource.atlassian.net/browse/SCAN4NET-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ