### PR TITLE
SCAN4NET-654 Fix failing ImportBeforeTargetTests on Linux/MacOS

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/Resources/ImportBeforeTargetTestsTemplate.xml
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/Resources/ImportBeforeTargetTestsTemplate.xml
@@ -1,23 +1,18 @@
-﻿<?xml version='1.0' encoding='utf-8'?>
-<Project ToolsVersion='Current' xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+﻿<Project Sdk='Microsoft.NET.Sdk'>
 
-  <!-- Test-specific data -->
-  TEST_SPECIFIC_XML
+    <PropertyGroup>
+        <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+        <TargetFramework>TARGET_FRAMEWORK</TargetFramework>
+    </PropertyGroup>
 
-  <!-- Boilerplate -->
-  <PropertyGroup>
-    <ImportByWildcardBeforeMicrosoftCommonTargets>false</ImportByWildcardBeforeMicrosoftCommonTargets>
-    <ImportByWildcardAfterMicrosoftCommonTargets>false</ImportByWildcardAfterMicrosoftCommonTargets>
-    <ImportUserLocationsByWildcardBeforeMicrosoftCommonTargets>false</ImportUserLocationsByWildcardBeforeMicrosoftCommonTargets>
-    <ImportUserLocationsByWildcardAfterMicrosoftCommonTargets>false</ImportUserLocationsByWildcardAfterMicrosoftCommonTargets>
-    <OutputPath>bin\</OutputPath>
-    <Language>C#</Language>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>    
-    <OutputType>library</OutputType>
-    <ProjectGuid>ffdb93c0-2880-44c7-89a6-bbd4ddab034a</ProjectGuid>
-  </PropertyGroup>
+    <!-- Remove items that MSBuild automatically adds to the project -->
+    <ItemGroup>
+        <None Remove="**\*" />
+    </ItemGroup>
 
-  <!-- Standard boilerplate closing imports -->
-  <Import Project='SQ_IMPORTS_BEFORE' />
-  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
+    <!-- Test-specific data -->
+    TEST_SPECIFIC_XML
+
+    <!-- Standard boilerplate closing imports -->
+    <Import Project='SQ_IMPORTS_BEFORE'/>
 </Project>

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/Resources/ImportBeforeTargetTestsTemplate.xml
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/Resources/ImportBeforeTargetTestsTemplate.xml
@@ -10,6 +10,9 @@
         <None Remove="**\*" />
     </ItemGroup>
 
+    <!--SonarQube Properties-->
+    SONARQUBE_PROPERTIES
+
     <!-- Test-specific data -->
     TEST_SPECIFIC_XML
 

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/ImportBeforeTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/ImportBeforeTargetsTests.cs
@@ -174,7 +174,7 @@ public class ImportBeforeTargetsTests
         // Locate the real "ImportsBefore" target file
         File.Exists(importsBeforeTargets).Should().BeTrue("Test error: the SonarQube imports before target file does not exist. Path: {0}", importsBeforeTargets);
 
-        return context.CreateProjectFile(testSpecificProjectXml, emptySqProperties: true, template: Resources.ImportBeforeTargetTestsTemplate);
+        return context.CreateProjectFile(testSpecificProjectXml, sqProperties: string.Empty, template: Resources.ImportBeforeTargetTestsTemplate);
     }
 
     #endregion Private methods

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/ImportBeforeTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/ImportBeforeTargetsTests.cs
@@ -18,30 +18,24 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.IO;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarScanner.Integration.Tasks.IntegrationTests.TargetsTests;
-using TestUtilities;
 
 namespace SonarScanner.MSBuild.Tasks.IntegrationTest.TargetsTests;
 
 [TestClass]
 public class ImportBeforeTargetsTests
 {
-    public TestContext TestContext { get; set; }
-
     /// <summary>
-    /// Name of the property to check for to determine whether or not
+    /// Name of the property to check for to determine whether
     /// the targets have been imported or not
     /// </summary>
     private const string DummyAnalysisTargetsMarkerProperty = "DummyProperty";
 
+    public TestContext TestContext { get; set; }
+
     [TestInitialize]
-    public void TestInitialize()
-    {
+    public void TestInitialize() =>
         TestUtils.EnsureImportBeforeTargetsExists(TestContext);
-    }
 
     #region Tests
 
@@ -51,14 +45,13 @@ public class ImportBeforeTargetsTests
     public void ImportsBefore_SonarQubeTargetsPathNotSet()
     {
         // 1. Prebuild
-        // Arrange
-        var projectXml = @"
-<PropertyGroup>
-  <SonarQubeTargetsPath />
-  <AGENT_BUILDDIRECTORY />
-  <TF_BUILD_BUILDDIRECTORY />
-</PropertyGroup>
-";
+        var projectXml = """
+            <PropertyGroup>
+              <SonarQubeTargetsPath />
+              <AGENT_BUILDDIRECTORY />
+              <TF_BUILD_BUILDDIRECTORY />
+            </PropertyGroup>
+            """;
         var projectFilePath = CreateProjectFile(projectXml);
         var result = BuildRunner.BuildTargets(TestContext, projectFilePath);
 
@@ -75,15 +68,15 @@ public class ImportBeforeTargetsTests
     public void ImportsBefore_BuildingInsideVS_NotImported()
     {
         var dummySonarTargetsDir = EnsureDummyIntegrationTargetsFileExists();
-        var projectXml = $@"
-<PropertyGroup>
-  <SonarQubeTempPath>{Path.GetTempPath()}</SonarQubeTempPath>
-  <SonarQubeTargetsPath>{Path.GetDirectoryName(dummySonarTargetsDir)}</SonarQubeTargetsPath>
-  <BuildingInsideVisualStudio>tRuE</BuildingInsideVisualStudio>
-</PropertyGroup>
-";
+        var projectXml = $"""
+            <PropertyGroup>
+              <SonarQubeTempPath>{Path.GetTempPath()}</SonarQubeTempPath>
+              <SonarQubeTargetsPath>{Path.GetDirectoryName(dummySonarTargetsDir)}</SonarQubeTargetsPath>
+              <BuildingInsideVisualStudio>tRuE</BuildingInsideVisualStudio>
+            </PropertyGroup>
+            """;
         var projectFilePath = CreateProjectFile(projectXml);
-        var result  = BuildRunner.BuildTargets(TestContext, projectFilePath);
+        var result = BuildRunner.BuildTargets(TestContext, projectFilePath);
 
         result.AssertPropertyValue(TargetProperties.SonarQubeTargetFilePath, dummySonarTargetsDir);
         AssertAnalysisTargetsAreNotImported(result);
@@ -97,13 +90,14 @@ public class ImportBeforeTargetsTests
     [Description("Checks what happens if the analysis targets cannot be located")]
     public void ImportsBefore_MissingAnalysisTargets()
     {
-        var projectXml = @"
-<PropertyGroup>
-  <SonarQubeTempPath>nonExistentPath</SonarQubeTempPath>
-  <MSBuildExtensionsPath>nonExistentPath</MSBuildExtensionsPath>
-  <AGENT_BUILDDIRECTORY />
-  <TF_BUILD_BUILDDIRECTORY />
-</PropertyGroup>";
+        var projectXml = """
+            <PropertyGroup>
+              <SonarQubeTempPath>nonExistentPath</SonarQubeTempPath>
+              <MSBuildExtensionsPath>nonExistentPath</MSBuildExtensionsPath>
+              <AGENT_BUILDDIRECTORY />
+              <TF_BUILD_BUILDDIRECTORY />
+            </PropertyGroup>
+            """;
         var projectFilePath = CreateProjectFile(projectXml);
         var result = BuildRunner.BuildTargets(TestContext, projectFilePath);
 
@@ -125,13 +119,14 @@ public class ImportBeforeTargetsTests
     public void ImportsBefore_TargetsExist()
     {
         var dummySonarTargetsDir = EnsureDummyIntegrationTargetsFileExists();
-        var projectXml = $@"
-<PropertyGroup>
-  <SonarQubeTempPath>{Path.GetTempPath()}</SonarQubeTempPath>
-  <SonarQubeTargetsPath>{Path.GetDirectoryName(dummySonarTargetsDir)}</SonarQubeTargetsPath>
-  <AGENT_BUILDDIRECTORY />
-  <TF_BUILD_BUILDDIRECTORY />
-</PropertyGroup>";
+        var projectXml = $"""
+            <PropertyGroup>
+              <SonarQubeTempPath>{Path.GetTempPath()}</SonarQubeTempPath>
+              <SonarQubeTargetsPath>{Path.GetDirectoryName(dummySonarTargetsDir)}</SonarQubeTargetsPath>
+              <AGENT_BUILDDIRECTORY />
+              <TF_BUILD_BUILDDIRECTORY />
+            </PropertyGroup>
+            """;
         var projectFilePath = CreateProjectFile(projectXml);
         var result = BuildRunner.BuildTargets(TestContext, projectFilePath);
 
@@ -162,13 +157,14 @@ public class ImportBeforeTargetsTests
         {
 // To check whether the targets are imported or not we check for
 // the existence of the DummyProperty, below.
-            var contents = @"<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <PropertyGroup>
-    <DummyProperty>123</DummyProperty>
-  </PropertyGroup>
-  <Target Name='DummyTarget' />
-</Project>
-";
+            var contents = """
+                <Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+                  <PropertyGroup>
+                    <DummyProperty>123</DummyProperty>
+                  </PropertyGroup>
+                  <Target Name='DummyTarget' />
+                </Project>
+                """;
             File.WriteAllText(fullPath, contents);
         }
         return fullPath;


### PR DESCRIPTION
[SCAN4NET-654](https://sonarsource.atlassian.net/browse/SCAN4NET-654)

Part of [SCAN4NET-387](https://sonarsource.atlassian.net/browse/SCAN4NET-387)


[SCAN4NET-387]: https://sonarsource.atlassian.net/browse/SCAN4NET-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SCAN4NET-654]: https://sonarsource.atlassian.net/browse/SCAN4NET-654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ