### PR TITLE
SCAN4NET-650 Exclude windows specific tests from MSBuildPathSettingsTests

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/MsBuildPathSettingsTests.cs
@@ -116,7 +116,8 @@ public class MsBuildPathSettingsTests
             Path.Combine("c:\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"));
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
+    [TestCategory(TestCategories.NoLinux)]
+    [TestCategory(TestCategories.NoMacOS)]
     [TestMethod]
     public void GetImportBeforePaths_Windows_System_Account()
     {
@@ -155,7 +156,8 @@ public class MsBuildPathSettingsTests
             Path.Combine("c:\\windows\\Sysnative\\app data", "Microsoft", "MSBuild", "Current", "Microsoft.Common.targets", "ImportBefore"));
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
+    [TestCategory(TestCategories.NoLinux)]
+    [TestCategory(TestCategories.NoMacOS)]
     [TestMethod]
     public void GetImportBeforePaths_Windows_System_Account_WOW64_Missing()
     {
@@ -251,9 +253,10 @@ public class MsBuildPathSettingsTests
         testSubject2.GetGlobalTargetsPaths().Should().BeEmpty();
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
+    [TestCategory(TestCategories.NoLinux)]
+    [TestCategory(TestCategories.NoMacOS)]
     [TestMethod]
-    public void GetGlobalTargetsPaths_WhenProgramFilesNotEmpty_ReturnsExpectedPaths()
+    public void GetGlobalTargetsPaths_Windows_WhenProgramFilesNotEmpty_ReturnsExpectedPaths()
     {
         var paths = new[]
         {


### PR DESCRIPTION
[SCAN4NET-650](https://sonarsource.atlassian.net/browse/SCAN4NET-650)

Part of SCAN4NET-432

[SCAN4NET-650]: https://sonarsource.atlassian.net/browse/SCAN4NET-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

I added SCAN4NET-652 to track refactoring this class