### PR TITLE
SCAN4NET-685 Fix failing UTs on Linux/MacOS in TrxFileReaderTests

### DIFF
--- a/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
@@ -51,14 +51,9 @@ public class TrxFileReaderTests
     }
 
     [TestMethod]
-    public void TrxReader_TestsResultsDirectoryMissing()
-    {
+    public void TrxReader_TestsResultsDirectoryMissing() =>
         // With no call to CreateDirectories, Directory.GetDirectories(RootDirectory) will return an empty array.
-        trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEmpty();
-        // Not expecting errors or warnings: we assume it means that tests have not been executed
-        logger.AssertErrorsLogged(0);
-        logger.AssertWarningsLogged(0);
-    }
+        AssertFindCodeCoverageFiles();
 
     [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
@@ -81,11 +76,9 @@ public class TrxFileReaderTests
         directoryMock.GetFiles(Arg.Is<string>(x => testResults.Equals(x, StringComparison.InvariantCultureIgnoreCase)), Arg.Any<string>())
             .Returns([file1, file2]);
 
-        trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEmpty();
+        AssertFindCodeCoverageFiles();
         logger.DebugMessages.Should().BeEmpty();
         logger.AssertSingleInfoMessageExists("No code coverage attachments were found from the trx files.");
-        logger.AssertWarningsLogged(0);
-        logger.AssertErrorsLogged(0);
     }
 
     [TestMethod]
@@ -96,9 +89,7 @@ public class TrxFileReaderTests
             .GetDirectories(Arg.Is<string>(x => RootDirectory.Equals(x, StringComparison.InvariantCultureIgnoreCase)), "TestResults", SearchOption.AllDirectories)
             .Returns([testResults]);
 
-        trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEmpty();
-        logger.AssertErrorsLogged(0);
-        logger.AssertWarningsLogged(0);
+        AssertFindCodeCoverageFiles();
         logger.AssertSingleInfoMessageExists("No code coverage attachments were found from the trx files.");
     }
 
@@ -106,9 +97,7 @@ public class TrxFileReaderTests
     public void TrxReader_TrxWithNoAttachments()
     {
         CreateDirectory(RootDirectory, "no_attachments.trx", TrxContent());
-        trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEmpty();
-        logger.AssertErrorsLogged(0);
-        logger.AssertWarningsLogged(0);
+        AssertFindCodeCoverageFiles();
         logger.AssertSingleInfoMessageExists("No code coverage attachments were found from the trx files.");
     }
 
@@ -297,4 +286,11 @@ public class TrxFileReaderTests
             </UriAttachments>
         </Collector>
         """;
+
+    private void AssertFindCodeCoverageFiles()
+    {
+        trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEmpty();
+        logger.AssertErrorsLogged(0);
+        logger.AssertWarningsLogged(0);
+    }
 }

--- a/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
@@ -62,7 +62,7 @@ public class TrxFileReaderTests
         trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEmpty();
         logger.AssertSingleInfoMessageExists("No code coverage attachments were found from the trx files.");
         logger.Warnings.Should().ContainSingle().Which.Should()
-            .Match(@$"Located trx file is not a valid xml file. File: *{Path.Combine("TestResults", "dummy.trx")}. File load error: Data at the root level is invalid. Line 1, position 1.");
+            .Match($"Located trx file is not a valid xml file. File: *{Path.Combine("TestResults", "dummy.trx")}. File load error: Data at the root level is invalid. Line 1, position 1.");
         logger.AssertErrorsLogged(0); // should be a warning, not an error
     }
 
@@ -109,16 +109,16 @@ public class TrxFileReaderTests
         logger.Warnings.OrderBy(x => x).Should().SatisfyRespectively(
             x => x.Should().Match(
                     "None of the following coverage attachments could be found: "
-                    + @"MACHINENAME\AAA.coverage, "
-                    + @$"*{Path.Combine("TestResults", "multiple_attachments", "In", @"MACHINENAME\AAA.coverage")}, "
-                    + @$"*{Path.Combine("TestResults", "multiple_attachments", "In", @"MACHINENAME\AAA.coverage")}. "
-                    + @$"Trx file: *{Path.Combine("TestResults", "multiple_attachments.trx")}"),
+                    + "MACHINENAME\AAA.coverage, "
+                    + $"*{Path.Combine("TestResults", "multiple_attachments", "In", @"MACHINENAME\AAA.coverage")}, "
+                    + $"*{Path.Combine("TestResults", "multiple_attachments", "In", @"MACHINENAME\AAA.coverage")}. "
+                    + $"Trx file: *{Path.Combine("TestResults", "multiple_attachments.trx")}"),
             x => x.Should().Match(
                     "None of the following coverage attachments could be found: "
                     + "XXX.coverage, "
-                    + @$"*{Path.Combine("TestResults", "multiple_attachments", "In", "XXX.coverage")}, "
-                    + @$"*{Path.Combine("TestResults", "multiple_attachments", "In", "XXX.coverage")}. "
-                    + @$"Trx file: *{Path.Combine("TestResults", "multiple_attachments.trx")}"));
+                    + $"*{Path.Combine("TestResults", "multiple_attachments", "In", "XXX.coverage")}, "
+                    + $"*{Path.Combine("TestResults", "multiple_attachments", "In", "XXX.coverage")}. "
+                    + $"Trx file: *{Path.Combine("TestResults", "multiple_attachments.trx")}"));
         logger.AssertErrorsLogged(0);
     }
 
@@ -130,10 +130,10 @@ public class TrxFileReaderTests
         trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEmpty();
         logger.Warnings.Should().ContainSingle().Which.Should().Match(
             "None of the following coverage attachments could be found: "
-            + @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage, "
-            + @$"*{Path.Combine("TestResults", "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}, "
-            + @$"*{Path.Combine("TestResults", "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}. "
-            + @$"Trx file: *{Path.Combine("TestResults", "single_attachment.trx")}");
+            + "MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage, "
+            + $"*{Path.Combine("TestResults", "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}, "
+            + $"*{Path.Combine("TestResults", "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}. "
+            + $"Trx file: *{Path.Combine("TestResults", "single_attachment.trx")}");
     }
 
     [TestMethod]
@@ -172,7 +172,7 @@ public class TrxFileReaderTests
         CreateDirectory(RootDirectory, "single_attachment.trx", TrxContent(coverageFileName));
 
         trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEquivalentTo(coverageFileName);
-        logger.AssertDebugMessageExists(@$"Absolute path to coverage file: {Path.Combine(@"x:\dir1", "TestResults", "xxx.coverage")}");
+        logger.AssertDebugMessageExists($"Absolute path to coverage file: {Path.Combine(@"x:\dir1", "TestResults", "xxx.coverage")}");
     }
 
     [TestMethod]
@@ -185,9 +185,9 @@ public class TrxFileReaderTests
         CreateFile(Path.GetDirectoryName(coverageFileName), Path.GetFileName(coverageFileName));
 
         trxReader.FindCodeCoverageFiles(RootDirectory).Should().ContainSingle()
-            .Which.Should().EndWith(@$"{Path.Combine("TestResults", "pathFromDeploymentRoot", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}")
+            .Which.Should().EndWith($"{Path.Combine("TestResults", "pathFromDeploymentRoot", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}")
             .And.Be(coverageFileName);
-        logger.AssertDebugLogged($@"Absolute path to coverage file: {coverageFileName}");
+        logger.AssertDebugLogged($"Absolute path to coverage file: {coverageFileName}");
     }
 
     [TestMethod]
@@ -203,10 +203,10 @@ public class TrxFileReaderTests
         logger.AssertWarningLogged(
             "None of the following coverage attachments could be found: "
             + @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage, "
-            + $@"{Path.Combine(resultsDir, "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}, "
-            + $@"{Path.Combine(resultsDir, "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}, "
-            + $@"{Path.Combine(resultsDir, "invalidRoot", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}. "
-            + $@"Trx file: {Path.Combine(resultsDir, "single_attachment.trx")}");
+            + $"{Path.Combine(resultsDir, "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}, "
+            + $"{Path.Combine(resultsDir, "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}, "
+            + $"{Path.Combine(resultsDir, "invalidRoot", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}. "
+            + $"Trx file: {Path.Combine(resultsDir, "single_attachment.trx")}");
     }
 
     private string CreateDirectory(string path, string fileName = null, string fileContent = "")

--- a/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
@@ -108,19 +108,19 @@ public class TrxFileReaderTests
     {
         CreateDirectory(RootDirectory, "multiple_attachments.trx", TrxContent("MACHINENAME\\AAA.coverage", "XXX.coverage"));
         trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEmpty();
-        logger.Warnings.Should().SatisfyRespectively(
+        logger.Warnings.OrderBy(x => x).Should().SatisfyRespectively(
             x => x.Should().Match(
                     "None of the following coverage attachments could be found: "
                     + @"MACHINENAME\AAA.coverage, "
-                    + @"*\TestResults\multiple_attachments\In\MACHINENAME\AAA.coverage, "
-                    + @"*\TestResults\multiple_attachments\In\MACHINENAME\AAA.coverage. "
-                    + @"Trx file: *\TestResults\multiple_attachments.trx"),
+                    + @$"*{Path.Combine("TestResults", "multiple_attachments", "In", @"MACHINENAME\AAA.coverage")}, "
+                    + @$"*{Path.Combine("TestResults", "multiple_attachments", "In", @"MACHINENAME\AAA.coverage")}. "
+                    + @$"Trx file: *{Path.Combine("TestResults", "multiple_attachments.trx")}"),
             x => x.Should().Match(
                     "None of the following coverage attachments could be found: "
                     + "XXX.coverage, "
-                    + @"*\TestResults\multiple_attachments\In\XXX.coverage, "
-                    + @"*\TestResults\multiple_attachments\In\XXX.coverage. "
-                    + @"Trx file: *\TestResults\multiple_attachments.trx"));
+                    + @$"*{Path.Combine("TestResults", "multiple_attachments", "In", "XXX.coverage")}, "
+                    + @$"*{Path.Combine("TestResults", "multiple_attachments", "In", "XXX.coverage")}. "
+                    + @$"Trx file: *{Path.Combine("TestResults", "multiple_attachments.trx")}"));
         logger.AssertErrorsLogged(0);
     }
 

--- a/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
@@ -101,7 +101,6 @@ public class TrxFileReaderTests
         logger.AssertSingleInfoMessageExists("No code coverage attachments were found from the trx files.");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Tests handling of a trx file that contains information about multiple code coverage runs (i.e. an error case, as we're not expecting this)")]
     public void TrxReader_TrxWithMultipleAttachments()
@@ -124,7 +123,6 @@ public class TrxFileReaderTests
         logger.AssertErrorsLogged(0);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Tests handling of a trx file that contains a single code coverage attachment with a non existing file")]
     public void TrxReader_SingleAttachment_PathDoesNotExist()
@@ -134,9 +132,9 @@ public class TrxFileReaderTests
         logger.Warnings.Should().ContainSingle().Which.Should().Match(
             "None of the following coverage attachments could be found: "
             + @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage, "
-            + @"*\TestResults\single_attachment\In\MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage, "
-            + @"*\TestResults\single_attachment\In\MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage. "
-            + @"Trx file: *\TestResults\single_attachment.trx");
+            + @$"*{Path.Combine("TestResults", "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}, "
+            + @$"*{Path.Combine("TestResults", "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}. "
+            + @$"Trx file: *{Path.Combine("TestResults", "single_attachment.trx")}");
     }
 
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
@@ -96,7 +96,10 @@ public class TrxFileReaderTests
     [TestMethod]
     public void TrxReader_SingleTrxFileInSubfolder()
     {
-        var testResults = CreateDirectories(RootDirectory, "Dummy\\TestResults")[0];
+        var testResults = CreateDirectories(Path.Combine(RootDirectory, "Dummy"), "TestResults")[0];
+        directoryMock
+            .GetDirectories(Arg.Is<string>(x => RootDirectory.Equals(x, StringComparison.InvariantCultureIgnoreCase)), "TestResults", SearchOption.AllDirectories)
+            .Returns([testResults]);
         CreateFiles(testResults, ("no_attachments.trx", TrxContent()));
 
         trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEmpty();

--- a/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
@@ -245,7 +245,7 @@ public class TrxFileReaderTests
     {
         var subdir = Path.Combine(path, "TestResults");
         directoryMock.Exists(Arg.Is<string>(x => subdir.Equals(x, StringComparison.InvariantCultureIgnoreCase))).Returns(true);
-        directoryMock.GetDirectories(Arg.Is<string>(x => path.Equals(x, StringComparison.InvariantCultureIgnoreCase)), Arg.Any<string>(), Arg.Any<SearchOption>())
+        directoryMock.GetDirectories(Arg.Is<string>(x => path.Equals(x, StringComparison.InvariantCultureIgnoreCase)), "TestResults", Arg.Any<SearchOption>())
             .Returns([subdir]);
         return subdir;
     }

--- a/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
@@ -176,7 +176,6 @@ public class TrxFileReaderTests
         logger.AssertDebugMessageExists(@$"Absolute path to coverage file: {Path.Combine(@"x:\dir1", "TestResults", "xxx.coverage")}");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Tests handling of a trx file that contain a single code coverage attachment with a path specified by the runDeploymentRoot attribute")]
     public void TrxReader_RunDeploymentRoot_Valid()
@@ -187,12 +186,11 @@ public class TrxFileReaderTests
         CreateFile(Path.GetDirectoryName(coverageFileName), Path.GetFileName(coverageFileName));
 
         trxReader.FindCodeCoverageFiles(RootDirectory).Should().ContainSingle()
-            .Which.Should().EndWith(@"TestResults\pathFromDeploymentRoot\In\MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")
+            .Which.Should().EndWith(@$"{Path.Combine("TestResults", "pathFromDeploymentRoot", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}")
             .And.Be(coverageFileName);
         logger.AssertDebugLogged($@"Absolute path to coverage file: {coverageFileName}");
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Tests handling of a trx file that contain a single code coverage attachment with an invalid path specified by the runDeploymentRoot attribute")]
     public void TrxReader_RunDeploymentRoot_Invalid()
@@ -206,10 +204,10 @@ public class TrxFileReaderTests
         logger.AssertWarningLogged(
             "None of the following coverage attachments could be found: "
             + @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage, "
-            + $@"{resultsDir}\single_attachment\In\MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage, "
-            + $@"{resultsDir}\single_attachment\In\MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage, "
-            + $@"{resultsDir}\invalidRoot\In\MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage. "
-            + $@"Trx file: {resultsDir}\single_attachment.trx");
+            + $@"{Path.Combine(resultsDir, "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}, "
+            + $@"{Path.Combine(resultsDir, "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}, "
+            + $@"{Path.Combine(resultsDir, "invalidRoot", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}. "
+            + $@"Trx file: {Path.Combine(resultsDir, "single_attachment.trx")}");
     }
 
     private string CreateDirectory(string path, string fileName = null, string fileContent = "")

--- a/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
@@ -164,17 +164,16 @@ public class TrxFileReaderTests
         logger.AssertDebugMessageExists(relativeCoveragePath);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     [Description("Tests handling of a trx file that contains a single code coverage attachment with a rooted path")]
     public void TrxReader_SingleAttachment_AbsolutePath()
     {
-        var coverageResults = CreateDirectory("x:\\dir1");
+        var coverageResults = CreateDirectory(@"x:\dir1");
         var coverageFileName = CreateFile(coverageResults, "xxx.coverage");
         CreateDirectory(RootDirectory, "single_attachment.trx", TrxContent(coverageFileName));
 
         trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEquivalentTo(coverageFileName);
-        logger.AssertDebugMessageExists(@"Absolute path to coverage file: x:\dir1\TestResults\xxx.coverage");
+        logger.AssertDebugMessageExists(@$"Absolute path to coverage file: {Path.Combine(@"x:\dir1", "TestResults", "xxx.coverage")}");
     }
 
     [TestCategory(TestCategories.NoUnixNeedsReview)]

--- a/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
@@ -55,7 +55,6 @@ public class TrxFileReaderTests
         // With no call to CreateDirectories, Directory.GetDirectories(RootDirectory) will return an empty array.
         AssertFindCodeCoverageFiles();
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void TrxReader_InvalidTrxFile()
     {
@@ -63,7 +62,7 @@ public class TrxFileReaderTests
         trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEmpty();
         logger.AssertSingleInfoMessageExists("No code coverage attachments were found from the trx files.");
         logger.Warnings.Should().ContainSingle().Which.Should()
-            .Match(@"Located trx file is not a valid xml file. File: *\TestResults\dummy.trx. File load error: Data at the root level is invalid. Line 1, position 1.");
+            .Match(@$"Located trx file is not a valid xml file. File: *{Path.Combine("TestResults", "dummy.trx")}. File load error: Data at the root level is invalid. Line 1, position 1.");
         logger.AssertErrorsLogged(0); // should be a warning, not an error
     }
 

--- a/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/TrxFileReaderTests.cs
@@ -109,7 +109,7 @@ public class TrxFileReaderTests
         logger.Warnings.OrderBy(x => x).Should().SatisfyRespectively(
             x => x.Should().Match(
                     "None of the following coverage attachments could be found: "
-                    + "MACHINENAME\AAA.coverage, "
+                    + @"MACHINENAME\AAA.coverage, "
                     + $"*{Path.Combine("TestResults", "multiple_attachments", "In", @"MACHINENAME\AAA.coverage")}, "
                     + $"*{Path.Combine("TestResults", "multiple_attachments", "In", @"MACHINENAME\AAA.coverage")}. "
                     + $"Trx file: *{Path.Combine("TestResults", "multiple_attachments.trx")}"),
@@ -130,7 +130,7 @@ public class TrxFileReaderTests
         trxReader.FindCodeCoverageFiles(RootDirectory).Should().BeEmpty();
         logger.Warnings.Should().ContainSingle().Which.Should().Match(
             "None of the following coverage attachments could be found: "
-            + "MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage, "
+            + @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage, "
             + $"*{Path.Combine("TestResults", "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}, "
             + $"*{Path.Combine("TestResults", "single_attachment", "In", @"MACHINENAME\LOCAL SERVICE_MACHINENAME 2015-05-06 08_38_35.coverage")}. "
             + $"Trx file: *{Path.Combine("TestResults", "single_attachment.trx")}");

--- a/src/SonarScanner.MSBuild.TFS/TrxFileReader.cs
+++ b/src/SonarScanner.MSBuild.TFS/TrxFileReader.cs
@@ -18,13 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using System.Xml;
-using SonarScanner.MSBuild.Common;
 
 namespace SonarScanner.MSBuild.TFS;
 


### PR DESCRIPTION
[SCAN4NET-685](https://sonarsource.atlassian.net/browse/SCAN4NET-685)

Part of SCAN4NET-438

[SCAN4NET-685]: https://sonarsource.atlassian.net/browse/SCAN4NET-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ