### PR TITLE
SCAN4NET-324 Disable CppTest ITs on Linux & MacOS

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CppTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CppTest.java
@@ -35,6 +35,8 @@ import java.nio.file.Path;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarqube.ws.Issues.Issue;
 
@@ -44,8 +46,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Only cpp, without C# plugin
  */
-// See task https://github.com/SonarSource/sonar-scanner-msbuild/issues/789
 @ExtendWith({ServerTests.class, ContextExtension.class})
+@EnabledOnOs(OS.WINDOWS)
 class CppTest {
 
   @Test

--- a/templates/unix-qa-stage.yml
+++ b/templates/unix-qa-stage.yml
@@ -39,7 +39,7 @@ stages:
             LATEST_RELEASE:
               PRODUCT: "SonarQube"
               SQ_VERSION: "LATEST_RELEASE"
-              TEST_INCLUDE: "**/sonarqube/ScannerTest*,**/sonarqube/SslTest*,**/sonarqube/JreProvisioningTest*,**/sonarqube/ParameterTest*,**/sonarqube/IncrementalPRAnalysisTest*"
+              TEST_INCLUDE: "**/sonarqube/ScannerTest*,**/sonarqube/SslTest*,**/sonarqube/JreProvisioningTest*,**/sonarqube/ParameterTest*,**/sonarqube/IncrementalPRAnalysisTest*,**/sonarqube/CppTest*"
             Cloud:
               PRODUCT: "SonarCloud"
               SQ_VERSION: ""


### PR DESCRIPTION
[SCAN4NET-324](https://sonarsource.atlassian.net/browse/SCAN4NET-324)

The tests has been disabled on Linux and MacOS.
The project built is using windows specific dependencies.


[SCAN4NET-324]: https://sonarsource.atlassian.net/browse/SCAN4NET-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ