### PR TITLE
SCAN4NET-657 Fix failing RoslynTargetsTests on Linux/MacOS

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/RoslynTargetsTests.cs
@@ -133,7 +133,7 @@ public class RoslynTargetsTests
               </ItemGroup>
             """;
 
-        var filePath = context.CreateProjectFile(testSpecificProjectXml, config);
+        var filePath = context.CreateProjectFile(testSpecificProjectXml, config: config);
 
         var result = BuildRunner.BuildTargets(TestContext, filePath, TargetConstants.SonarOverrideRunAnalyzers, TargetConstants.OverrideRoslynAnalysis);
 
@@ -202,7 +202,7 @@ public class RoslynTargetsTests
                 <AdditionalFiles Include='d:\duplicate.should.be.removed\config.2.TXT' />
               </ItemGroup>
             """;
-        var filePath = context.CreateProjectFile(testSpecificProjectXml, config);
+        var filePath = context.CreateProjectFile(testSpecificProjectXml, config: config);
 
         var result = BuildRunner.BuildTargets(TestContext, filePath, TargetConstants.SonarOverrideRunAnalyzers, TargetConstants.OverrideRoslynAnalysis);
 
@@ -251,7 +251,7 @@ public class RoslynTargetsTests
               <AdditionalFiles Include='should.be.preserved.additional1.txt' />
             </ItemGroup>
             """;
-        var filePath = context.CreateProjectFile(projectSnippet, config);
+        var filePath = context.CreateProjectFile(projectSnippet, config: config);
 
         var result = BuildRunner.BuildTargets(TestContext, filePath, TargetConstants.OverrideRoslynAnalysis);
 
@@ -295,7 +295,7 @@ public class RoslynTargetsTests
               <AdditionalFiles Include='should.be.preserved.additional1.txt' />
             </ItemGroup>
             """;
-        var filePath = context.CreateProjectFile(projectSnippet, config);
+        var filePath = context.CreateProjectFile(projectSnippet, config: config);
 
         var result = BuildRunner.BuildTargets(TestContext, filePath, TargetConstants.OverrideRoslynAnalysis);
 
@@ -683,7 +683,7 @@ public class RoslynTargetsTests
                 <AdditionalFiles Include='{someFolder}project.additional.file.2.txt' />
             </ItemGroup>
             """;
-        var filePath = context.CreateProjectFile(projectSnippet, config);
+        var filePath = context.CreateProjectFile(projectSnippet, config: config);
 
         var result = BuildRunner.BuildTargets(TestContext, filePath, TargetConstants.SonarOverrideRunAnalyzers, TargetConstants.OverrideRoslynAnalysis);
 

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/RoslynTargetsTests.cs
@@ -30,7 +30,6 @@ public class RoslynTargetsTests
 
     #region SetRoslynSettingsTarget tests
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [DataTestMethod]
     [DataRow("C#", false, "false")]
     [DataRow("C#", false, "true")]
@@ -67,7 +66,6 @@ public class RoslynTargetsTests
         AssertExpectedAdditionalFiles(result, "project.additional.file.1.txt", @"x:\aaa\project.additional.file.2.txt");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [DataTestMethod]
     [DataRow("C#")]
     [DataRow("VB")]
@@ -90,7 +88,6 @@ public class RoslynTargetsTests
         AssertExpectedAdditionalFiles(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Checks any existing analyzers are overridden for projects using SonarQube pre-7.5")]
     public void Settings_ValidSetup_LegacyServer_Override_Analyzers()
@@ -155,7 +152,6 @@ public class RoslynTargetsTests
         AssertRunAnalyzersIsEnabled(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Checks existing analysis settings are merged for projects using SonarQube 7.5+")]
     public void Settings_ValidSetup_NonLegacyServer_MergeSettings()
@@ -243,7 +239,6 @@ public class RoslynTargetsTests
         AssertRunAnalyzersIsEnabled(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void Settings_LanguageMissing_NoError()
     {
@@ -293,7 +288,6 @@ public class RoslynTargetsTests
             });
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Checks that a config file with no analyzer settings does not cause an issue")]
     public void Settings_SettingsMissing_NoError()
@@ -339,7 +333,6 @@ public class RoslynTargetsTests
             "should.be.preserved.additional1.txt");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Checks the target is not executed if the temp folder is not set")]
     public void Settings_TempFolderIsNotSet()
@@ -379,7 +372,6 @@ public class RoslynTargetsTests
         result.AssertPropertyValue(TargetProperties.RunAnalyzersDuringBuild, "false");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Checks an existing errorLog value is used if set")]
     public void Settings_ErrorLogAlreadySet()
@@ -403,7 +395,6 @@ public class RoslynTargetsTests
         result.AssertPropertyValue(TargetProperties.SonarErrorLog, "already.set.txt");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Checks the code analysis properties are cleared for excludedprojects")]
     public void Settings_NotRunForExcludedProject()
@@ -437,7 +428,6 @@ public class RoslynTargetsTests
 
     #region AddAnalysisResults tests
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Checks the target is not executed if the temp folder is not set")]
     public void SetResults_TempFolderIsNotSet()
@@ -456,7 +446,6 @@ public class RoslynTargetsTests
         result.AssertTargetNotExecuted(TargetConstants.SonarWriteProjectData);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Checks the analysis setting is not set if the results file does not exist")]
     public void SetResults_ResultsFileDoesNotExist()
@@ -479,7 +468,6 @@ public class RoslynTargetsTests
         AssertAnalysisSettingDoesNotExist(result, RoslynAnalysisResultsSettingName);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Checks the analysis setting is set if the result file exists")]
     public void SetResults_ResultsFileExists()
@@ -510,7 +498,6 @@ public class RoslynTargetsTests
 
     #region Combined tests
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Checks the targets are executed in the expected order")]
     public void TargetExecutionOrder()

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/TargetsTestsContext.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/TargetsTestsContext.cs
@@ -76,6 +76,7 @@ public class TargetsTestsContext
                 <SonarQubeTempPath>{ProjectFolder}</SonarQubeTempPath>
                 <SonarQubeOutputPath>{OutputFolder}</SonarQubeOutputPath>
                 <SonarQubeConfigPath>{ConfigFolder}</SonarQubeConfigPath>
+                <EnableNETAnalyzers>false</EnableNETAnalyzers> <!-- NetAnalyzers disabled as they are picked up by MsBuild in test context on Linux, but not on Windows. -->
             </PropertyGroup>
             """;
         testSpecificProjectXml ??= "<!-- none -->";


### PR DESCRIPTION
[SCAN4NET-657](https://sonarsource.atlassian.net/browse/SCAN4NET-657)

Part of [SCAN4NET-387](https://sonarsource.atlassian.net/browse/SCAN4NET-387)

[SCAN4NET-387]: https://sonarsource.atlassian.net/browse/SCAN4NET-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This is still WIP.
I did not finish migrating all the Windows path to Unix path.

[SCAN4NET-657]: https://sonarsource.atlassian.net/browse/SCAN4NET-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ