### PR TITLE
SCAN4NET-693 SonarScanner.MSBuild.Shim.Test: Fix failing UTs on Linux/MacOS - PathHelperTests

### DIFF
--- a/src/SonarScanner.MSBuild.Shim/PathHelper.cs
+++ b/src/SonarScanner.MSBuild.Shim/PathHelper.cs
@@ -66,7 +66,7 @@ public static class PathHelper
         }
     }
 
-    public static string[] GetParts(DirectoryInfo directory)
+    public static string[] GetParts(this DirectoryInfo directory)
     {
         _ = directory ?? throw new ArgumentNullException(nameof(directory));
         var parts = new List<string>();


### PR DESCRIPTION
[SCAN4NET-693](https://sonarsource.atlassian.net/browse/SCAN4NET-693)



[SCAN4NET-693]: https://sonarsource.atlassian.net/browse/SCAN4NET-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ