### PR TITLE
SCAN4NET-686 Fix failing UTs on Linux/MacOS in CacheProcessorTests.cs

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
@@ -105,27 +105,25 @@ public class CacheProcessorTests
         sut.PullRequestCacheBasePath.Should().Be(Path.Combine(workingDirectory, "Custom"));
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void PullRequestCacheBasePath_NoProjectBaseDir_UsesSourcesDirectory()
     {
         var buildSettings = Substitute.For<IBuildSettings>();
-        buildSettings.SourcesDirectory.Returns(@"C:\Sources\Directory");
-        buildSettings.SonarScannerWorkingDirectory.Returns(@"C:\SonarScanner\WorkingDirectory");
+        buildSettings.SourcesDirectory.Returns(Path.Combine(TestUtils.DriveRoot(), "Sources", "Directory"));
+        buildSettings.SonarScannerWorkingDirectory.Returns(TestUtils.DriveRoot(), "SonarScanner", "WorkingDirectory");
         using var sut = CreateSut(buildSettings);
 
-        sut.PullRequestCacheBasePath.Should().Be(@"C:\Sources\Directory");
+        sut.PullRequestCacheBasePath.Should().Be(Path.Combine(TestUtils.DriveRoot(), "Sources", "Directory"));
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
     [TestMethod]
     public void PullRequestCacheBasePath_NoSourcesDirectory_UsesSonarScannerWorkingDirectory()
     {
         var buildSettings = Substitute.For<IBuildSettings>();
-        buildSettings.SonarScannerWorkingDirectory.Returns(@"C:\SonarScanner\WorkingDirectory");
+        buildSettings.SonarScannerWorkingDirectory.Returns(TestUtils.DriveRoot(), "SonarScanner", "WorkingDirectory");
         using var sut = CreateSut(buildSettings);
 
-        sut.PullRequestCacheBasePath.Should().Be(@"C:\SonarScanner\WorkingDirectory");
+        sut.PullRequestCacheBasePath.Should().Be(TestUtils.DriveRoot(), "SonarScanner", "WorkingDirectory");
     }
 
     [TestMethod]


### PR DESCRIPTION
[SCAN4NET-686](https://sonarsource.atlassian.net/browse/SCAN4NET-686)



[SCAN4NET-686]: https://sonarsource.atlassian.net/browse/SCAN4NET-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ