### PR TITLE
SCAN4NET-664 Make SonarCategoriseProjectTests run on Linux

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/SonarCategoriseProjectTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/SonarCategoriseProjectTests.cs
@@ -30,11 +30,11 @@ public class SonarCategoriseProjectTests
 
     [TestMethod]
     public void SimpleProject_NoTestMarkers_IsNotATestProject() =>
-        ExecuteTest("foo.proj", projXml: string.Empty);
+        AssertBuildAndTargets("foo.proj", projXml: string.Empty);
 
     [TestMethod]
     public void ExplicitMarking_IsTrue() =>
-        ExecuteTest(
+        AssertBuildAndTargets(
             "foo.proj", """
             <PropertyGroup>
               <SonarQubeTestProject>true</SonarQubeTestProject>
@@ -57,7 +57,7 @@ public class SonarCategoriseProjectTests
               <ProjectCapability Include='TestContainer' />
             </ItemGroup>
             """;
-        var result = ExecuteTest("foo.proj", projectXmlSnippet, CreateAnalysisConfigWithRegEx("*"));
+        var result = AssertBuildAndTargets("foo.proj", projectXmlSnippet, CreateAnalysisConfigWithRegEx("*"));
         result.Messages.Should().Contain("Sonar: (foo.proj) SonarQubeTestProject has been set explicitly to false.");
     }
 
@@ -66,12 +66,12 @@ public class SonarCategoriseProjectTests
     [DataRow("TestafoXB.proj", ".*foo.*")]
     [DataTestMethod]
     public void WildcardMatch_NoMatch(string projectName, string regex) =>
-        ExecuteTest(projectName, projXml: string.Empty, analysisConfigDir: CreateAnalysisConfigWithRegEx(regex));
+        AssertBuildAndTargets(projectName, projXml: string.Empty, analysisConfigDir: CreateAnalysisConfigWithRegEx(regex));
 
     [TestMethod]
     // Check user-specified wildcard matching
     public void WildcardMatch_UserSpecified_Match() =>
-        ExecuteTest(
+        AssertBuildAndTargets(
             "foo.proj",
             projXml: string.Empty,
             analysisConfigDir: CreateAnalysisConfigWithRegEx(".*foo.*"),
@@ -80,7 +80,7 @@ public class SonarCategoriseProjectTests
     [TestMethod]
     // Snippet with the Test Project Type Guid between two other Guids
     public void ProjectTypeGuids_IsRecognized() =>
-        ExecuteTest(
+        AssertBuildAndTargets(
             "foo.proj", """
             <PropertyGroup>
               <ProjectTypeGuids>D1C3357D-82B4-43D2-972C-4D5455F0A7DB;3AC096D0-A1C2-E12C-1390-A8335801FDAB;BF3D2153-F372-4432-8D43-09B24D530F20</ProjectTypeGuids>
@@ -90,7 +90,7 @@ public class SonarCategoriseProjectTests
 
     [TestMethod]
     public void ProjectTypeGuids_IsRecognized_CaseInsensitive() =>
-        ExecuteTest(
+        AssertBuildAndTargets(
             "foo.proj", """
             <PropertyGroup>
               <ProjectTypeGuids>3AC096D0-A1C2-E12C-1390-A8335801fdab</ProjectTypeGuids>
@@ -100,7 +100,7 @@ public class SonarCategoriseProjectTests
 
     [TestMethod]
     public void ServiceGuid_IsRecognized() =>
-        ExecuteTest(
+        AssertBuildAndTargets(
             "foo.proj", """
             <ItemGroup>
               <Service Include='{D1C3357D-82B4-43D2-972C-4D5455F0A7DB}' />
@@ -112,7 +112,7 @@ public class SonarCategoriseProjectTests
 
     [TestMethod]
     public void ServiceGuid_IsRecognized_CaseInsensitive() =>
-        ExecuteTest(
+        AssertBuildAndTargets(
             "foo.proj", """
             <ItemGroup>
               <Service Include='{82a7f48d-3b50-4b1e-b82e-3ada8210c358}' />
@@ -122,7 +122,7 @@ public class SonarCategoriseProjectTests
 
     [TestMethod]
     public void ProjectCapability_IsRecognized() =>
-        ExecuteTest(
+        AssertBuildAndTargets(
             "foo.proj", """
             <ItemGroup>
               <ProjectCapability Include='Foo' />
@@ -134,7 +134,7 @@ public class SonarCategoriseProjectTests
 
     [TestMethod]
     public void ProjectCapability_IsRecognized_CaseInsensitive() =>
-        ExecuteTest(
+        AssertBuildAndTargets(
             "foo.proj", """
             <ItemGroup>
               <ProjectCapability Include='testcontainer' />
@@ -144,7 +144,7 @@ public class SonarCategoriseProjectTests
 
     [TestMethod]
     public void References_IsProduct() =>
-        ExecuteTest("foo.proj", """
+        AssertBuildAndTargets("foo.proj", """
             <ItemGroup>
               <SonarResolvedReferences Include='mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' />
               <SonarResolvedReferences Include='SimpleName' />
@@ -154,7 +154,7 @@ public class SonarCategoriseProjectTests
     [TestMethod]
     public void References_IsTest()
     {
-        var result = ExecuteTest(
+        var result = AssertBuildAndTargets(
             "foo.proj", """
             <ItemGroup>
               <SonarResolvedReferences Include='mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' />
@@ -170,7 +170,7 @@ public class SonarCategoriseProjectTests
 
     [TestMethod]
     public void SqlServerProjectsAreNotExcluded() =>
-        ExecuteTest("foo.sqproj", """
+        AssertBuildAndTargets("foo.sqproj", """
             <PropertyGroup>
               <SqlTargetName>non-empty</SqlTargetName>
             </PropertyGroup>
@@ -178,7 +178,7 @@ public class SonarCategoriseProjectTests
 
     [TestMethod] // SONARMSBRU-26: MS Fakes should be excluded from analysis
     public void FakesProjects_AreExcluded_WhenNoExplicitSonarProperties() =>
-        ExecuteTest(
+        AssertBuildAndTargets(
             "foo.proj", """
             <PropertyGroup>
               <AssemblyName>f.fAKes</AssemblyName>
@@ -189,7 +189,7 @@ public class SonarCategoriseProjectTests
 
     [TestMethod]
     public void FakesProjects_FakesInName_AreNotExcluded() =>
-        ExecuteTest("foo.proj", """
+        AssertBuildAndTargets("foo.proj", """
             <PropertyGroup>
               <AssemblyName>f.fAKes.proj</AssemblyName>
             </PropertyGroup>
@@ -199,7 +199,7 @@ public class SonarCategoriseProjectTests
     // Checks that fakes projects are not marked as test if the project
     // says otherwise.
     public void FakesProjects_AreNotTestProjects_WhenExplicitSonarTestProperty() => // @odalet - Issue #844
-        ExecuteTest(
+        AssertBuildAndTargets(
             "foo.proj", """
             <PropertyGroup>
                 <SonarQubeTestProject>false</SonarQubeTestProject>
@@ -213,14 +213,14 @@ public class SonarCategoriseProjectTests
     // says otherwise.
     public void FakesProjects_AreNotExcluded_WhenExplicitSonarExcludeProperty() // @odalet - Issue #844
     {
-        var result = ExecuteTest(
+        var result = BuildAndRunTarget(
             "f.proj", """
             <PropertyGroup>
               <SonarQubeExclude>false</SonarQubeExclude>
               <AssemblyName>MyFakeProject.fakes</AssemblyName>
             </PropertyGroup>
             """,
-            skipAssertions: true);
+            "c:\\dummy");
         AssertProjectIsNotExcluded(result);
     }
 
@@ -235,23 +235,18 @@ public class SonarCategoriseProjectTests
     [DataTestMethod]
     public void WpfTemporaryProjects_AreExcluded(string projectName, bool expectedExclusionState)
     {
-        var exclusionMessage = expectedExclusionState ? $"Sonar: ({projectName}) project is a temporary project and will be excluded." : string.Empty;
-        ExecuteTest(
+        var exclusionMessage = expectedExclusionState ? $"Sonar: ({projectName}) project is a temporary project and will be excluded." : null;
+        AssertBuildAndTargets(
             projectName,
             projXml: string.Empty,
             exclusionMessage: exclusionMessage);
     }
 
-    private BuildLog ExecuteTest(string projName, string projXml, string analysisConfigDir = "c:\\dummy", string testProjMessage = null, string exclusionMessage = null, bool skipAssertions = false)
+    private BuildLog AssertBuildAndTargets(string projName, string projXml, string analysisConfigDir = "c:\\dummy", string testProjMessage = null, string exclusionMessage = null)
     {
         var result = BuildAndRunTarget(projName, projXml, analysisConfigDir);
 
-        if (skipAssertions)
-        {
-            return result;
-        }
-
-        if (string.IsNullOrEmpty(testProjMessage))
+        if (testProjMessage is null)
         {
             AssertIsNotTestProject(result, projName);
         }
@@ -259,7 +254,7 @@ public class SonarCategoriseProjectTests
         {
             AssertIsTestProject(result, testProjMessage);
         }
-        if (string.IsNullOrEmpty(exclusionMessage))
+        if (exclusionMessage is null)
         {
             AssertProjectIsNotExcluded(result);
         }

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/SonarCategoriseProjectTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/SonarCategoriseProjectTests.cs
@@ -18,14 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.IO;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.Tasks;
 using SonarScanner.MSBuild.Tasks.IntegrationTest;
-using TestUtilities;
 
 namespace SonarScanner.Integration.Tasks.IntegrationTests.TargetsTests;
 
@@ -34,30 +28,21 @@ public class SonarCategoriseProjectTests
 {
     public TestContext TestContext { get; set; }
 
-    #region Detection of test projects
-
     [TestMethod]
     public void SimpleProject_NoTestMarkers_IsNotATestProject()
     {
-        // Act
-        var result = BuildAndRunTarget("foo.proj", "");
-
-        // Assert
+        var result = BuildAndRunTarget("foo.proj", string.Empty);
         AssertIsNotTestProject(result);
     }
 
     [TestMethod]
     public void ExplicitMarking_IsTrue()
     {
-        const string projectXmlSnippet = @"
-<PropertyGroup>
-  <SonarQubeTestProject>true</SonarQubeTestProject>
-</PropertyGroup>
-";
-        // Act
-        var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
-
-        // Assert
+        var result = BuildAndRunTarget("foo.proj", """
+            <PropertyGroup>
+              <SonarQubeTestProject>true</SonarQubeTestProject>
+            </PropertyGroup>
+            """);
         AssertIsTestProject(result, $"Sonar: (foo.proj) SonarQubeTestProject has been set explicitly to true.");
         AssertProjectIsNotExcluded(result);
     }
@@ -66,54 +51,35 @@ public class SonarCategoriseProjectTests
     public void ExplicitMarking_IsFalse()
     {
         // If the project is explicitly marked as not a test then the other conditions should be ignored
-        const string projectXmlSnippet = @"
-<PropertyGroup>
-  <ProjectTypeGuids>D1C3357D-82B4-43D2-972C-4D5455F0A7DB;3AC096D0-A1C2-E12C-1390-A8335801FDAB;BF3D2153-F372-4432-8D43-09B24D530F20</ProjectTypeGuids>
-  <SonarQubeTestProject>false</SonarQubeTestProject>
-</PropertyGroup>
+        const string projectXmlSnippet = """
+            <PropertyGroup>
+              <ProjectTypeGuids>D1C3357D-82B4-43D2-972C-4D5455F0A7DB;3AC096D0-A1C2-E12C-1390-A8335801FDAB;BF3D2153-F372-4432-8D43-09B24D530F20</ProjectTypeGuids>
+              <SonarQubeTestProject>false</SonarQubeTestProject>
+            </PropertyGroup>
 
-<ItemGroup>
-  <Service Include='{D1C3357D-82B4-43D2-972C-4D5455F0A7DB}' />
-  <ProjectCapability Include='TestContainer' />
-</ItemGroup>
-
-";
+            <ItemGroup>
+              <Service Include='{D1C3357D-82B4-43D2-972C-4D5455F0A7DB}' />
+              <ProjectCapability Include='TestContainer' />
+            </ItemGroup>
+            """;
         var configFilePath = CreateAnalysisConfigWithRegEx("*");
-
-        // Act
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet, configFilePath);
 
-        // Assert
         AssertIsNotTestProject(result);
         AssertProjectIsNotExcluded(result);
         result.Messages.Should().Contain($"Sonar: (foo.proj) SonarQubeTestProject has been set explicitly to false.");
     }
-
-    [TestMethod]
-    public void WildcardMatch_Default_NoMatchForTestName()
+    [DataRow("MyTests.csproj", null)]
+    [DataRow("foo.proj", null)]
+    [DataRow("TestafoXB.proj", ".*foo.*")]
+    [DataTestMethod]
+    public void WildcardMatch_NoMatch(string projectName, string regex)
     {
-        // Check the default behavior - name is not checked
-        var configFilePath = CreateAnalysisConfigWithRegEx(null);
+        var configFilePath = CreateAnalysisConfigWithRegEx(regex);
 
-        // Act
-        var result = BuildAndRunTarget("MyTests.csproj", string.Empty, configFilePath);
+        var result = BuildAndRunTarget(projectName, string.Empty, configFilePath);
 
-        // Assert
-        AssertIsNotTestProject(result, "MyTests.csproj");
-        AssertProjectIsNotExcluded(result);
-    }
-
-    [TestMethod]
-    public void WildcardMatch_Default_NoMatchForOtherName()
-    {
-        // Check the default behavior - name is not checked
-        var configFilePath = CreateAnalysisConfigWithRegEx(null);
-
-        // Act
-        var result = BuildAndRunTarget("foo.proj", string.Empty, configFilePath);
-
-        // Assert
-        AssertIsNotTestProject(result);
+        AssertIsNotTestProject(result, projectName);
         AssertProjectIsNotExcluded(result);
     }
 
@@ -121,32 +87,11 @@ public class SonarCategoriseProjectTests
     public void WildcardMatch_UserSpecified_Match()
     {
         // Check user-specified wildcard matching
-
-        // Arrange
         var configFilePath = CreateAnalysisConfigWithRegEx(".*foo.*");
 
-        // Act
         var result = BuildAndRunTarget("foo.proj", string.Empty, configFilePath);
 
-        // Assert
         AssertIsTestProject(result, "Sonar: (foo.proj) project is evaluated as a test project based on the project name.");
-        AssertProjectIsNotExcluded(result);
-    }
-
-    [TestMethod]
-    public void WildcardMatch_UserSpecified_NoMatch()
-    {
-        // Check user-specified wildcard matching
-
-        // Arrange
-        var configFilePath = CreateAnalysisConfigWithRegEx(".*foo.*");
-
-        // Act
-        // Using a project name that will be recognized as a test by the default regex
-        var result = BuildAndRunTarget("TestafoXB.proj", string.Empty, configFilePath);
-
-        // Assert
-        AssertIsNotTestProject(result, "TestafoXB.proj");
         AssertProjectIsNotExcluded(result);
     }
 
@@ -154,109 +99,96 @@ public class SonarCategoriseProjectTests
     public void ProjectTypeGuids_IsRecognized()
     {
         // Snippet with the Test Project Type Guid between two other Guids
-        const string projectXmlSnippet = @"
-<PropertyGroup>
-  <ProjectTypeGuids>D1C3357D-82B4-43D2-972C-4D5455F0A7DB;3AC096D0-A1C2-E12C-1390-A8335801FDAB;BF3D2153-F372-4432-8D43-09B24D530F20</ProjectTypeGuids>
-</PropertyGroup>
-";
-        // Act
+        const string projectXmlSnippet = """
+            <PropertyGroup>
+              <ProjectTypeGuids>D1C3357D-82B4-43D2-972C-4D5455F0A7DB;3AC096D0-A1C2-E12C-1390-A8335801FDAB;BF3D2153-F372-4432-8D43-09B24D530F20</ProjectTypeGuids>
+            </PropertyGroup>
+            """;
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
 
-        // Assert
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the MSTest project type guid -> test project.");
     }
 
     [TestMethod]
     public void ProjectTypeGuids_IsRecognized_CaseInsensitive()
     {
-        const string projectXmlSnippet = @"
-<PropertyGroup>
-  <ProjectTypeGuids>3AC096D0-A1C2-E12C-1390-A8335801fdab</ProjectTypeGuids>
-</PropertyGroup>
-";
-        // Act
+        const string projectXmlSnippet = """
+            <PropertyGroup>
+              <ProjectTypeGuids>3AC096D0-A1C2-E12C-1390-A8335801fdab</ProjectTypeGuids>
+            </PropertyGroup>
+            """;
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
 
-        // Assert
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the MSTest project type guid -> test project.");
     }
 
     [TestMethod]
     public void ServiceGuid_IsRecognized()
     {
-        const string projectXmlSnippet = @"
-<ItemGroup>
-  <Service Include='{D1C3357D-82B4-43D2-972C-4D5455F0A7DB}' />
-  <Service Include='{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}' />
-  <Service Include='{BF3D2153-F372-4432-8D43-09B24D530F20}' />
-</ItemGroup>
-";
-        // Act
+        const string projectXmlSnippet = """
+            <ItemGroup>
+              <Service Include='{D1C3357D-82B4-43D2-972C-4D5455F0A7DB}' />
+              <Service Include='{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}' />
+              <Service Include='{BF3D2153-F372-4432-8D43-09B24D530F20}' />
+            </ItemGroup>
+            """;
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
 
-        // Assert
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the legacy Test Explorer Service tag {82A7F48D-3B50-4B1E-B82E-3ADA8210C358} -> test project.");
     }
 
     [TestMethod]
     public void ServiceGuid_IsRecognized_CaseInsensitive()
     {
-        const string projectXmlSnippet = @"
-<ItemGroup>
-  <Service Include='{82a7f48d-3b50-4b1e-b82e-3ada8210c358}' />
-</ItemGroup>
-";
-        // Act
+        const string projectXmlSnippet = """
+            <ItemGroup>
+              <Service Include='{82a7f48d-3b50-4b1e-b82e-3ada8210c358}' />
+            </ItemGroup>
+            """;
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
 
-        // Assert
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the legacy Test Explorer Service tag {82A7F48D-3B50-4B1E-B82E-3ADA8210C358} -> test project.");
     }
 
     [TestMethod]
     public void ProjectCapability_IsRecognized()
     {
-        const string projectXmlSnippet = @"
-<ItemGroup>
-  <ProjectCapability Include='Foo' />
-  <ProjectCapability Include='TestContainer' />
-  <ProjectCapability Include='Something else' />
-</ItemGroup>
-";
-        // Act
+        const string projectXmlSnippet = """
+            <ItemGroup>
+              <ProjectCapability Include='Foo' />
+              <ProjectCapability Include='TestContainer' />
+              <ProjectCapability Include='Something else' />
+            </ItemGroup>
+            """;
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
 
-        // Assert
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the ProjectCapability 'TestContainer' -> test project.");
     }
 
     [TestMethod]
     public void ProjectCapability_IsRecognized_CaseInsensitive()
     {
-        const string projectXmlSnippet = @"
-<ItemGroup>
-  <ProjectCapability Include='testcontainer' />
-</ItemGroup>
-";
-        // Act
+        const string projectXmlSnippet = """
+            <ItemGroup>
+              <ProjectCapability Include='testcontainer' />
+            </ItemGroup>
+            """;
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
 
-        // Assert
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the ProjectCapability 'TestContainer' -> test project.");
     }
 
     [TestMethod]
     public void References_IsProduct()
     {
-        const string projectXmlSnippet = @"
-<ItemGroup>
-  <SonarResolvedReferences Include='mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' />
-  <SonarResolvedReferences Include='SimpleName' />
-</ItemGroup>";
-        // Act
+        const string projectXmlSnippet = """
+            <ItemGroup>
+              <SonarResolvedReferences Include='mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' />
+              <SonarResolvedReferences Include='SimpleName' />
+            </ItemGroup>
+            """;
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
 
-        // Assert
         AssertIsNotTestProject(result);
     }
 
@@ -264,89 +196,45 @@ public class SonarCategoriseProjectTests
     [TestMethod]
     public void References_IsTest()
     {
-        const string projectXmlSnippet = @"
-<ItemGroup>
-  <SonarResolvedReferences Include='mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' />
-  <SonarResolvedReferences Include='SimpleName' />
-  <SonarResolvedReferences Include='Moq, Version=4.16.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920' />
-  <SonarResolvedReferences Include='Microsoft.VisualStudio.TestPlatform.TestFramework' />
-</ItemGroup>";
-        // Act
+        const string projectXmlSnippet = """
+            <ItemGroup>
+              <SonarResolvedReferences Include='mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' />
+              <SonarResolvedReferences Include='SimpleName' />
+              <SonarResolvedReferences Include='Moq, Version=4.16.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920' />
+              <SonarResolvedReferences Include='Microsoft.VisualStudio.TestPlatform.TestFramework' />
+            </ItemGroup>
+            """;
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
 
-        // Assert
         AssertIsTestProject(result, "Sonar: (foo.proj) project is evaluated as a test project based on the 'Moq' reference.");
         // Only first match is reported in the log
         result.Messages.Should().NotContain("Sonar: (foo.proj) project is evaluated as a test project based on the 'Microsoft.VisualStudio.TestPlatform.TestFramework' reference.");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
-    [DataTestMethod]
-    [DataRow("dotMemory.Unit")]
-    [DataRow("Microsoft.VisualStudio.TestPlatform.TestFramework")]
-    [DataRow("Microsoft.VisualStudio.QualityTools.UnitTestFramework")]
-    [DataRow("Machine.Specifications")]
-    [DataRow("nunit.framework")]
-    [DataRow("nunitlite")]
-    [DataRow("TechTalk.SpecFlow")]
-    [DataRow("xunit")]
-    [DataRow("xunit.core")]
-    [DataRow("xunit.v3.core")]
-    [DataRow("FluentAssertions")]
-    [DataRow("Shouldly")]
-    [DataRow("FakeItEasy")]
-    [DataRow("Moq")]
-    [DataRow("NSubstitute")]
-    [DataRow("Rhino.Mocks")]
-    [DataRow("Telerik.JustMock")]
-    public void References_IsTest_AllLibraries(string testAssemblyName)
-    {
-        var projectXmlSnippet = $"""
-            <ItemGroup>
-              <SonarResolvedReferences Include='{testAssemblyName}' />
-            </ItemGroup>
-            """;
-        var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
-
-        AssertIsTestProject(result, $"Sonar: (foo.proj) project is evaluated as a test project based on the '{testAssemblyName}' reference.");
-    }
-
-    #endregion Detection of test projects
-
-    #region SQL Server projects tests
-
     [TestMethod]
     public void SqlServerProjectsAreNotExcluded()
     {
-        const string projectXmlSnippet = @"
-<PropertyGroup>
-  <SqlTargetName>non-empty</SqlTargetName>
-</PropertyGroup>
-";
-        // Act
+        const string projectXmlSnippet = """
+            <PropertyGroup>
+              <SqlTargetName>non-empty</SqlTargetName>
+            </PropertyGroup>
+            """;
         var result = BuildAndRunTarget("foo.sqproj", projectXmlSnippet);
 
-        // Assert
         AssertIsNotTestProject(result, "foo.sqproj");
         AssertProjectIsNotExcluded(result);
     }
 
-    #endregion SQL Server projects tests
-
-    #region Fakes projects tests
-
     [TestMethod] // SONARMSBRU-26: MS Fakes should be excluded from analysis
     public void FakesProjects_AreExcluded_WhenNoExplicitSonarProperties()
     {
-        const string projectXmlSnippet = @"
-<PropertyGroup>
-  <AssemblyName>f.fAKes</AssemblyName>
-</PropertyGroup>
-";
-        // Act
+        const string projectXmlSnippet = """
+            <PropertyGroup>
+              <AssemblyName>f.fAKes</AssemblyName>
+            </PropertyGroup>
+            """;
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
 
-        // Assert
         AssertIsTestProject(result, "Sonar: (foo.proj) project is a temporary project generated by Microsoft Fakes and will be ignored.");
         AssertProjectIsExcluded(result);
     }
@@ -355,16 +243,13 @@ public class SonarCategoriseProjectTests
     public void FakesProjects_FakesInName_AreNotExcluded()
     {
         // Checks that projects with ".fakes" in the name are not excluded
-
-        const string projectXmlSnippet = @"
-<PropertyGroup>
-  <AssemblyName>f.fAKes.proj</AssemblyName>
-</PropertyGroup>
-";
-        // Act
+        const string projectXmlSnippet = """
+            <PropertyGroup>
+              <AssemblyName>f.fAKes.proj</AssemblyName>
+            </PropertyGroup>
+            """;
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
 
-        // Assert
         AssertIsNotTestProject(result);
         AssertProjectIsNotExcluded(result);
     }
@@ -374,17 +259,14 @@ public class SonarCategoriseProjectTests
     {
         // Checks that fakes projects are not marked as test if the project
         // says otherwise.
-
-        const string projectXmlSnippet = @"
-<PropertyGroup>
-  <SonarQubeTestProject>false</SonarQubeTestProject>
-  <AssemblyName>MyFakeProject.fakes</AssemblyName>
-</PropertyGroup>
-";
-        // Act
+        const string projectXmlSnippet = """
+            <PropertyGroup>
+              <SonarQubeTestProject>false</SonarQubeTestProject>
+              <AssemblyName>MyFakeProject.fakes</AssemblyName>
+            </PropertyGroup>
+            """;
         var result = BuildAndRunTarget("foo.proj", projectXmlSnippet);
 
-        // Assert
         AssertIsNotTestProject(result);
     }
 
@@ -393,67 +275,45 @@ public class SonarCategoriseProjectTests
     {
         // Checks that fakes projects are not excluded if the project
         // says otherwise.
-
-        const string projectXmlSnippet = @"
-<PropertyGroup>
-  <SonarQubeExclude>false</SonarQubeExclude>
-  <AssemblyName>MyFakeProject.fakes</AssemblyName>
-</PropertyGroup>
-";
-        // Act
+        const string projectXmlSnippet = """
+            <PropertyGroup>
+              <SonarQubeExclude>false</SonarQubeExclude>
+              <AssemblyName>MyFakeProject.fakes</AssemblyName>
+            </PropertyGroup>
+            """;
         var result = BuildAndRunTarget("f.proj", projectXmlSnippet);
 
-        // Assert
         AssertProjectIsNotExcluded(result);
     }
 
-    #endregion Fakes projects tests
-
-    #region Temp projects tests
-
-    [TestMethod]
-    public void WpfTemporaryProjects_AreExcluded()
+    [DataRow("f.tmp_proj", true)]
+    [DataRow("f.TMP_PROJ", true)]
+    [DataRow("f_wpftmp.csproj", true)]
+    [DataRow("f_WpFtMp.csproj", true)]
+    [DataRow("f_wpftmp.vbproj", true)]
+    [DataRow("WpfApplication.csproj", false)]
+    [DataRow("ftmp_proj.csproj", false)]
+    [DataRow("wpftmp.csproj", false)]
+    [DataTestMethod]
+    public void WpfTemporaryProjects_AreExcluded(string projectName, bool expectedExclusionState)
     {
-        ExecuteTest("f.tmp_proj", expectedExclusionState: true);
-        ExecuteTest("f.TMP_PROJ", expectedExclusionState: true);
-        ExecuteTest("f_wpftmp.csproj", expectedExclusionState: true);
-        ExecuteTest("f_WpFtMp.csproj", expectedExclusionState: true);
-        ExecuteTest("f_wpftmp.vbproj", expectedExclusionState: true);
-
-        ExecuteTest("WpfApplication.csproj", expectedExclusionState: false);
-        ExecuteTest("ftmp_proj.csproj", expectedExclusionState: false);
-        ExecuteTest("wpftmp.csproj", expectedExclusionState: false);
-
-        void ExecuteTest(string projectName, bool expectedExclusionState)
+        var result = BuildAndRunTarget(projectName, string.Empty);
+        AssertIsNotTestProject(result, projectName);
+        if (expectedExclusionState)
         {
-            // Act
-            var result = BuildAndRunTarget(projectName, string.Empty);
-
-            // Assert
-            AssertIsNotTestProject(result, projectName);
-
-            if (expectedExclusionState)
-            {
-                AssertProjectIsExcluded(result);
-                result.Messages.Should().Contain($"Sonar: ({projectName}) project is a temporary project and will be excluded.");
-            }
-            else
-            {
-                AssertProjectIsNotExcluded(result);
-            }
+            AssertProjectIsExcluded(result);
+            result.Messages.Should().Contain($"Sonar: ({projectName}) project is a temporary project and will be excluded.");
+        }
+        else
+        {
+            AssertProjectIsNotExcluded(result);
         }
     }
-
-    #endregion Temp projects tests
 
     private BuildLog BuildAndRunTarget(string projectFileName, string projectXmlSnippet, string analysisConfigDir = "c:\\dummy")
     {
         var projectFilePath = CreateProjectFile(projectFileName, projectXmlSnippet, analysisConfigDir);
-
-        // Act
         var result = BuildRunner.BuildTargets(TestContext, projectFilePath, TargetConstants.SonarCategoriseProject);
-
-        // Assert
         result.AssertTargetSucceeded(TargetConstants.SonarCategoriseProject);
         return result;
     }
@@ -461,14 +321,16 @@ public class SonarCategoriseProjectTests
     private string CreateProjectFile(string projectFileName, string xmlSnippet, string analysisConfigDir)
     {
         var rootInputFolder = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "Inputs");
-
         var sqTargetFile = TestUtils.EnsureAnalysisTargetsExists(TestContext);
         var projectFilePath = Path.Combine(rootInputFolder, projectFileName);
 
         // Boilerplate XML for minimal project file that will execute the "categorise project" task
         var projectXml = Resources.CategoriseProjectTestTemplate;
 
-        BuildUtilities.CreateFileFromTemplate(projectFilePath, TestContext, projectXml,
+        BuildUtilities.CreateFileFromTemplate(
+            projectFilePath,
+            TestContext,
+            projectXml,
             xmlSnippet,
             Guid.NewGuid(),
             typeof(WriteProjectInfoFile).Assembly.Location,
@@ -487,11 +349,10 @@ public class SonarCategoriseProjectTests
     private string CreateAnalysisConfigWithRegEx(string regExExpression)
     {
         var config = new AnalysisConfig();
-        if (regExExpression != null)
+        if (regExExpression is not null)
         {
-            config.LocalSettings = new AnalysisProperties { new(IsTestFileByName.TestRegExSettingId, regExExpression) };
+            config.LocalSettings = [new(IsTestFileByName.TestRegExSettingId, regExExpression)];
         }
-
         var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
         var fullPath = Path.Combine(testDir, "SonarQubeAnalysisConfig.xml");
         if (File.Exists(fullPath))
@@ -507,17 +368,17 @@ public class SonarCategoriseProjectTests
     {
         log.GetPropertyAsBoolean(TargetProperties.SonarQubeTestProject).Should().BeTrue();
         log.Messages.Should()
-            .Contain("Sonar: (foo.proj) Categorizing project as test or product code...").And
-            .Contain("Sonar: (foo.proj) categorized as TEST project (test code).").And
-            .Contain(expectedReason);
+            .Contain("Sonar: (foo.proj) Categorizing project as test or product code...")
+            .And.Contain("Sonar: (foo.proj) categorized as TEST project (test code).")
+            .And.Contain(expectedReason);
     }
 
     private static void AssertIsNotTestProject(BuildLog log, string projectName = "foo.proj")
     {
         log.GetPropertyAsBoolean(TargetProperties.SonarQubeTestProject).Should().BeFalse();
         log.Messages.Should()
-            .Contain($"Sonar: ({projectName}) Categorizing project as test or product code...").And
-            .Contain($"Sonar: ({projectName}) categorized as MAIN project (production code).");
+            .Contain($"Sonar: ({projectName}) Categorizing project as test or product code...")
+            .And.Contain($"Sonar: ({projectName}) categorized as MAIN project (production code).");
     }
 
     private static void AssertProjectIsExcluded(BuildLog log) =>

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/SonarCategoriseProjectTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/SonarCategoriseProjectTests.cs
@@ -36,7 +36,6 @@ public class SonarCategoriseProjectTests
 
     #region Detection of test projects
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void SimpleProject_NoTestMarkers_IsNotATestProject()
     {
@@ -47,7 +46,6 @@ public class SonarCategoriseProjectTests
         AssertIsNotTestProject(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void ExplicitMarking_IsTrue()
     {
@@ -64,7 +62,6 @@ public class SonarCategoriseProjectTests
         AssertProjectIsNotExcluded(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void ExplicitMarking_IsFalse()
     {
@@ -92,7 +89,6 @@ public class SonarCategoriseProjectTests
         result.Messages.Should().Contain($"Sonar: (foo.proj) SonarQubeTestProject has been set explicitly to false.");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void WildcardMatch_Default_NoMatchForTestName()
     {
@@ -107,7 +103,6 @@ public class SonarCategoriseProjectTests
         AssertProjectIsNotExcluded(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void WildcardMatch_Default_NoMatchForOtherName()
     {
@@ -122,7 +117,6 @@ public class SonarCategoriseProjectTests
         AssertProjectIsNotExcluded(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void WildcardMatch_UserSpecified_Match()
     {
@@ -139,7 +133,6 @@ public class SonarCategoriseProjectTests
         AssertProjectIsNotExcluded(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void WildcardMatch_UserSpecified_NoMatch()
     {
@@ -157,7 +150,6 @@ public class SonarCategoriseProjectTests
         AssertProjectIsNotExcluded(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void ProjectTypeGuids_IsRecognized()
     {
@@ -174,7 +166,6 @@ public class SonarCategoriseProjectTests
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the MSTest project type guid -> test project.");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void ProjectTypeGuids_IsRecognized_CaseInsensitive()
     {
@@ -190,7 +181,6 @@ public class SonarCategoriseProjectTests
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the MSTest project type guid -> test project.");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void ServiceGuid_IsRecognized()
     {
@@ -208,7 +198,6 @@ public class SonarCategoriseProjectTests
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the legacy Test Explorer Service tag {82A7F48D-3B50-4B1E-B82E-3ADA8210C358} -> test project.");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void ServiceGuid_IsRecognized_CaseInsensitive()
     {
@@ -224,7 +213,6 @@ public class SonarCategoriseProjectTests
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the legacy Test Explorer Service tag {82A7F48D-3B50-4B1E-B82E-3ADA8210C358} -> test project.");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void ProjectCapability_IsRecognized()
     {
@@ -242,7 +230,6 @@ public class SonarCategoriseProjectTests
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the ProjectCapability 'TestContainer' -> test project.");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void ProjectCapability_IsRecognized_CaseInsensitive()
     {
@@ -258,7 +245,6 @@ public class SonarCategoriseProjectTests
         AssertIsTestProject(result, "Sonar: (foo.proj) project has the ProjectCapability 'TestContainer' -> test project.");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void References_IsProduct()
     {
@@ -329,7 +315,6 @@ public class SonarCategoriseProjectTests
 
     #region SQL Server projects tests
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void SqlServerProjectsAreNotExcluded()
     {
@@ -350,7 +335,6 @@ public class SonarCategoriseProjectTests
 
     #region Fakes projects tests
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod] // SONARMSBRU-26: MS Fakes should be excluded from analysis
     public void FakesProjects_AreExcluded_WhenNoExplicitSonarProperties()
     {
@@ -367,7 +351,6 @@ public class SonarCategoriseProjectTests
         AssertProjectIsExcluded(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void FakesProjects_FakesInName_AreNotExcluded()
     {
@@ -386,7 +369,6 @@ public class SonarCategoriseProjectTests
         AssertProjectIsNotExcluded(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void FakesProjects_AreNotTestProjects_WhenExplicitSonarTestProperty() // @odalet - Issue #844
     {
@@ -406,7 +388,6 @@ public class SonarCategoriseProjectTests
         AssertIsNotTestProject(result);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void FakesProjects_AreNotExcluded_WhenExplicitSonarExcludeProperty() // @odalet - Issue #844
     {
@@ -430,7 +411,6 @@ public class SonarCategoriseProjectTests
 
     #region Temp projects tests
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void WpfTemporaryProjects_AreExcluded()
     {


### PR DESCRIPTION
[SCAN4NET-664](https://sonarsource.atlassian.net/browse/SCAN4NET-664)

Part of SCAN4NET-387

Technically I think I could make all of these into one single DataTestMethod with large DataRows.
But I think keeping the test names is valuable and that would be messy.

[SCAN4NET-664]: https://sonarsource.atlassian.net/browse/SCAN4NET-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ