### PR TITLE
SCAN4NET-485 Add Provider Kind to IAnalysisPropertyProvider

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/AggregatePropertiesProviderTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/AggregatePropertiesProviderTests.cs
@@ -99,7 +99,7 @@ public class AggregatePropertiesProviderTests
     [TestMethod]
     public void AggProperties_GetAllPropertiesPerProvider()
     {
-        var listPropertiesProvider = new ListPropertiesProvider();
+        var listPropertiesProvider = new ListPropertiesProvider(PropertyProviderKind.SQ_SERVER_SETTINGS);
         listPropertiesProvider.AddProperty("shared.key.A", "value A from one");
         listPropertiesProvider.AddProperty("key.B", "value B from one");
         listPropertiesProvider.AddProperty("p1.unique.key.1", "p1 unique value 1");
@@ -121,7 +121,7 @@ public class AggregatePropertiesProviderTests
         };
 
         aggProvider.AssertExpectedPropertyCount(4);
-        aggProvider.GetAllPropertiesPerProvider().ToDictionary(x => x.Key.Id, x => x.Value.ProviderType).Should().BeEquivalentTo(expected);
+        aggProvider.GetAllPropertiesWithProvider().ToDictionary(x => x.Key.Id, x => x.Value.ProviderType).Should().BeEquivalentTo(expected);
     }
 
     #endregion Tests

--- a/Tests/SonarScanner.MSBuild.Common.Test/AggregatePropertiesProviderTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/AggregatePropertiesProviderTests.cs
@@ -18,13 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Security.Cryptography;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSubstitute;
-using TestUtilities;
-
 namespace SonarScanner.MSBuild.Common.Test;
 
 [TestClass]
@@ -112,16 +105,32 @@ public class AggregatePropertiesProviderTests
         _ = CmdLineArgPropertyProvider.TryCreateProvider(args, new TestLogger(), out var commandLineProvider);
 
         var aggProvider = new AggregatePropertiesProvider(commandLineProvider, listPropertiesProvider);
-        var expected = new Dictionary<string, PropertyProviderKind>
-        {
-            { "key.B", PropertyProviderKind.SQ_SERVER_SETTINGS },
-            { "p1.unique.key.1", PropertyProviderKind.SQ_SERVER_SETTINGS },
-            { "shared.key.A", PropertyProviderKind.CLI },
-            { "p2.unique.key.1", PropertyProviderKind.CLI },
-        };
-
         aggProvider.AssertExpectedPropertyCount(4);
-        aggProvider.GetAllPropertiesWithProvider().ToDictionary(x => x.Key.Id, x => x.Value.ProviderType).Should().BeEquivalentTo(expected);
+        aggProvider.GetAllPropertiesWithProvider().Should().SatisfyRespectively(
+            x0 =>
+            {
+                x0.Key.Id.Should().Be("shared.key.A");
+                x0.Key.Value.Should().Be("value A from one");
+                x0.Value.ProviderType.Should().Be(PropertyProviderKind.CLI);
+            },
+            x1 =>
+            {
+                x1.Key.Id.Should().Be("p2.unique.key.1");
+                x1.Key.Value.Should().Be("p2 unique value 1");
+                x1.Value.ProviderType.Should().Be(PropertyProviderKind.CLI);
+            },
+            x2 =>
+            {
+                x2.Key.Id.Should().Be("key.B");
+                x2.Key.Value.Should().Be("value B from one");
+                x2.Value.ProviderType.Should().Be(PropertyProviderKind.SQ_SERVER_SETTINGS);
+            },
+            x3 =>
+            {
+                x3.Key.Id.Should().Be("p1.unique.key.1");
+                x3.Key.Value.Should().Be("p1 unique value 1");
+                x3.Value.ProviderType.Should().Be(PropertyProviderKind.SQ_SERVER_SETTINGS);
+            });
     }
 
     #endregion Tests

--- a/Tests/SonarScanner.MSBuild.Common.Test/AggregatePropertiesProviderTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/AggregatePropertiesProviderTests.cs
@@ -107,29 +107,29 @@ public class AggregatePropertiesProviderTests
         var aggProvider = new AggregatePropertiesProvider(commandLineProvider, listPropertiesProvider);
         aggProvider.AssertExpectedPropertyCount(4);
         aggProvider.GetAllPropertiesWithProvider().Should().SatisfyRespectively(
-            x0 =>
+            x =>
             {
-                x0.Key.Id.Should().Be("shared.key.A");
-                x0.Key.Value.Should().Be("value A from one");
-                x0.Value.ProviderType.Should().Be(PropertyProviderKind.CLI);
+                x.Key.Id.Should().Be("shared.key.A");
+                x.Key.Value.Should().Be("value A from one");
+                x.Value.ProviderType.Should().Be(PropertyProviderKind.CLI);
             },
-            x1 =>
+            x =>
             {
-                x1.Key.Id.Should().Be("p2.unique.key.1");
-                x1.Key.Value.Should().Be("p2 unique value 1");
-                x1.Value.ProviderType.Should().Be(PropertyProviderKind.CLI);
+                x.Key.Id.Should().Be("p2.unique.key.1");
+                x.Key.Value.Should().Be("p2 unique value 1");
+                x.Value.ProviderType.Should().Be(PropertyProviderKind.CLI);
             },
-            x2 =>
+            x =>
             {
-                x2.Key.Id.Should().Be("key.B");
-                x2.Key.Value.Should().Be("value B from one");
-                x2.Value.ProviderType.Should().Be(PropertyProviderKind.SQ_SERVER_SETTINGS);
+                x.Key.Id.Should().Be("key.B");
+                x.Key.Value.Should().Be("value B from one");
+                x.Value.ProviderType.Should().Be(PropertyProviderKind.SQ_SERVER_SETTINGS);
             },
-            x3 =>
+            x =>
             {
-                x3.Key.Id.Should().Be("p1.unique.key.1");
-                x3.Key.Value.Should().Be("p1 unique value 1");
-                x3.Value.ProviderType.Should().Be(PropertyProviderKind.SQ_SERVER_SETTINGS);
+                x.Key.Id.Should().Be("p1.unique.key.1");
+                x.Key.Value.Should().Be("p1 unique value 1");
+                x.Value.ProviderType.Should().Be(PropertyProviderKind.SQ_SERVER_SETTINGS);
             });
     }
 

--- a/Tests/SonarScanner.MSBuild.Common.Test/AnalysisProperties/AnalysisPropertyProviderExtensionsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/AnalysisProperties/AnalysisPropertyProviderExtensionsTests.cs
@@ -18,10 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-
 namespace SonarScanner.MSBuild.Common.Test;
 
 [TestClass]

--- a/Tests/SonarScanner.MSBuild.Common.Test/EmptyPropertyProviderTest.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/EmptyPropertyProviderTest.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarScanner.MSBuild.Common.Test;
+
+[TestClass]
+public class EmptyPropertyProviderTest
+{
+    [TestMethod]
+    public void EmptyPropertyProvider_HasCorrectProviderType() =>
+        EmptyPropertyProvider.Instance.ProviderType.Should().Be(PropertyProviderKind.UNKNOWN);
+}

--- a/Tests/SonarScanner.MSBuild.Common.Test/EnvScannerPropertiesProviderTest.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/EnvScannerPropertiesProviderTest.cs
@@ -18,12 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Linq;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using TestUtilities;
-
 namespace SonarScanner.MSBuild.Common.Test;
 
 [TestClass]
@@ -69,4 +63,8 @@ public class EnvScannerPropertiesProviderTest
         var provider = new EnvScannerPropertiesProvider(null);
         provider.GetAllProperties().Should().BeEmpty();
     }
+
+    [TestMethod]
+    public void EnvScannerProvider_HasCorrectProviderType() =>
+        new EnvScannerPropertiesProvider("""{"key": "value"}""").ProviderType.Should().Be(PropertyProviderKind.SONARQUBE_SCANNER_PARAMS);
 }

--- a/Tests/SonarScanner.MSBuild.Common.Test/FilePropertyProviderTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/FilePropertyProviderTests.cs
@@ -18,13 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using TestUtilities;
 
 namespace SonarScanner.MSBuild.Common.Test;
 
@@ -173,6 +167,16 @@ public class FilePropertyProviderTests
         // Assert
         logger.AssertErrorsLogged(1);
         logger.AssertSingleErrorExists(invalidFile);
+    }
+
+    [TestMethod]
+    public void FileProvider_HasCorrectProviderType()
+    {
+        var defaultPropertiesDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
+        _ = CreateValidPropertiesFile(defaultPropertiesDir, FilePropertyProvider.DefaultFileName, "key1", "value1");
+        var provider = CheckProcessingSucceeds(new List<ArgumentInstance>(), defaultPropertiesDir, new TestLogger());
+
+        provider.ProviderType.Should().Be(PropertyProviderKind.SONARQUBE_ANALYSIS_XML);
     }
 
     #endregion Tests

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/AggregatePropertiesProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/AggregatePropertiesProvider.cs
@@ -42,23 +42,10 @@ public class AggregatePropertiesProvider : IAnalysisPropertyProvider
 
     #region IAnalysisPropertyProvider interface
 
-    public IEnumerable<Property> GetAllProperties()
-    {
-        var allKeys = new HashSet<string>(providers.SelectMany(x => x.GetAllProperties().Select(x => x.Id)));
+    public IEnumerable<Property> GetAllProperties() =>
+        GetAllPropertiesWithProvider().Select(x => x.Key);
 
-        IList<Property> allProperties = [];
-        foreach (var key in allKeys)
-        {
-            var match = TryGetProperty(key, out var property);
-
-            Debug.Assert(match, "Expecting to find value for all keys. Key: " + key);
-            allProperties.Add(property);
-        }
-
-        return allProperties;
-    }
-
-    public IEnumerable<KeyValuePair<Property, IAnalysisPropertyProvider>> GetAllPropertiesPerProvider()
+    public IEnumerable<KeyValuePair<Property, IAnalysisPropertyProvider>> GetAllPropertiesWithProvider()
     {
         var allKeys = new HashSet<string>(providers.SelectMany(x => x.GetAllProperties().Select(x => x.Id)));
 

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/AggregatePropertiesProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/AggregatePropertiesProvider.cs
@@ -32,15 +32,17 @@ namespace SonarScanner.MSBuild.Common;
 public class AggregatePropertiesProvider : IAnalysisPropertyProvider
 {
     /// <summary>
-    /// Ordered list of child providers
+    /// Ordered list of child providers.
     /// </summary>
-    private readonly IAnalysisPropertyProvider[] providers;
+    public IAnalysisPropertyProvider[] Providers { get; }
+
+    public PropertyProviderKind ProviderType => PropertyProviderKind.UNKNOWN;
 
     #region Public methods
 
     public AggregatePropertiesProvider(params IAnalysisPropertyProvider[] providers)
     {
-        this.providers = providers ?? throw new ArgumentNullException(nameof(providers));
+        Providers = providers ?? throw new ArgumentNullException(nameof(providers));
     }
 
     #endregion Public methods
@@ -49,9 +51,9 @@ public class AggregatePropertiesProvider : IAnalysisPropertyProvider
 
     public IEnumerable<Property> GetAllProperties()
     {
-        var allKeys = new HashSet<string>(providers.SelectMany(p => p.GetAllProperties().Select(s => s.Id)));
+        var allKeys = new HashSet<string>(Providers.SelectMany(p => p.GetAllProperties().Select(s => s.Id)));
 
-        IList<Property> allProperties = new List<Property>();
+        IList<Property> allProperties = [];
         foreach (var key in allKeys)
         {
             var match = TryGetProperty(key, out var property);
@@ -67,7 +69,7 @@ public class AggregatePropertiesProvider : IAnalysisPropertyProvider
     {
         property = null;
 
-        foreach (var current in providers)
+        foreach (var current in Providers)
         {
             if (current.TryGetProperty(key, out property))
             {

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/AggregatePropertiesProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/AggregatePropertiesProvider.cs
@@ -54,7 +54,7 @@ public class AggregatePropertiesProvider : IAnalysisPropertyProvider
         {
             var match = TryGetProperty(key, out var property, out var provider);
             Debug.Assert(match, "Expecting to find value for all keys. Key: " + key);
-            allProperties.Add(new KeyValuePair<Property, IAnalysisPropertyProvider>(property, provider));
+            allProperties.Add(new(property, provider));
         }
 
         return allProperties;

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/CmdLineArgPropertyProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/CmdLineArgPropertyProvider.cs
@@ -32,11 +32,13 @@ public class CmdLineArgPropertyProvider : IAnalysisPropertyProvider
 {
     public const string DynamicPropertyArgumentId = "dynamic.property";
 
-    public static readonly ArgumentDescriptor Descriptor = new ArgumentDescriptor(
+    public static readonly ArgumentDescriptor Descriptor = new(
         id: DynamicPropertyArgumentId, prefixes: CommandLineFlagPrefix.GetPrefixedFlags("d:"), required: false, allowMultiple: true,
         description: Resources.CmdLine_ArgDescription_DynamicProperty);
 
     private readonly IEnumerable<Property> properties;
+
+    public PropertyProviderKind ProviderType => PropertyProviderKind.CLI;
 
     #region Public methods
 
@@ -46,14 +48,13 @@ public class CmdLineArgPropertyProvider : IAnalysisPropertyProvider
     /// <param name="commandLineArguments">List of command line arguments (optional)</param>
     /// <returns>False if errors occurred when constructing the provider, otherwise true</returns>
     /// <remarks>If no properties were provided on the command line then an empty provider will be returned</remarks>
-    public static bool TryCreateProvider(IEnumerable<ArgumentInstance> commandLineArguments, ILogger logger,
-        out IAnalysisPropertyProvider provider)
+    public static bool TryCreateProvider(IEnumerable<ArgumentInstance> commandLineArguments, ILogger logger, out IAnalysisPropertyProvider provider)
     {
-        if (commandLineArguments == null)
+        if (commandLineArguments is null)
         {
             throw new ArgumentNullException(nameof(commandLineArguments));
         }
-        if (logger == null)
+        if (logger is null)
         {
             throw new ArgumentNullException(nameof(logger));
         }
@@ -80,15 +81,11 @@ public class CmdLineArgPropertyProvider : IAnalysisPropertyProvider
 
     #region IAnalysisPropertyProvider interface
 
-    public bool TryGetProperty(string key, out Property property)
-    {
-        return Property.TryGetProperty(key, properties, out property);
-    }
+    public bool TryGetProperty(string key, out Property property) =>
+        Property.TryGetProperty(key, properties, out property);
 
-    public IEnumerable<Property> GetAllProperties()
-    {
-        return properties ?? Enumerable.Empty<Property>();
-    }
+    public IEnumerable<Property> GetAllProperties() =>
+        properties ?? [];
 
     #endregion IAnalysisPropertyProvider interface
 
@@ -112,8 +109,7 @@ public class CmdLineArgPropertyProvider : IAnalysisPropertyProvider
     /// Analysis properties (/d:[key]=[value] arguments) need further processing. We need
     /// to extract the key-value pairs and check for duplicate keys.
     /// </remarks>
-    private static bool ExtractAndValidateProperties(IEnumerable<ArgumentInstance> arguments, ILogger logger,
-        out IEnumerable<Property> analysisProperties)
+    private static bool ExtractAndValidateProperties(IEnumerable<ArgumentInstance> arguments, ILogger logger, out IEnumerable<Property> analysisProperties)
     {
         var containsDuplicateProperty = false;
         var containsAnalysisProperty = false;
@@ -166,8 +162,7 @@ public class CmdLineArgPropertyProvider : IAnalysisPropertyProvider
             !containsUnsettableWorkingDirectory;
     }
 
-    private static bool ContainsNamedParameter(string propertyName, IEnumerable<Property> properties, ILogger logger,
-        string errorMessage)
+    private static bool ContainsNamedParameter(string propertyName, IEnumerable<Property> properties, ILogger logger, string errorMessage)
     {
         if (Property.TryGetProperty(propertyName, properties, out var existing))
         {

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/EnvScannerPropertiesProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/EnvScannerPropertiesProvider.cs
@@ -62,7 +62,7 @@ public class EnvScannerPropertiesProvider : IAnalysisPropertyProvider
     public bool TryGetProperty(string key, out Property property) =>
         Property.TryGetProperty(key, properties, out property);
 
-    private IEnumerable<Property> ParseVar(string json) =>
+    private static IEnumerable<Property> ParseVar(string json) =>
         JObject.Parse(json)
             .Properties()
             .Select(x => new Property(x.Name, x.Value.ToString()));

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/EnvScannerPropertiesProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/EnvScannerPropertiesProvider.cs
@@ -18,9 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Newtonsoft.Json.Linq;
 
 namespace SonarScanner.MSBuild.Common;
@@ -33,9 +30,16 @@ public class EnvScannerPropertiesProvider : IAnalysisPropertyProvider
     public static readonly string ENV_VAR_KEY = "SONARQUBE_SCANNER_PARAMS";
     private readonly IEnumerable<Property> properties;
 
+    public PropertyProviderKind ProviderType => PropertyProviderKind.SONARQUBE_SCANNER_PARAMS;
+
+    public EnvScannerPropertiesProvider(string json)
+    {
+        properties = (json is null) ? [] : ParseVar(json);
+    }
+
     public static bool TryCreateProvider(ILogger logger, out IAnalysisPropertyProvider provider)
     {
-        if (logger == null)
+        if (logger is null)
         {
             throw new ArgumentNullException(nameof(logger));
         }
@@ -53,25 +57,13 @@ public class EnvScannerPropertiesProvider : IAnalysisPropertyProvider
         return false;
     }
 
-    public EnvScannerPropertiesProvider(string json)
-    {
-        properties = (json == null) ? new List<Property>() : ParseVar(json);
-    }
+    public IEnumerable<Property> GetAllProperties() => properties;
 
-    public IEnumerable<Property> GetAllProperties()
-    {
-        return properties;
-    }
+    public bool TryGetProperty(string key, out Property property) =>
+        Property.TryGetProperty(key, properties, out property);
 
-    public bool TryGetProperty(string key, out Property property)
-    {
-        return Property.TryGetProperty(key, properties, out property);
-    }
-
-    private IEnumerable<Property> ParseVar(string json)
-    {
-        return JObject.Parse(json)
+    private IEnumerable<Property> ParseVar(string json) =>
+        JObject.Parse(json)
             .Properties()
-            .Select(p => new Property(p.Name, p.Value.ToString()));
-    }
+            .Select(x => new Property(x.Name, x.Value.ToString()));
 }

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/FilePropertyProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/FilePropertyProvider.cs
@@ -18,10 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using SonarScanner.MSBuild.Common.CommandLine;
 
 namespace SonarScanner.MSBuild.Common;

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/FilePropertyProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/FilePropertyProvider.cs
@@ -31,13 +31,18 @@ namespace SonarScanner.MSBuild.Common;
 /// </summary>
 public class FilePropertyProvider : IAnalysisPropertyProvider
 {
-    private const string DescriptorId = "properties.file.argument";
     public const string DefaultFileName = "SonarQube.Analysis.xml";
     public const string Prefix = "/s:";
     public const string DescriptorPrefix = "s:";
+    private const string DescriptorId = "properties.file.argument";
 
-    public static readonly ArgumentDescriptor Descriptor = new ArgumentDescriptor(DescriptorId, CommandLineFlagPrefix.GetPrefixedFlags(DescriptorPrefix),
+    public static readonly ArgumentDescriptor Descriptor = new(DescriptorId, CommandLineFlagPrefix.GetPrefixedFlags(DescriptorPrefix),
         false, Resources.CmdLine_ArgDescription_PropertiesFilePath, false);
+
+    public AnalysisProperties PropertiesFile { get; }
+    public bool IsDefaultSettingsFile => IsDefaultPropertiesFile;
+    public bool IsDefaultPropertiesFile { get; private set; }
+    public PropertyProviderKind ProviderType => PropertyProviderKind.SONARQUBE_ANALYSIS_XML;
 
     #region Public methods
 
@@ -48,10 +53,9 @@ public class FilePropertyProvider : IAnalysisPropertyProvider
     /// <param name="commandLineArguments">List of command line arguments (optional)</param>
     /// <returns>False if errors occurred when constructing the provider, otherwise true</returns>
     /// <remarks>If a properties file could not be located then an empty provider will be returned</remarks>
-    public static bool TryCreateProvider(IEnumerable<ArgumentInstance> commandLineArguments, string defaultPropertiesFileDirectory,
-        ILogger logger, out IAnalysisPropertyProvider provider)
+    public static bool TryCreateProvider(IEnumerable<ArgumentInstance> commandLineArguments, string defaultPropertiesFileDirectory, ILogger logger, out IAnalysisPropertyProvider provider)
     {
-        if (commandLineArguments == null)
+        if (commandLineArguments is null)
         {
             throw new ArgumentNullException(nameof(commandLineArguments));
         }
@@ -59,7 +63,7 @@ public class FilePropertyProvider : IAnalysisPropertyProvider
         {
             throw new ArgumentNullException(nameof(defaultPropertiesFileDirectory));
         }
-        if (logger == null)
+        if (logger is null)
         {
             throw new ArgumentNullException(nameof(logger));
         }
@@ -72,7 +76,7 @@ public class FilePropertyProvider : IAnalysisPropertyProvider
         if (ResolveFilePath(propertiesFilePath, defaultPropertiesFileDirectory, logger,
             out var locatedPropertiesFile))
         {
-            if (locatedPropertiesFile == null)
+            if (locatedPropertiesFile is null)
             {
                 provider = EmptyPropertyProvider.Instance;
             }
@@ -103,25 +107,15 @@ public class FilePropertyProvider : IAnalysisPropertyProvider
         return provider;
     }
 
-    public AnalysisProperties PropertiesFile { get; }
-
-    public bool IsDefaultSettingsFile { get { return IsDefaultPropertiesFile; } }
-
-    public bool IsDefaultPropertiesFile { get; private set; }
-
     #endregion Public methods
 
     #region IAnalysisPropertyProvider methods
 
-    public IEnumerable<Property> GetAllProperties()
-    {
-        return PropertiesFile ?? Enumerable.Empty<Property>();
-    }
+    public IEnumerable<Property> GetAllProperties() =>
+        PropertiesFile ?? Enumerable.Empty<Property>();
 
-    public bool TryGetProperty(string key, out Property property)
-    {
-        return Property.TryGetProperty(key, PropertiesFile, out property);
-    }
+    public bool TryGetProperty(string key, out Property property) =>
+        Property.TryGetProperty(key, PropertiesFile, out property);
 
     #endregion IAnalysisPropertyProvider methods
 
@@ -137,15 +131,14 @@ public class FilePropertyProvider : IAnalysisPropertyProvider
     /// Attempt to find a properties file - either the one specified by the user, or the default properties file.
     /// Returns true if the path to a file could be resolved, otherwise false.
     /// </summary>
-    private static bool ResolveFilePath(string propertiesFilePath, string defaultPropertiesFileDirectory, ILogger logger,
-        out AnalysisProperties properties)
+    private static bool ResolveFilePath(string propertiesFilePath, string defaultPropertiesFileDirectory, ILogger logger, out AnalysisProperties properties)
     {
         properties = null;
         var isValid = true;
 
         var resolvedPath = propertiesFilePath ?? TryGetDefaultPropertiesFilePath(defaultPropertiesFileDirectory, logger);
 
-        if (resolvedPath != null)
+        if (resolvedPath is not null)
         {
             // The File APIs below will automatically work with relative paths, but we resolve
             // the path anyway because we want to show better error messages, containing the

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/ListSettingsProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/ListSettingsProvider.cs
@@ -30,13 +30,14 @@ public class ListPropertiesProvider : IAnalysisPropertyProvider
 {
     private readonly IList<Property> properties;
 
-    public PropertyProviderKind ProviderType => PropertyProviderKind.SQ_SERVER_SETTINGS;
+    public PropertyProviderKind ProviderType { get; }
 
     #region Public methods
 
-    public ListPropertiesProvider()
+    public ListPropertiesProvider(PropertyProviderKind propertyProvider = PropertyProviderKind.UNKNOWN)
     {
         properties = [];
+        ProviderType = propertyProvider;
     }
 
     public ListPropertiesProvider(IEnumerable<Property> properties)
@@ -49,8 +50,8 @@ public class ListPropertiesProvider : IAnalysisPropertyProvider
         this.properties = [.. properties];
     }
 
-    public ListPropertiesProvider(IDictionary<string, string> keyValuePairs)
-        : this()
+    public ListPropertiesProvider(IDictionary<string, string> keyValuePairs, PropertyProviderKind propertyProvider = PropertyProviderKind.UNKNOWN)
+        : this(propertyProvider)
     {
         if (keyValuePairs is null)
         {

--- a/src/SonarScanner.MSBuild.Common/AnalysisProperties/ListSettingsProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/AnalysisProperties/ListSettingsProvider.cs
@@ -30,27 +30,29 @@ public class ListPropertiesProvider : IAnalysisPropertyProvider
 {
     private readonly IList<Property> properties;
 
+    public PropertyProviderKind ProviderType => PropertyProviderKind.SQ_SERVER_SETTINGS;
+
     #region Public methods
 
     public ListPropertiesProvider()
     {
-        properties = new List<Property>();
+        properties = [];
     }
 
     public ListPropertiesProvider(IEnumerable<Property> properties)
     {
-        if (properties == null)
+        if (properties is null)
         {
             throw new ArgumentNullException(nameof(properties));
         }
 
-        this.properties = new List<Property>(properties);
+        this.properties = [.. properties];
     }
 
     public ListPropertiesProvider(IDictionary<string, string> keyValuePairs)
         : this()
     {
-        if (keyValuePairs == null)
+        if (keyValuePairs is null)
         {
             throw new ArgumentNullException(nameof(keyValuePairs));
         }
@@ -82,20 +84,12 @@ public class ListPropertiesProvider : IAnalysisPropertyProvider
 
     #region IAnalysisProperiesProvider interface
 
-    public IEnumerable<Property> GetAllProperties()
-    {
-        return properties;
-    }
+    public IEnumerable<Property> GetAllProperties() => properties;
 
-    public bool TryGetProperty(string key, out Property property)
-    {
-        if (string.IsNullOrWhiteSpace(key))
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
-
-        return Property.TryGetProperty(key, properties, out property);
-    }
+    public bool TryGetProperty(string key, out Property property) =>
+        string.IsNullOrWhiteSpace(key)
+            ? throw new ArgumentNullException(nameof(key))
+            : Property.TryGetProperty(key, properties, out property);
 
     #endregion IAnalysisProperiesProvider interface
 }

--- a/src/SonarScanner.MSBuild.Common/Interfaces/IAnalysisPropertyProvider.cs
+++ b/src/SonarScanner.MSBuild.Common/Interfaces/IAnalysisPropertyProvider.cs
@@ -18,9 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-
 namespace SonarScanner.MSBuild.Common;
 
 /// <summary>
@@ -29,6 +26,8 @@ namespace SonarScanner.MSBuild.Common;
 /// <remarks>The properties could come from different sources e.g. a file, command line arguments, the SonarQube server</remarks>
 public interface IAnalysisPropertyProvider
 {
+    PropertyProviderKind ProviderType { get; }
+
     IEnumerable<Property> GetAllProperties();
 
     bool TryGetProperty(string key, out Property property);
@@ -38,7 +37,7 @@ public static class AnalysisPropertyProviderExtensions
 {
     public static bool TryGetValue(this IAnalysisPropertyProvider provider, string name, out string value)
     {
-        if (provider == null)
+        if (provider is null)
         {
             throw new ArgumentNullException(nameof(provider));
         }
@@ -61,7 +60,7 @@ public static class AnalysisPropertyProviderExtensions
 
     public static bool HasProperty(this IAnalysisPropertyProvider provider, string key)
     {
-        if (provider == null)
+        if (provider is null)
         {
             throw new ArgumentNullException(nameof(provider));
         }

--- a/src/SonarScanner.MSBuild.Common/Telemetry/PropertyProviderKind.cs
+++ b/src/SonarScanner.MSBuild.Common/Telemetry/PropertyProviderKind.cs
@@ -26,6 +26,5 @@ public enum PropertyProviderKind
     SONARQUBE_SCANNER_PARAMS,
     SONARQUBE_ANALYSIS_XML,
     SQ_SERVER_SETTINGS,
-    SONAR_SCANNER_OPTS, // Specifies options to the JVM for the sonar-scanner
     UNKNOWN
 }

--- a/src/SonarScanner.MSBuild.Common/Telemetry/PropertyProviderKind.cs
+++ b/src/SonarScanner.MSBuild.Common/Telemetry/PropertyProviderKind.cs
@@ -20,25 +20,12 @@
 
 namespace SonarScanner.MSBuild.Common;
 
-public class EmptyPropertyProvider : IAnalysisPropertyProvider
+public enum PropertyProviderKind
 {
-    public static readonly IAnalysisPropertyProvider Instance = new EmptyPropertyProvider();
-
-    public PropertyProviderKind ProviderType => PropertyProviderKind.UNKNOWN;
-
-    private EmptyPropertyProvider()
-    {
-    }
-
-    #region IAnalysisPropertyProvider interface
-
-    public IEnumerable<Property> GetAllProperties() => [];
-
-    public bool TryGetProperty(string key, out Property property)
-    {
-        property = null;
-        return false;
-    }
-
-    #endregion IAnalysisPropertyProvider interface
+    CLI,
+    SONARQUBE_SCANNER_PARAMS,
+    SONARQUBE_ANALYSIS_XML,
+    SQ_SERVER_SETTINGS,
+    SONAR_SCANNER_OPTS, // Specifies options to the JVM for the sonar-scanner
+    UNKNOWN
 }


### PR DESCRIPTION
[SCAN4NET-485](https://sonarsource.atlassian.net/browse/SCAN4NET-485)



[SCAN4NET-485]: https://sonarsource.atlassian.net/browse/SCAN4NET-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


This PR:

1. Adds provider kind to IAnalysisPropertyProvider
2. Add new GetAllPropertiesWithProvider to AggregatePropertiesProvider
3. Minor cleanup in coding style
