### PR TITLE
SCAN4NET-495 Increase timeout for whenAddingCoverage_ExclusionsAreRespected

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
@@ -128,7 +128,7 @@ class CodeCoverageTest {
     boolean isFileExcluded) {
     var context = AnalysisContext.forServer("ExclusionsAndCoverage");
     context.begin.setDebugLogs();
-    context.build.useDotNet();
+    context.build.useDotNet().setTimeout(Timeout.TWO_MINUTES);
     context.end.setTimeout(Timeout.TWO_MINUTES);
     ORCHESTRATOR.getServer().provisionProject(context.projectKey, context.projectKey);
 


### PR DESCRIPTION
[SCAN4NET-495](https://sonarsource.atlassian.net/browse/SCAN4NET-495)

We had at least two IT failures in MacOS and Linux because of a timeout in the builds recently:
https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=116948&view=logs&j=7d692771-62aa-5e24-bd85-b4dc8f6bca33&s=ffbece08-db33-5ffe-7537-8ad9d4bf6ce3&t=55d7b6d8-8660-5e3b-2c0a-f098d2482921&l=39061

https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=116948&view=logs&j=1267e320-60a8-5d9d-c934-b8464dbac3b7&s=821e3c99-8c09-5cb8-87e7-cf1391d9ddd1&t=5bce5501-070f-54f9-4cc4-53128a832b5a&l=38054

[SCAN4NET-495]: https://sonarsource.atlassian.net/browse/SCAN4NET-495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ