### PR TITLE
SCAN4NET-676 Change DebugType to portable

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 


### PR DESCRIPTION
[SCAN4NET-676](https://sonarsource.atlassian.net/browse/SCAN4NET-676)

For a better ubuntu debugging experience, the symbol file format needs to be changed to `portable`.
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/code-generation

[SCAN4NET-676]: https://sonarsource.atlassian.net/browse/SCAN4NET-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ