### PR TITLE
SCAN4NET-616 Fix telemetry ITs and set local sonar-dotnet analyzer version to be dev

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
@@ -67,8 +67,8 @@ public class ServerTests implements BeforeAllCallback, AfterAllCallback {
     addPlugin(orchestrator, "com.sonarsource.cpp", "sonar-cfamily-plugin", "sonar.cfamilyplugin.version");
     addPlugin(orchestrator, "com.sonarsource.plsql", "sonar-plsql-plugin", "sonar.plsqlplugin.version");
     addPlugin(orchestrator, "org.sonarsource.css", "sonar-css-plugin", "sonar.css.version", "NONE");
-    addPlugin(orchestrator, "org.sonarsource.dotnet", "sonar-csharp-plugin", "sonar.csharpplugin.version");
-    addPlugin(orchestrator, "org.sonarsource.dotnet", "sonar-vbnet-plugin", "sonar.vbnetplugin.version");
+    addPlugin(orchestrator, "org.sonarsource.dotnet", "sonar-csharp-plugin", "sonar.csharpplugin.version", "DEV");
+    addPlugin(orchestrator, "org.sonarsource.dotnet", "sonar-vbnet-plugin", "sonar.vbnetplugin.version", "DEV");
     addPlugin(orchestrator, "org.sonarsource.iac", "sonar-iac-plugin", "sonar.iacplugin.version");
     addPlugin(orchestrator, "org.sonarsource.java", "sonar-java-plugin", "sonar.javaplugin.version");
     addPlugin(orchestrator, "org.sonarsource.javascript", "sonar-javascript-plugin", "sonar.javascriptplugin.version");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
@@ -21,10 +21,7 @@ package com.sonar.it.scanner.msbuild.sonarqube;
 
 import com.sonar.it.scanner.msbuild.utils.*;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -37,11 +34,11 @@ import java.util.List;
 
 import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.spliterator;
 
 @ExtendWith({ServerTests.class, ContextExtension.class})
+@ServerMinVersion("LATEST_RELEASE")
 class TelemetryTest {
-  private static final Logger LOG = LoggerFactory.getLogger(TelemetryTest.class);
+
   @Test
   void telemetry_telemetryFiles_areCorrect_CS() throws IOException {
     AssertTelemetry("Telemetry");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
@@ -97,7 +97,7 @@ class TelemetryTest {
 
     var sonarQubeOutDirectory = context.projectDir.resolve(".sonarqube").resolve("out");
 
-    assertThat(readContents(sonarQubeOutDirectory.resolve(("Telemetry.S4NET.json"))))
+    assertThat(readContents(sonarQubeOutDirectory.resolve(("rTelemetry.S4NET.json"))))
       .satisfiesExactly(
         x -> assertThat(x).isEqualTo("{\"dotnetenterprise.s4net.params.sonar_scanner_skipjreprovisioning.source\":\"CLI\"}"),
         x -> assertThat(x).isEqualTo("{\"dotnetenterprise.s4net.params.sonar_branch_autoconfig_disabled.source\":\"CLI\"}"),
@@ -109,7 +109,7 @@ class TelemetryTest {
         x -> assertThat(x).isEqualTo("{\"dotnetenterprise.s4net.serverInfo.serverUrl\":\"custom_url\"}")
       );
 
-    assertThat(readContents(sonarQubeOutDirectory.resolve("Telemetry.Targets.S4NET.json")))
+    assertThat(readContents(sonarQubeOutDirectory.resolve("rTelemetry.Targets.S4NET.json")))
       .satisfiesExactly(
         x -> assertThat(x).startsWith("{\"dotnetenterprise.s4net.build.visual_studio_version\":"),
         x -> assertThat(x).startsWith("{\"dotnetenterprise.s4net.build.msbuild_version\":")

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
@@ -36,26 +36,30 @@ import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith({ServerTests.class, ContextExtension.class})
-@ServerMinVersion("LATEST_RELEASE")
 class TelemetryTest {
 
+
   @Test
+  @ServerMinVersion("LATEST_RELEASE")
   void telemetry_telemetryFiles_areCorrect_CS() throws IOException {
     AssertTelemetry("Telemetry");
   }
 
   @Test
+  @ServerMinVersion("LATEST_RELEASE")
   void telemetry_telemetryFiles_areCorrect_VB() throws IOException {
     AssertTelemetry("TelemetryVB");
   }
 
   @Test
+  @ServerMinVersion("LATEST_RELEASE")
   void telemetry_telemetryFiles_areCorrect_CSVB_Mixed() throws IOException {
     AssertTelemetry("TelemetryCSVBMixed");
   }
 
   @Test
   @MSBuildMinVersion(17)
+  @ServerMinVersion("LATEST_RELEASE")
   void telemetry_multiTargetFramework_tfmsAreCorrectlyRecorded() throws IOException {
     var context = AnalysisContext.forServer(Paths.get("Telemetry", "TelemetryMultiTarget").toString());
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
@@ -40,26 +40,26 @@ class TelemetryTest {
 
 
   @Test
-  @ServerMinVersion("LATEST_RELEASE")
+  @ServerMinVersion("2025.3")
   void telemetry_telemetryFiles_areCorrect_CS() throws IOException {
     AssertTelemetry("Telemetry");
   }
 
   @Test
-  @ServerMinVersion("LATEST_RELEASE")
+  @ServerMinVersion("2025.3")
   void telemetry_telemetryFiles_areCorrect_VB() throws IOException {
     AssertTelemetry("TelemetryVB");
   }
 
   @Test
-  @ServerMinVersion("LATEST_RELEASE")
+  @ServerMinVersion("2025.3")
   void telemetry_telemetryFiles_areCorrect_CSVB_Mixed() throws IOException {
     AssertTelemetry("TelemetryCSVBMixed");
   }
 
   @Test
   @MSBuildMinVersion(17)
-  @ServerMinVersion("LATEST_RELEASE")
+  @ServerMinVersion("2025.3")
   void telemetry_multiTargetFramework_tfmsAreCorrectlyRecorded() throws IOException {
     var context = AnalysisContext.forServer(Paths.get("Telemetry", "TelemetryMultiTarget").toString());
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
@@ -38,7 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith({ServerTests.class, ContextExtension.class})
 class TelemetryTest {
 
-
   @Test
   @ServerMinVersion("2025.3")
   void telemetry_telemetryFiles_areCorrect_CS() throws IOException {


### PR DESCRIPTION
[SCAN4NET-616](https://sonarsource.atlassian.net/browse/SCAN4NET-616)



[SCAN4NET-616]: https://sonarsource.atlassian.net/browse/SCAN4NET-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ