### PR TITLE
SCAN4NET-701 Fix MSTEST0049 Flow TestContext cancellation token

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/MutexWrapperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/MutexWrapperTests.cs
@@ -30,6 +30,11 @@ namespace SonarScanner.MSBuild.Common.Test;
 [TestClass]
 public class MutexWrapperTests
 {
+    public TestContext TestContext { get; }
+
+    public MutexWrapperTests(TestContext testContext) =>
+        TestContext = testContext;
+
     [TestMethod]
     public void MultipleDispose_DoesntThrow()
     {
@@ -72,7 +77,7 @@ public class MutexWrapperTests
                 {
                     new SingleGlobalInstanceMutex(mutexName, oneMinute);
                     steps.Add(201);
-                    Task.Delay(oneMinute, cancel.Token).Wait();
+                    Task.Delay(oneMinute, cancel.Token).Wait(TestContext.CancellationTokenSource.Token);
                     steps.Add(202);
                 }
                 catch (AggregateException aggEx) when (aggEx.InnerException is TaskCanceledException)

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilder.Net.Tests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilder.Net.Tests.cs
@@ -59,7 +59,7 @@ public partial class CertificateBuilderTests
             return valid;
         };
         using var client = new HttpClient(handler);
-        var result = await client.GetStringAsync(server.Url);
+        var result = await client.GetStringAsync(server.Url, TestContext.CancellationTokenSource.Token);
         result.Should().Be("Hello World");
         crlServer.LogEntries.Should().Contain(x => x.RequestMessage.Path == "/Revoked.crl");
     }
@@ -92,7 +92,7 @@ public partial class CertificateBuilderTests
             return valid;
         };
         using var client = new HttpClient(handler);
-        var download = async () => await client.GetStringAsync(server.Url);
+        var download = async () => await client.GetStringAsync(server.Url, TestContext.CancellationTokenSource.Token);
         await download.Should().ThrowAsync<HttpRequestException>();
         crlServer.LogEntries.Should().Contain(x => x.RequestMessage.Path == "/Revoked.crl");
     }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Certificates/CertificateBuilderTests.cs
@@ -31,6 +31,11 @@ namespace SonarScanner.MSBuild.PreProcessor.Test.Certificates;
 [DoNotParallelize]
 public partial class CertificateBuilderTests
 {
+    public TestContext TestContext { get; }
+
+    public CertificateBuilderTests(TestContext testContext) =>
+        TestContext = testContext;
+
     [TestMethod]
     public async Task MockServerReturnsSelfSignedCertificate()
     {


### PR DESCRIPTION
[SCAN4NET-701](https://sonarsource.atlassian.net/browse/SCAN4NET-701)

Fixes some of the issues found here:
https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&sinceLeakPeriod=true&id=sonarscanner-msbuild
(Some are not worth fixing because of multi-targeting and missing overloads in net48).

https://learn.microsoft.com/en-us/dotnet/core/testing/mstest-analyzers/mstest0049

I would really like to implement this as a rule for us:
* In CodeBlockStart:
    *  Look for CancelationToken in scope:
          * In parameters
          * In fields
    * Look one or two level deep inside complex types (to find e.g. AnalysisContext.CancelationToken)
* If in scope, register for invocation operations and look for method overloads that take a cancelation token.

This would be a nice addition to [S6966](https://sonarsource.github.io/rspec/#/rspec/S6966)

[SCAN4NET-701]: https://sonarsource.atlassian.net/browse/SCAN4NET-701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ