### PR TITLE
SCAN4NET-687 Fix failing UTs on Linux/MacOS in PreProcessorTests.cs

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
@@ -60,7 +60,10 @@ public partial class PreProcessorTests
         """);
     }
 
-    [TestCategory(TestCategories.NoUnixNeedsReview)]
+    // Windows enforces file locks at the OS level.
+    // Unix does not enforce file locks at the OS level, so this doesn't work.
+    [TestCategory(TestCategories.NoLinux)]
+    [TestCategory(TestCategories.NoMacOS)]
     [TestMethod]
     public async Task Execute_CannotCreateDirectories_ReturnsFalseAndLogsError()
     {


### PR DESCRIPTION
[SCAN4NET-687](https://sonarsource.atlassian.net/browse/SCAN4NET-687)



[SCAN4NET-687]: https://sonarsource.atlassian.net/browse/SCAN4NET-687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ