### PR TITLE
SCAN4NET-742 Untangle UnpackJre from download logic in JreCache

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/FileCacheTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/FileCacheTests.cs
@@ -305,7 +305,7 @@ public sealed class FileCacheTests : IDisposable
             "Starting the file download.",
             $"Deleting file '{tempFilePath}'.",
             "The download of the file from the server failed with the exception 'The download stream is null. The server likely returned an error status code.'.",
-            "The file was found after the download failed. Another scanner did the download in the parallel.",
+            "The file was found after the download failed. Another scanner downloaded the file in parallel.",
             $"The file was already downloaded from the server and stored at '{downloadTarget}'.",
             $"The checksum of the downloaded file is '{expectedSha}' and the expected checksum is '{expectedSha}'.");
     }
@@ -326,7 +326,7 @@ public sealed class FileCacheTests : IDisposable
             "Starting the file download.",
             $"Deleting file '{tempFilePath}'.",
             "The download of the file from the server failed with the exception 'The download stream is null. The server likely returned an error status code.'.",
-            "The file was found after the download failed. Another scanner did the download in the parallel.",
+            "The file was found after the download failed. Another scanner downloaded the file in parallel.",
             $"The file was already downloaded from the server and stored at '{downloadTarget}'.",
             $"The checksum of the downloaded file is 'someOtherHash' and the expected checksum is '{expectedSha}'.",
             $"Deleting file '{downloadTarget}'.");

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/FileCacheTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/FileCacheTests.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Security.Cryptography;
 using NSubstitute.ExceptionExtensions;
 using SonarScanner.MSBuild.PreProcessor.Interfaces;
 
@@ -212,48 +211,107 @@ public sealed class FileCacheTests : IDisposable
     }
 
     [TestMethod]
-    public async Task DownloadAndValidateFile_Success()
+    public async Task EnsureFileDownload_Succeeds()
     {
-        var result = await ExecuteDownloadAndValidateFile(new MemoryStream(downloadContentArray));
+        var result = await ExecuteEnsureFileDownloadTest(new MemoryStream(downloadContentArray));
 
         result.Should().BeNull();
         AssertStreamDisposed();
         fileWrapper.Received(1).Create(tempFilePath);
         fileWrapper.Received(1).Move(tempFilePath, downloadTarget);
         fileContentArray.Should().BeEquivalentTo(downloadContentArray);
-        testLogger.DebugMessages.Should().BeEquivalentTo($"The checksum of the downloaded file is '{expectedSha}' and the expected checksum is '{expectedSha}'.");
+        testLogger.DebugMessages.Should().BeEquivalentTo(
+            "Starting the file download.",
+            $"The checksum of the downloaded file is '{expectedSha}' and the expected checksum is '{expectedSha}'.");
     }
 
     [TestMethod]
-    public async Task DownloadAndValidateFile_NullStream_ReturnsInvalidOperationException()
+    public async Task EnsureFileDownload_NullStream_ReturnsCacheFailure()
     {
-        var result = await ExecuteDownloadAndValidateFile(null);
+        var result = await ExecuteEnsureFileDownloadTest(null);
 
-        result.Should().BeOfType<InvalidOperationException>().Which.Message.Should().Be(
-            "The download stream is null. The server likely returned an error status code.");
+        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be(
+            "The download of the file from the server failed with the exception 'The download stream is null. The server likely returned an error status code.'.");
         AssertTempFileCreatedAndDeleted();
         AssertStreamDisposed();
-        testLogger.DebugMessages.Should().BeEquivalentTo($"Deleting file '{tempFilePath}'.");
+        testLogger.DebugMessages.Should().BeEquivalentTo(
+            "Starting the file download.",
+            $"Deleting file '{tempFilePath}'.",
+            "The download of the file from the server failed with the exception 'The download stream is null. The server likely returned an error status code.'.");
     }
 
     [TestMethod]
-    public async Task DownloadAndValidateFile_WrongChecksum_ReturnsCryptographicException()
+    public async Task EnsureFileDownload_WrongChecksum_ReturnsCacheFailure()
     {
         checksum.ComputeHash(null).ReturnsForAnyArgs("someOtherHash");
 
-        var result = await ExecuteDownloadAndValidateFile(new MemoryStream(downloadContentArray));
+        var result = await ExecuteEnsureFileDownloadTest(new MemoryStream(downloadContentArray));
 
-        result.Should().BeOfType<CryptographicException>().Which.Message.Should().Be("The checksum of the downloaded file does not match the expected checksum.");
+        result.Should().BeOfType<CacheFailure>().Which.Message
+            .Should().Be("The download of the file from the server failed with the exception 'The checksum of the downloaded file does not match the expected checksum.'.");
         AssertTempFileCreatedAndDeleted();
-        fileContentArray.Should().BeEquivalentTo(downloadContentArray);
         AssertStreamDisposed();
+        fileContentArray.Should().BeEquivalentTo(downloadContentArray);
         testLogger.DebugMessages.Should().BeEquivalentTo(
+            "Starting the file download.",
             $"The checksum of the downloaded file is 'someOtherHash' and the expected checksum is '{expectedSha}'.",
-            $"Deleting file '{tempFilePath}'.");
+            $"Deleting file '{Path.Combine(downloadPath, tempFileName)}'.",
+            "The download of the file from the server failed with the exception 'The checksum of the downloaded file does not match the expected checksum.'.");
     }
 
-    private async Task<Exception> ExecuteDownloadAndValidateFile(MemoryStream downloadContent) =>
-        await fileCache.DownloadAndValidateFile(downloadPath, downloadTarget, new FileDescriptor(downloadTarget, expectedSha), () => Task.FromResult<Stream>(downloadContent));
+    [TestMethod]
+    public async Task EnsureFileDownload_ValidFileCached_Succeeds()
+    {
+        fileWrapper.Exists(downloadTarget).Returns(true);
+        var result = await ExecuteEnsureFileDownloadTest(new MemoryStream(downloadContentArray));
+
+        result.Should().BeNull();
+        fileWrapper.DidNotReceiveWithAnyArgs().Create(null);
+        fileWrapper.DidNotReceiveWithAnyArgs().Move(null, null);
+        testLogger.DebugMessages.Should().BeEquivalentTo(
+            $"The file was already downloaded from the server and stored at '{downloadTarget}'.",
+            $"The checksum of the downloaded file is '{expectedSha}' and the expected checksum is '{expectedSha}'.");
+    }
+
+    [TestMethod]
+    public async Task EnsureFileDownload_InvalidFileCached_ReturnsCacheFailure()
+    {
+        fileWrapper.Exists(downloadTarget).Returns(true);
+        checksum.ComputeHash(null).ReturnsForAnyArgs("someOtherHash");
+
+        var result = await ExecuteEnsureFileDownloadTest(new MemoryStream(downloadContentArray));
+
+        result.Should().BeOfType<CacheFailure>().Which.Message
+            .Should().Be("The checksum of the downloaded file does not match the expected checksum.");
+        fileWrapper.DidNotReceiveWithAnyArgs().Create(null);
+        fileWrapper.DidNotReceiveWithAnyArgs().Move(null, null);
+        testLogger.DebugMessages.Should().BeEquivalentTo(
+            $"The file was already downloaded from the server and stored at '{downloadTarget}'.",
+            $"The checksum of the downloaded file is 'someOtherHash' and the expected checksum is '{expectedSha}'.",
+            $"Deleting file '{downloadTarget}'.");
+    }
+
+    [TestMethod]
+    public async Task EnsureFileDownload_DownloadFails_FileDownloadedByOtherScanner_Succeeds()
+    {
+        fileWrapper.Exists(downloadTarget).Returns(false, true);
+
+        var result = await ExecuteEnsureFileDownloadTest(null);
+
+        result.Should().BeNull();
+        AssertTempFileCreatedAndDeleted();
+        AssertStreamDisposed();
+        testLogger.DebugMessages.Should().BeEquivalentTo(
+            "Starting the file download.",
+            $"Deleting file '{tempFilePath}'.",
+            "The download of the file from the server failed with the exception 'The download stream is null. The server likely returned an error status code.'.",
+            "The file was found after the download failed. Another scanner did the download in the parallel.",
+            "The file was already downloaded from the server and stored at 'someFile'.",
+            "The checksum of the downloaded file is 'sha256' and the expected checksum is 'sha256'.");
+    }
+
+    private async Task<CacheResult> ExecuteEnsureFileDownloadTest(MemoryStream downloadContent) =>
+        await fileCache.EnsureFileDownload(downloadPath, downloadTarget, new FileDescriptor(downloadTarget, expectedSha), () => Task.FromResult<Stream>(downloadContent));
 
     private void ExecuteValidateChecksumTest(string returnedSha, string expectedSha, bool expectSucces, string downloadTarget = "some.file")
     {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreCacheTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreCacheTests.cs
@@ -454,7 +454,7 @@ public class JreCacheTests
         result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The checksum of the downloaded file does not match the expected checksum.");
         testLogger.AssertDebugLogged(@"Starting the file download.");
         testLogger.AssertDebugLogged(@"The download of the file from the server failed with the exception 'I/O error occurred.'.");
-        testLogger.AssertDebugLogged(@"The file was found after the download failed. Another scanner did the download in the parallel.");
+        testLogger.AssertDebugLogged(@"The file was found after the download failed. Another scanner downloaded the file in parallel.");
     }
 
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreCacheTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreCacheTests.cs
@@ -174,9 +174,9 @@ public class JreCacheTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => throw new NotSupportedException("Unreachable"));
-        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The checksum of the downloaded Java runtime environment does not match the expected checksum.");
+        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The checksum of the downloaded file does not match the expected checksum.");
         testLogger.DebugMessages.Should().BeEquivalentTo(
-            $"The Java Runtime Environment was already downloaded from the server and stored at '{Path.Combine(ShaPath, "filename.tar.gz")}'.",
+            $"The file was already downloaded from the server and stored at '{Path.Combine(ShaPath, "filename.tar.gz")}'.",
             "The checksum of the downloaded file is '' and the expected checksum is 'sha256'.",
             $"Deleting file '{Path.Combine(ShaPath, "filename.tar.gz")}'.");
     }
@@ -194,7 +194,7 @@ public class JreCacheTests
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => throw new NotSupportedException("Unreachable"));
         result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The downloaded Java runtime environment could not be extracted.");
         testLogger.DebugMessages.Should().BeEquivalentTo(
-            $"The Java Runtime Environment was already downloaded from the server and stored at '{Path.Combine(ShaPath, "filename.tar.gz")}'.",
+            $"The file was already downloaded from the server and stored at '{Path.Combine(ShaPath, "filename.tar.gz")}'.",
             "The checksum of the downloaded file is 'sha256' and the expected checksum is 'sha256'.",
             $"Starting extracting the Java runtime environment from archive '{Path.Combine(ShaPath, "filename.tar.gz")}' to folder '{ShaPath}'.",
             $"The extraction of the downloaded Java runtime environment failed with error 'The java executable in the extracted Java runtime environment was expected to be at '{Path.Combine(ShaPath, "javaPath")}' but couldn't be found.'.");
@@ -214,7 +214,7 @@ public class JreCacheTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => Task.FromResult<Stream>(new MemoryStream(downloadContentArray)));
-        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the Java runtime environment from the server failed with the exception "
+        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
             + "'The checksum of the downloaded file does not match the expected checksum.'.");
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.DidNotReceive().Move(Path.Combine(ShaPath, "xFirst.rnd"), Path.Combine(ShaPath, "filename.tar.gz"));
@@ -222,10 +222,10 @@ public class JreCacheTests
         var streamAccess = () => fileContentStream.Position;
         streamAccess.Should().Throw<ObjectDisposedException>("FileStream should be closed after success.");
         testLogger.DebugMessages.Should().BeEquivalentTo(
-            "Starting the Java Runtime Environment download.",
+            "Starting the file download.",
             "The checksum of the downloaded file is '' and the expected checksum is 'sha256'.",
             $"Deleting file '{Path.Combine(ShaPath, "xFirst.rnd")}'.",
-            "The download of the Java runtime environment from the server failed with the exception 'The checksum of the downloaded file does not match the expected checksum.'.");
+            "The download of the file from the server failed with the exception 'The checksum of the downloaded file does not match the expected checksum.'.");
     }
 
     [TestMethod]
@@ -245,7 +245,7 @@ public class JreCacheTests
         try
         {
             var result = await sut.DownloadJreAsync(new("filename.tar.gz", sha, "javaPath"), () => Task.FromResult<Stream>(new MemoryStream(downloadContentArray)));
-            result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the Java runtime environment from the server failed with the exception "
+            result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
                 + "'The checksum of the downloaded file does not match the expected checksum.'.");
             File.Exists(file).Should().BeFalse();
         }
@@ -280,7 +280,7 @@ public class JreCacheTests
         {
             var result = await sut.DownloadJreAsync(new("filename.tar.gz", sha, "javaPath"), () => throw new InvalidOperationException("Download failure simulation."));
             result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be(
-                @"The download of the Java runtime environment from the server failed with the exception 'Download failure simulation.'.");
+                @"The download of the file from the server failed with the exception 'Download failure simulation.'.");
             File.Exists(file).Should().BeFalse();
             Directory.GetFiles(jre).Should().BeEmpty();
         }
@@ -312,7 +312,7 @@ public class JreCacheTests
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => throw new NotSupportedException("Unreachable"));
         result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be(
-            $"The download of the Java runtime environment from the server failed with the exception '{exception.Message}'.");
+            $"The download of the file from the server failed with the exception '{exception.Message}'.");
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.DidNotReceive().Move(Path.Combine(ShaPath, "xFirst.rnd"), Path.Combine(ShaPath, "filename.tar.gz"));
         fileWrapper.DidNotReceive().Delete(Path.Combine(ShaPath, "xFirst.rnd"));
@@ -331,7 +331,7 @@ public class JreCacheTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => throw new InvalidOperationException("Download failure simulation."));
-        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the Java runtime environment from the server failed with the "
+        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the file from the server failed with the "
             + "exception 'Download failure simulation.'."); // The exception from the failed temp file delete is not visible to the user.
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.Received(1).Delete(Path.Combine(ShaPath, "xFirst.rnd"));
@@ -352,10 +352,10 @@ public class JreCacheTests
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => throw new InvalidOperationException("Download failure simulation."));
         result.Should().BeOfType<CacheFailure>().Which.Message.Replace(Environment.NewLine, string.Empty).Should().Be("""
-            The download of the Java runtime environment from the server failed with the exception 'Cannot access a disposed object.Object name: 'stream'.'.
+            The download of the file from the server failed with the exception 'Cannot access a disposed object.Object name: 'stream'.'.
             """); // This should actually read "Download failure simulation." because the ObjectDisposedException is actually swallowed.
         result.Should().BeOfType<CacheFailure>().Which.Message.Replace(Environment.NewLine, string.Empty).Should().Be("""
-            The download of the Java runtime environment from the server failed with the exception 'Cannot access a disposed object.Object name: 'stream'.'.
+            The download of the file from the server failed with the exception 'Cannot access a disposed object.Object name: 'stream'.'.
             """); // This should actually read "Download failure simulation." because the ObjectDisposedException is actually swallowed.
                   // I assume this is either
                   // * a bug in NSubstitute, or
@@ -379,7 +379,7 @@ public class JreCacheTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => throw new InvalidOperationException("Download failure simulation."));
-        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the Java runtime environment from the server failed with the exception 'Download failure simulation.'.");
+        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the file from the server failed with the exception 'Download failure simulation.'.");
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.Received(1).Delete(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.DidNotReceive().Move(Path.Combine(ShaPath, "xFirst.rnd"), Path.Combine(ShaPath, "filename.tar.gz"));
@@ -400,7 +400,7 @@ public class JreCacheTests
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => Task.FromResult<Stream>(null));
         result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be(
-            "The download of the Java runtime environment from the server failed with the exception 'The download stream is null. The server likely returned an error status code.'.");
+            "The download of the file from the server failed with the exception 'The download stream is null. The server likely returned an error status code.'.");
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.Received(1).Delete(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.DidNotReceive().Move(Path.Combine(ShaPath, "xFirst.rnd"), Path.Combine(ShaPath, "filename.tar.gz"));
@@ -427,7 +427,7 @@ public class JreCacheTests
         checksum.ComputeHash(computeHashStream).Returns("sha256");
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => Task.FromResult<Stream>(new MemoryStream([1, 2, 3])));
-        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be($"The download of the Java runtime environment from the server failed with the exception '{exception.Message}'.");
+        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be($"The download of the file from the server failed with the exception '{exception.Message}'.");
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.Received(1).Move(Path.Combine(ShaPath, "xFirst.rnd"), file);
         fileWrapper.Received(1).Delete(Path.Combine(ShaPath, "xFirst.rnd"));
@@ -451,10 +451,10 @@ public class JreCacheTests
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => throw new NotSupportedException("Unreachable"));
         // The download failed, but we still progress with the provisioning because somehow magically the file is there anyway.
-        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The checksum of the downloaded Java runtime environment does not match the expected checksum.");
-        testLogger.AssertDebugLogged(@"Starting the Java Runtime Environment download.");
-        testLogger.AssertDebugLogged(@"The download of the Java runtime environment from the server failed with the exception 'I/O error occurred.'.");
-        testLogger.AssertDebugLogged(@"The Java Runtime Environment archive was found after the download failed. Another scanner did the download in the parallel.");
+        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The checksum of the downloaded file does not match the expected checksum.");
+        testLogger.AssertDebugLogged(@"Starting the file download.");
+        testLogger.AssertDebugLogged(@"The download of the file from the server failed with the exception 'I/O error occurred.'.");
+        testLogger.AssertDebugLogged(@"The file was found after the download failed. Another scanner did the download in the parallel.");
     }
 
     [TestMethod]
@@ -478,7 +478,7 @@ public class JreCacheTests
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", expectedHashValue, "javaPath"), () => Task.FromResult<Stream>(new MemoryStream()));
         result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The downloaded Java runtime environment could not be extracted.");
         testLogger.DebugMessages.Should().BeEquivalentTo(
-            "Starting the Java Runtime Environment download.",
+            "Starting the file download.",
             $"The checksum of the downloaded file is '{fileHashValue}' and the expected checksum is '{expectedHashValue}'.",
             $"Starting extracting the Java runtime environment from archive '{Path.Combine(SonarUserHome, "cache", expectedHashValue, "filename.tar.gz")}' "
             + $"to folder '{Path.Combine(SonarUserHome, "cache", expectedHashValue, "xSecond.rnd")}'.",
@@ -513,14 +513,14 @@ public class JreCacheTests
         checksum.ComputeHash(fileStream).Returns(fileHashValue);
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", expectedHashValue, "javaPath"), () => Task.FromResult<Stream>(new MemoryStream()));
-        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the Java runtime environment from the server failed with the exception "
+        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
             + "'The checksum of the downloaded file does not match the expected checksum.'.");
         testLogger.DebugMessages.Should().BeEquivalentTo(
-            "Starting the Java Runtime Environment download.",
+            "Starting the file download.",
             $"The checksum of the downloaded file is '{fileHashValue}' and the expected checksum is '{expectedHashValue}'.",
             @$"Deleting file '{Path.Combine(SonarCache, expectedHashValue, "xFirst.rnd")}'.",
             @$"Failed to delete file '{Path.Combine(SonarCache, expectedHashValue, "xFirst.rnd")}'. Unable to find the specified file.",
-            "The download of the Java runtime environment from the server failed with the exception 'The checksum of the downloaded file does not match the expected checksum.'.");
+            "The download of the file from the server failed with the exception 'The checksum of the downloaded file does not match the expected checksum.'.");
         fileWrapper.Received(2).Exists(file); // One before the download and one after the failed download.
         fileWrapper.Received(1).Create(Path.Combine(sha, "xFirst.rnd"));
         fileWrapper.Received(1).Open(Path.Combine(sha, "xFirst.rnd"));
@@ -542,7 +542,7 @@ public class JreCacheTests
         checksum.ComputeHash(fileStream).Throws<InvalidOperationException>();
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => Task.FromResult<Stream>(new MemoryStream()));
-        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the Java runtime environment from the server failed with the exception "
+        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
             + "'The checksum of the downloaded file does not match the expected checksum.'.");
         testLogger.AssertDebugLogged($"The calculation of the checksum of the file '{Path.Combine(ShaPath, "xFirst.rnd")}' failed with message "
             + "'Operation is not valid due to the current state of the object.'.");
@@ -566,7 +566,7 @@ public class JreCacheTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(new("filename.tar.gz", "sha256", "javaPath"), () => Task.FromResult<Stream>(new MemoryStream()));
-        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the Java runtime environment from the server failed with the exception "
+        result.Should().BeOfType<CacheFailure>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
             + "'The checksum of the downloaded file does not match the expected checksum.'.");
         testLogger.AssertDebugLogged(@$"The calculation of the checksum of the file '{Path.Combine(ShaPath, "xFirst.rnd")}' failed with message 'I/O error occurred.'.");
         fileWrapper.Received(2).Exists(file); // One before the download and one after the failed download.
@@ -597,7 +597,7 @@ public class JreCacheTests
         checksum.Received(1).ComputeHash(Arg.Any<Stream>());
         unpackerFactory.Received(1).Create(testLogger, directoryWrapper, fileWrapper, filePermissionsWrapper, "filename.tar.gz");
         testLogger.DebugMessages.Should().BeEquivalentTo(
-            @"Starting the Java Runtime Environment download.",
+            @"Starting the file download.",
             @"The checksum of the downloaded file is 'sha256' and the expected checksum is 'sha256'.",
             // The unpackerFactory returned an unpacker and it was called. But the test setup is incomplete and therefore fails later:
             @$"Starting extracting the Java runtime environment from archive '{file}' to folder '{Path.Combine(ShaPath, "xSecond.rnd")}'.",
@@ -661,7 +661,7 @@ public class JreCacheTests
         directoryWrapper.Received(1).Move(Path.Combine(ShaPath, "xSecond.rnd"), file + "_extracted");
         unpacker.Received(1).Unpack(archiveFileStream, Path.Combine(ShaPath, "xSecond.rnd"));
         testLogger.DebugMessages.Should().BeEquivalentTo(
-            @"Starting the Java Runtime Environment download.",
+            @"Starting the file download.",
             @"The checksum of the downloaded file is 'sha256' and the expected checksum is 'sha256'.",
             @$"Starting extracting the Java runtime environment from archive '{file}' to folder '{Path.Combine(ShaPath, "xSecond.rnd")}'.",
             @$"Moving extracted Java runtime environment from '{Path.Combine(ShaPath, "xSecond.rnd")}' to '{file}_extracted'.",
@@ -690,7 +690,7 @@ public class JreCacheTests
         directoryWrapper.DidNotReceiveWithAnyArgs().Move(null, null);
         directoryWrapper.Received(1).Delete(Path.Combine(ShaPath, "xSecond.rnd"), true);
         testLogger.DebugMessages.Should().BeEquivalentTo(
-            @"Starting the Java Runtime Environment download.",
+            @"Starting the file download.",
             @"The checksum of the downloaded file is 'sha256' and the expected checksum is 'sha256'.",
             @$"Starting extracting the Java runtime environment from archive '{file}' to folder '{Path.Combine(ShaPath, "xSecond.rnd")}'.",
             @$"The extraction of the downloaded Java runtime environment failed with error 'Unpack failure'.");
@@ -719,7 +719,7 @@ public class JreCacheTests
         directoryWrapper.Received(1).Move(Path.Combine(ShaPath, "xSecond.rnd"), file + "_extracted");
         directoryWrapper.Received(1).Delete(Path.Combine(ShaPath, "xSecond.rnd"), true);
         testLogger.DebugMessages.Should().BeEquivalentTo(
-            @"Starting the Java Runtime Environment download.",
+            @"Starting the file download.",
             @"The checksum of the downloaded file is 'sha256' and the expected checksum is 'sha256'.",
             @$"Starting extracting the Java runtime environment from archive '{file}' to folder '{Path.Combine(ShaPath, "xSecond.rnd")}'.",
             @$"Moving extracted Java runtime environment from '{Path.Combine(ShaPath, "xSecond.rnd")}' to '{file}_extracted'.",
@@ -748,7 +748,7 @@ public class JreCacheTests
         fileWrapper.Received(1).Exists(Path.Combine(ShaPath, "xSecond.rnd", "javaPath"));
         directoryWrapper.Received(1).Delete(Path.Combine(ShaPath, "xSecond.rnd"), true);
         testLogger.DebugMessages.Should().BeEquivalentTo(
-            @"Starting the Java Runtime Environment download.",
+            @"Starting the file download.",
             @"The checksum of the downloaded file is 'sha256' and the expected checksum is 'sha256'.",
             @$"Starting extracting the Java runtime environment from archive '{file}' to folder '{Path.Combine(ShaPath, "xSecond.rnd")}'.",
             @$"The extraction of the downloaded Java runtime environment failed with error 'The java executable in the extracted Java runtime environment was expected to be at '{Path.Combine(ShaPath, "xSecond.rnd", "javaPath")}' but couldn't be found.'.");
@@ -775,7 +775,7 @@ public class JreCacheTests
         directoryWrapper.Received(1).Move(Path.Combine(ShaPath, "xSecond.rnd"), file + "_extracted");
         directoryWrapper.Received(1).Delete(Path.Combine(ShaPath, "xSecond.rnd"), true);
         testLogger.DebugMessages.Should().BeEquivalentTo(
-            @"Starting the Java Runtime Environment download.",
+            @"Starting the file download.",
             @"The checksum of the downloaded file is 'sha256' and the expected checksum is 'sha256'.",
             @$"Starting extracting the Java runtime environment from archive '{file}' to folder '{Path.Combine(ShaPath, "xSecond.rnd")}'.",
             @$"Moving extracted Java runtime environment from '{Path.Combine(ShaPath, "xSecond.rnd")}' to '{file}_extracted'.",
@@ -828,7 +828,7 @@ public class JreCacheTests
                 If you already have a compatible java version installed, please add either the parameter "/d:sonar.scanner.skipJreProvisioning=true" or "/d:sonar.scanner.javaExePath=<PATH>".
                 """);
             testLogger.DebugMessages.Should().SatisfyRespectively(
-                x => x.Should().Be(@$"Starting the Java Runtime Environment download."),
+                x => x.Should().Be(@$"Starting the file download."),
                 x => x.Should().Be(@$"The checksum of the downloaded file is '{sha}' and the expected checksum is '{sha}'."),
                 x => x.Should().Match(@$"Starting extracting the Java runtime environment from archive '{Path.Combine(cache, sha, file)}' to folder '{Path.Combine(cache, sha, "*")}'."),
                 x => x.Should().Match(@$"Moving extracted Java runtime environment from '{Path.Combine(cache, sha, "*")}' to '{Path.Combine(cache, sha, "OpenJDK17U-jre_x64_windows_hotspot_17.0.11_9.zip_extracted")}'."),
@@ -880,7 +880,7 @@ public class JreCacheTests
                 If you already have a compatible java version installed, please add either the parameter "/d:sonar.scanner.skipJreProvisioning=true" or "/d:sonar.scanner.javaExePath=<PATH>".
                 """);
             testLogger.DebugMessages.Should().SatisfyRespectively(
-                x => x.Should().Be("Starting the Java Runtime Environment download."),
+                x => x.Should().Be("Starting the file download."),
                 x => x.Should().Be($"The checksum of the downloaded file is '{sha}' and the expected checksum is '{sha}'."),
                 x => x.Should().Match($"Starting extracting the Java runtime environment from archive '{Path.Combine(cache, sha, "OpenJDK17U-jre_x64_windows_hotspot_17.0.11_9.tar.gz")}' to folder '{Path.Combine(cache, sha, "*")}'."),
                 x => x.Should().Match($"Moving extracted Java runtime environment from '{Path.Combine(cache, sha, "*")}' to '{Path.Combine(cache, sha, "OpenJDK17U-jre_x64_windows_hotspot_17.0.11_9.tar.gz_extracted")}'."),

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/CloudJreProvisioningTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarcloud/CloudJreProvisioningTest.java
@@ -98,7 +98,7 @@ class CloudJreProvisioningTest {
       var cacheMissLogs = context.runAnalysis().begin().getLogs();
       assertThat(cacheMissLogs).contains(
         "JreResolver: Cache miss",
-        "Starting the Java Runtime Environment download.");
+        "Starting the file download.");
       assertThat(cacheMissLogs).doesNotContain(
         "JreResolver: Cache hit",
         "JreResolver: Cache failure");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/JreProvisioningTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/JreProvisioningTest.java
@@ -66,7 +66,7 @@ class JreProvisioningTest {
       assertThat(firstBegin.isSuccess()).isTrue();
       assertThat(firstBegin.getLogs()).contains(
         "JreResolver: Cache miss",
-        "Starting the Java Runtime Environment download.");
+        "Starting the file download.");
       assertThat(firstBegin.getLogs()).doesNotContain(
         "JreResolver: Cache hit",
         "JreResolver: Cache failure");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/JreProvisioningAssertions.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/JreProvisioningAssertions.java
@@ -36,7 +36,7 @@ public final class JreProvisioningAssertions {
       "Downloading from " + sqApiUrl + "/analysis/jres?os=" + os + "&arch=" + arch + "...",
       "Response received from " + sqApiUrl + "/analysis/jres?os=" + os + "&arch=" + arch + "...",
       "JreResolver: Cache miss. Attempting to download JRE.",
-      "Starting the Java Runtime Environment download.");
+      "Starting the file download.");
     TestUtils.matchesSingleLine(beginLogs, "Downloading Java JRE from " + jreUrlPattern);
     TestUtils.matchesSingleLine(beginLogs, "The checksum of the downloaded file is '.+' and the expected checksum is '.+'");
     TestUtils.matchesSingleLine(beginLogs, "Starting extracting the Java runtime environment from archive '" + cacheFolderPattern + "' to folder '" + cacheFolderPattern + "'");
@@ -56,6 +56,6 @@ public final class JreProvisioningAssertions {
     assertThat(secondBegin.getLogs()).doesNotContain(
       "JreResolver: Cache miss",
       "JreResolver: Cache failure",
-      "Starting the Java Runtime Environment download.");
+      "Starting the file download.");
   }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
@@ -73,7 +73,7 @@ public class FileCache : IFileCache
         }
     }
 
-    public async Task<string> EnsureFileDownload(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download)
+    public async Task<CacheFailure> EnsureFileDownload(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download)
     {
         if (fileWrapper.Exists(downloadTarget))
         {
@@ -88,7 +88,7 @@ public class FileCache : IFileCache
                 logger.LogDebug(Resources.MSG_FileFoundAfterFailedDownload, downloadTarget);
                 return ValidateFile(downloadTarget, descriptor);
             }
-            return string.Format(Resources.ERR_DownloadFailed, exception.Message);
+            return new(string.Format(Resources.ERR_DownloadFailed, exception.Message));
         }
         return null;
     }
@@ -180,7 +180,7 @@ public class FileCache : IFileCache
     public string FileRootPath(FileDescriptor descriptor) =>
         Path.Combine(CacheRoot, descriptor.Sha256);
 
-    private string ValidateFile(string downloadTarget, FileDescriptor descriptor)
+    private CacheFailure ValidateFile(string downloadTarget, FileDescriptor descriptor)
     {
         logger.LogDebug(Resources.MSG_FileAlreadyDownloaded, downloadTarget);
         if (ValidateChecksum(downloadTarget, descriptor.Sha256))
@@ -190,7 +190,7 @@ public class FileCache : IFileCache
         else
         {
             TryDeleteFile(downloadTarget);
-            return Resources.ERR_ChecksumMismatch;
+            return new(Resources.ERR_ChecksumMismatch);
         }
     }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
@@ -93,17 +93,8 @@ public class FileCache : IFileCache
         return null;
     }
 
-    public string EnsureDownloadDirectory(FileDescriptor fileDescriptor)
-    {
-        if (EnsureCacheRoot() is not null && EnsureDirectoryExists(FileRootPath(fileDescriptor)) is { } downloadPath)
-        {
-            return downloadPath;
-        }
-        else
-        {
-            return null;
-        }
-    }
+    public string EnsureDownloadDirectory(FileDescriptor fileDescriptor) =>
+        EnsureCacheRoot() is not null && EnsureDirectoryExists(FileRootPath(fileDescriptor)) is { } downloadPath ? downloadPath : null;
 
     public bool ValidateChecksum(string downloadTarget, string sha256)
     {

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
@@ -73,22 +73,22 @@ public class FileCache : IFileCache
         }
     }
 
-    public async Task<string> EnsureFileDownload(string jreDownloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download)
+    public async Task<string> EnsureFileDownload(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download)
     {
         if (fileWrapper.Exists(downloadTarget))
         {
             return ValidateFile(downloadTarget, descriptor);
         }
-        logger.LogDebug(Resources.MSG_StartingJreDownload);
-        if (await DownloadAndValidateFile(jreDownloadPath, downloadTarget, descriptor, download) is { } exception)
+        logger.LogDebug(Resources.MSG_StartingFileDownload);
+        if (await DownloadAndValidateFile(downloadPath, downloadTarget, descriptor, download) is { } exception)
         {
-            logger.LogDebug(Resources.ERR_JreDownloadFailed, exception.Message);
+            logger.LogDebug(Resources.ERR_DownloadFailed, exception.Message);
             if (fileWrapper.Exists(downloadTarget)) // Even though the download failed, there is a small chance the file was downloaded by another scanner in the meantime.
             {
-                logger.LogDebug(Resources.MSG_JreFoundAfterFailedDownload, downloadTarget);
+                logger.LogDebug(Resources.MSG_FileFoundAfterFailedDownload, downloadTarget);
                 return ValidateFile(downloadTarget, descriptor);
             }
-            return string.Format(Resources.ERR_JreDownloadFailed, exception.Message);
+            return string.Format(Resources.ERR_DownloadFailed, exception.Message);
         }
         return null;
     }
@@ -177,12 +177,12 @@ public class FileCache : IFileCache
         }
     }
 
-    public string FileRootPath(FileDescriptor jreDescriptor) =>
-        Path.Combine(CacheRoot, jreDescriptor.Sha256);
+    public string FileRootPath(FileDescriptor descriptor) =>
+        Path.Combine(CacheRoot, descriptor.Sha256);
 
     private string ValidateFile(string downloadTarget, FileDescriptor descriptor)
     {
-        logger.LogDebug(Resources.MSG_JreAlreadyDownloaded, downloadTarget);
+        logger.LogDebug(Resources.MSG_FileAlreadyDownloaded, downloadTarget);
         if (ValidateChecksum(downloadTarget, descriptor.Sha256))
         {
             return null;
@@ -190,7 +190,7 @@ public class FileCache : IFileCache
         else
         {
             TryDeleteFile(downloadTarget);
-            return Resources.ERR_JreChecksumMismatch;
+            return Resources.ERR_ChecksumMismatch;
         }
     }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
@@ -145,6 +145,9 @@ public class FileCache : IFileCache
         }
     }
 
+    public string FileRootPath(FileDescriptor jreDescriptor) =>
+        Path.Combine(CacheRoot, jreDescriptor.Sha256);
+
     private static void EnsureClosed(Stream fileStream)
     {
         try

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
@@ -116,6 +116,18 @@ public class FileCache : IFileCache
         }
     }
 
+    public string EnsureDownloadDirectory(FileDescriptor fileDescriptor)
+    {
+        if (EnsureCacheRoot() is not null && EnsureDirectoryExists(FileRootPath(fileDescriptor)) is { } downloadPath)
+        {
+            return downloadPath;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
     public bool ValidateChecksum(string downloadTarget, string sha256)
     {
         try

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/FileCache.cs
@@ -80,28 +80,7 @@ public class FileCache : IFileCache
             return ValidateFile(downloadTarget, descriptor);
         }
         logger.LogDebug(Resources.MSG_StartingFileDownload);
-        try
-        {
-            var tempFilePath = await DownloadFile(downloadPath, download);
-            try
-            {
-                if (ValidateChecksum(tempFilePath, descriptor.Sha256))
-                {
-                    fileWrapper.Move(tempFilePath, downloadTarget);
-                    return null;
-                }
-                else
-                {
-                    throw new CryptographicException(Resources.ERR_ChecksumMismatch);
-                }
-            }
-            catch
-            {
-                TryDeleteFile(tempFilePath);    // Cleanup the temp file
-                throw;
-            }
-        }
-        catch (Exception exception)
+        if (await DownloadAndValidateFile(downloadPath, downloadTarget, descriptor, download) is { } exception)
         {
             logger.LogDebug(Resources.ERR_DownloadFailed, exception.Message);
             if (fileWrapper.Exists(downloadTarget)) // Even though the download failed, there is a small chance the file was downloaded by another scanner in the meantime.
@@ -111,6 +90,7 @@ public class FileCache : IFileCache
             }
             return new(string.Format(Resources.ERR_DownloadFailed, exception.Message));
         }
+        return null;
     }
 
     public string EnsureDownloadDirectory(FileDescriptor fileDescriptor) =>
@@ -148,29 +128,46 @@ public class FileCache : IFileCache
     public string FileRootPath(FileDescriptor descriptor) =>
         Path.Combine(CacheRoot, descriptor.Sha256);
 
-    private async Task<string> DownloadFile(string downloadPath, Func<Task<Stream>> download)
+    private async Task<Exception> DownloadAndValidateFile(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download)
     {
+        // We download to a temporary file in the correct folder.
+        // This avoids conflicts, if multiple scanner try to download to the same file.
         var tempFileName = directoryWrapper.GetRandomFileName();
         var tempFile = Path.Combine(downloadPath, tempFileName);
-        using var fileStream = fileWrapper.Create(tempFile);
         try
         {
-            using var downloadStream = await download();
-            if (downloadStream is null)
+            using var fileStream = fileWrapper.Create(tempFile);
+            try
             {
-                throw new InvalidOperationException(Resources.ERR_DownloadStreamNull);
+                using var downloadStream = await download();
+                if (downloadStream is null)
+                {
+                    throw new InvalidOperationException(Resources.ERR_DownloadStreamNull);
+                }
+                await downloadStream.CopyToAsync(fileStream);
+                fileStream.Close();
+                if (ValidateChecksum(tempFile, descriptor.Sha256))
+                {
+                    fileWrapper.Move(tempFile, downloadTarget);
+                    return null;
+                }
+                else
+                {
+                    throw new CryptographicException(Resources.ERR_ChecksumMismatch);
+                }
             }
-            await downloadStream.CopyToAsync(fileStream);
-            fileStream.Close();
-            return tempFile;
+            catch
+            {
+                // Cleanup the temp file
+                EnsureClosed(fileStream); // If we do not close  the stream, deleting the file fails with:
+                                          // The process cannot access the file '<<path-to-file>>' because it is being used by another process.
+                TryDeleteFile(tempFile);
+                throw;
+            }
         }
-        catch
+        catch (Exception ex)
         {
-            // Cleanup the temp file
-            EnsureClosed(fileStream); // If we do not close  the stream, deleting the file fails with:
-                                        // The process cannot access the file '<<path-to-file>>' because it is being used by another process.
-            TryDeleteFile(tempFile);
-            throw;
+            return ex;
         }
     }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
@@ -28,6 +28,6 @@ public interface IFileCache
     CacheResult IsFileCached(FileDescriptor fileDescriptor);
     string FileRootPath(FileDescriptor descriptor);
     string EnsureDownloadDirectory(FileDescriptor fileDescriptor);
-    Task<string> EnsureFileDownload(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download);
+    Task<CacheFailure> EnsureFileDownload(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download);
     void TryDeleteFile(string tempFile);
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
@@ -28,7 +28,6 @@ public interface IFileCache
     CacheResult IsFileCached(FileDescriptor fileDescriptor);
     string FileRootPath(FileDescriptor jreDescriptor);
     string EnsureDownloadDirectory(FileDescriptor fileDescriptor);
-    bool ValidateChecksum(string downloadTarget, string sha256);
     Task<string> EnsureFileDownload(string jreDownloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download);
     void TryDeleteFile(string tempFile);
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
@@ -26,6 +26,7 @@ public interface IFileCache
     string EnsureCacheRoot();
     string EnsureDirectoryExists(string directory);
     CacheResult IsFileCached(FileDescriptor fileDescriptor);
+    string FileRootPath(FileDescriptor jreDescriptor);
     bool ValidateChecksum(string downloadTarget, string sha256);
     Task<Exception> DownloadAndValidateFile(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download);
     void TryDeleteFile(string tempFile);

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
@@ -28,6 +28,6 @@ public interface IFileCache
     CacheResult IsFileCached(FileDescriptor fileDescriptor);
     string FileRootPath(FileDescriptor descriptor);
     string EnsureDownloadDirectory(FileDescriptor fileDescriptor);
-    Task<CacheFailure> EnsureFileDownload(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download);
+    Task<CacheFailure> EnsureFileIsDownloaded(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download);
     void TryDeleteFile(string tempFile);
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
@@ -27,6 +27,7 @@ public interface IFileCache
     string EnsureDirectoryExists(string directory);
     CacheResult IsFileCached(FileDescriptor fileDescriptor);
     string FileRootPath(FileDescriptor jreDescriptor);
+    string EnsureDownloadDirectory(FileDescriptor fileDescriptor);
     bool ValidateChecksum(string downloadTarget, string sha256);
     Task<Exception> DownloadAndValidateFile(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download);
     void TryDeleteFile(string tempFile);

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
@@ -26,8 +26,8 @@ public interface IFileCache
     string EnsureCacheRoot();
     string EnsureDirectoryExists(string directory);
     CacheResult IsFileCached(FileDescriptor fileDescriptor);
-    string FileRootPath(FileDescriptor jreDescriptor);
+    string FileRootPath(FileDescriptor descriptor);
     string EnsureDownloadDirectory(FileDescriptor fileDescriptor);
-    Task<string> EnsureFileDownload(string jreDownloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download);
+    Task<string> EnsureFileDownload(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download);
     void TryDeleteFile(string tempFile);
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/IFileCache.cs
@@ -29,6 +29,6 @@ public interface IFileCache
     string FileRootPath(FileDescriptor jreDescriptor);
     string EnsureDownloadDirectory(FileDescriptor fileDescriptor);
     bool ValidateChecksum(string downloadTarget, string sha256);
-    Task<Exception> DownloadAndValidateFile(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download);
+    Task<string> EnsureFileDownload(string jreDownloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download);
     void TryDeleteFile(string tempFile);
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreCache.cs
@@ -52,21 +52,9 @@ internal class JreCache(
         return new CacheFailure(string.Format(Resources.ERR_CacheDirectoryCouldNotBeCreated, Path.Combine(fileCache.CacheRoot)));
     }
 
-    private string EnsureDownloadDirectory(FileDescriptor jreDescriptor)
-    {
-        if (fileCache.EnsureCacheRoot() is not null && fileCache.EnsureDirectoryExists(fileCache.FileRootPath(jreDescriptor)) is { } jreDownloadPath)
-        {
-            return jreDownloadPath;
-        }
-        else
-        {
-            return null;
-        }
-    }
-
     public async Task<CacheResult> DownloadJreAsync(JreDescriptor jreDescriptor, Func<Task<Stream>> jreDownload)
     {
-        var jreDownloadPath = EnsureDownloadDirectory(jreDescriptor);
+        var jreDownloadPath = fileCache.EnsureDownloadDirectory(jreDescriptor);
         if (jreDownloadPath is null)
         {
             return new CacheFailure(string.Format(Resources.ERR_CacheDirectoryCouldNotBeCreated, fileCache.FileRootPath(jreDescriptor)));

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreCache.cs
@@ -65,6 +65,7 @@ internal class JreCache(
             return new CacheFailure(string.Format(Resources.ERR_JreArchiveFormatNotSupported, jreDescriptor.Filename));
         }
         var downloadTarget = Path.Combine(jreDownloadPath, jreDescriptor.Filename);
+        logger.LogInfo(Resources.MSG_JreDownloadBottleneck, jreDescriptor.Filename);
         if (await fileCache.EnsureFileDownload(jreDownloadPath, downloadTarget, jreDescriptor, jreDownload) is { } errorMessage)
         {
             return new CacheFailure(errorMessage);

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreCache.cs
@@ -34,7 +34,7 @@ internal class JreCache(
 {
     public CacheResult IsJreCached(JreDescriptor jreDescriptor)
     {
-        if (fileCache.EnsureCacheRoot() is { } cacheRoot)
+        if (fileCache.EnsureCacheRoot() is not null)
         {
             var extractedPath = JreExtractionPath(jreDescriptor);
             if (directoryWrapper.Exists(extractedPath))
@@ -54,7 +54,7 @@ internal class JreCache(
 
     private string EnsureDownloadDirectory(FileDescriptor jreDescriptor)
     {
-        if (fileCache.EnsureCacheRoot() is { } cacheRoot && fileCache.EnsureDirectoryExists(FileRootPath(jreDescriptor)) is { } jreDownloadPath)
+        if (fileCache.EnsureCacheRoot() is not null && fileCache.EnsureDirectoryExists(fileCache.FileRootPath(jreDescriptor)) is { } jreDownloadPath)
         {
             return jreDownloadPath;
         }
@@ -69,7 +69,7 @@ internal class JreCache(
         var jreDownloadPath = EnsureDownloadDirectory(jreDescriptor);
         if (jreDownloadPath is null)
         {
-            return new CacheFailure(string.Format(Resources.ERR_CacheDirectoryCouldNotBeCreated, FileRootPath(jreDescriptor)));
+            return new CacheFailure(string.Format(Resources.ERR_CacheDirectoryCouldNotBeCreated, fileCache.FileRootPath(jreDescriptor)));
         }
         // If we do not support the archive format, there is no point in downloading. Therefore we bail out early in such a case.
         if (unpackerFactory.Create(logger, directoryWrapper, fileWrapper, filePermissionsWrapper, jreDescriptor.Filename) is not { } unpacker)
@@ -128,7 +128,7 @@ internal class JreCache(
     private CacheResult UnpackJre(IUnpacker unpacker, string jreArchive, JreDescriptor jreDescriptor)
     {
         // We extract the archive to a temporary folder in the right location, to avoid conflicts with other scanners.
-        var tempExtractionPath = Path.Combine(FileRootPath(jreDescriptor), directoryWrapper.GetRandomFileName());
+        var tempExtractionPath = Path.Combine(fileCache.FileRootPath(jreDescriptor), directoryWrapper.GetRandomFileName());
         var finalExtractionPath = JreExtractionPath(jreDescriptor); // If all goes well, this will be the final folder. We rename the temporary folder to this one.
         try
         {
@@ -168,9 +168,6 @@ internal class JreCache(
         }
     }
 
-    private string FileRootPath(FileDescriptor jreDescriptor) =>
-        Path.Combine(fileCache.CacheRoot, jreDescriptor.Sha256);
-
     private string JreExtractionPath(JreDescriptor jreDescriptor) =>
-        Path.Combine(FileRootPath(jreDescriptor), $"{jreDescriptor.Filename}_extracted");
+        Path.Combine(fileCache.FileRootPath(jreDescriptor), $"{jreDescriptor.Filename}_extracted");
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreCache.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreCache.cs
@@ -66,9 +66,9 @@ internal class JreCache(
         }
         var downloadTarget = Path.Combine(jreDownloadPath, jreDescriptor.Filename);
         logger.LogInfo(Resources.MSG_JreDownloadBottleneck, jreDescriptor.Filename);
-        if (await fileCache.EnsureFileDownload(jreDownloadPath, downloadTarget, jreDescriptor, jreDownload) is { } errorMessage)
+        if (await fileCache.EnsureFileDownload(jreDownloadPath, downloadTarget, jreDescriptor, jreDownload) is { } cacheFailure)
         {
-            return new CacheFailure(errorMessage);
+            return cacheFailure;
         }
         else
         {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -169,6 +169,15 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The download of the file from the server failed with the exception &apos;{0}&apos;..
+        /// </summary>
+        internal static string ERR_DownloadFailed {
+            get {
+                return ResourceManager.GetString("ERR_DownloadFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The download stream is null. The server likely returned an error status code..
         /// </summary>
         internal static string ERR_DownloadStreamNull {
@@ -228,24 +237,6 @@ namespace SonarScanner.MSBuild.PreProcessor {
         internal static string ERR_JreArchiveFormatNotSupported {
             get {
                 return ResourceManager.GetString("ERR_JreArchiveFormatNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The checksum of the downloaded Java runtime environment does not match the expected checksum..
-        /// </summary>
-        internal static string ERR_JreChecksumMismatch {
-            get {
-                return ResourceManager.GetString("ERR_JreChecksumMismatch", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The download of the Java runtime environment from the server failed with the exception &apos;{0}&apos;..
-        /// </summary>
-        internal static string ERR_JreDownloadFailed {
-            get {
-                return ResourceManager.GetString("ERR_JreDownloadFailed", resourceCulture);
             }
         }
         
@@ -712,11 +703,29 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The file was already downloaded from the server and stored at &apos;{0}&apos;..
+        /// </summary>
+        internal static string MSG_FileAlreadyDownloaded {
+            get {
+                return ResourceManager.GetString("MSG_FileAlreadyDownloaded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The checksum of the downloaded file is &apos;{0}&apos; and the expected checksum is &apos;{1}&apos;..
         /// </summary>
         internal static string MSG_FileChecksum {
             get {
                 return ResourceManager.GetString("MSG_FileChecksum", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The file was found after the download failed. Another scanner did the download in the parallel..
+        /// </summary>
+        internal static string MSG_FileFoundAfterFailedDownload {
+            get {
+                return ResourceManager.GetString("MSG_FileFoundAfterFailedDownload", resourceCulture);
             }
         }
         
@@ -865,15 +874,6 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Java Runtime Environment was already downloaded from the server and stored at &apos;{0}&apos;..
-        /// </summary>
-        internal static string MSG_JreAlreadyDownloaded {
-            get {
-                return ResourceManager.GetString("MSG_JreAlreadyDownloaded", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The JRE provisioning is a time consuming operation.
         ///JRE provisioned: {0}.
         ///If you already have a compatible java version installed, please add either the parameter &quot;/d:sonar.scanner.skipJreProvisioning=true&quot; or &quot;/d:sonar.scanner.javaExePath=&lt;PATH&gt;&quot;..
@@ -899,15 +899,6 @@ namespace SonarScanner.MSBuild.PreProcessor {
         internal static string MSG_JreExtractedSucessfully {
             get {
                 return ResourceManager.GetString("MSG_JreExtractedSucessfully", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The Java Runtime Environment archive was found after the download failed. Another scanner did the download in the parallel..
-        /// </summary>
-        internal static string MSG_JreFoundAfterFailedDownload {
-            get {
-                return ResourceManager.GetString("MSG_JreFoundAfterFailedDownload", resourceCulture);
             }
         }
         
@@ -1173,11 +1164,11 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Starting the Java Runtime Environment download..
+        ///   Looks up a localized string similar to Starting the file download..
         /// </summary>
-        internal static string MSG_StartingJreDownload {
+        internal static string MSG_StartingFileDownload {
             get {
-                return ResourceManager.GetString("MSG_StartingJreDownload", resourceCulture);
+                return ResourceManager.GetString("MSG_StartingFileDownload", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -721,7 +721,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The file was found after the download failed. Another scanner did the download in the parallel..
+        ///   Looks up a localized string similar to The file was found after the download failed. Another scanner downloaded the file in parallel..
         /// </summary>
         internal static string MSG_FileFoundAfterFailedDownload {
             get {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -387,23 +387,20 @@ Use '/?' or '/h' to see the help message.</value>
   <data name="WARN_DefaultUserHomeCreationFailed" xml:space="preserve">
     <value>Failed to create the default user home directory '{0}' with exception '{1}'.</value>
   </data>
-  <data name="ERR_JreDownloadFailed" xml:space="preserve">
-    <value>The download of the Java runtime environment from the server failed with the exception '{0}'.</value>
+  <data name="ERR_DownloadFailed" xml:space="preserve">
+    <value>The download of the file from the server failed with the exception '{0}'.</value>
   </data>
-  <data name="MSG_JreAlreadyDownloaded" xml:space="preserve">
-    <value>The Java Runtime Environment was already downloaded from the server and stored at '{0}'.</value>
+  <data name="MSG_FileAlreadyDownloaded" xml:space="preserve">
+    <value>The file was already downloaded from the server and stored at '{0}'.</value>
   </data>
-  <data name="MSG_JreFoundAfterFailedDownload" xml:space="preserve">
-    <value>The Java Runtime Environment archive was found after the download failed. Another scanner did the download in the parallel.</value>
+  <data name="MSG_FileFoundAfterFailedDownload" xml:space="preserve">
+    <value>The file was found after the download failed. Another scanner did the download in the parallel.</value>
   </data>
-  <data name="MSG_StartingJreDownload" xml:space="preserve">
-    <value>Starting the Java Runtime Environment download.</value>
+  <data name="MSG_StartingFileDownload" xml:space="preserve">
+    <value>Starting the file download.</value>
   </data>
   <data name="MSG_FileChecksum" xml:space="preserve">
     <value>The checksum of the downloaded file is '{0}' and the expected checksum is '{1}'.</value>
-  </data>
-  <data name="ERR_JreChecksumMismatch" xml:space="preserve">
-    <value>The checksum of the downloaded Java runtime environment does not match the expected checksum.</value>
   </data>
   <data name="ERR_ChecksumCalculationFailed" xml:space="preserve">
     <value>The calculation of the checksum of the file '{0}' failed with message '{1}'.</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -394,7 +394,7 @@ Use '/?' or '/h' to see the help message.</value>
     <value>The file was already downloaded from the server and stored at '{0}'.</value>
   </data>
   <data name="MSG_FileFoundAfterFailedDownload" xml:space="preserve">
-    <value>The file was found after the download failed. Another scanner did the download in the parallel.</value>
+    <value>The file was found after the download failed. Another scanner downloaded the file in parallel.</value>
   </data>
   <data name="MSG_StartingFileDownload" xml:space="preserve">
     <value>Starting the file download.</value>


### PR DESCRIPTION
[SCAN4NET-742](https://sonarsource.atlassian.net/browse/SCAN4NET-742)

Part of SCAN4NET-712

I wasn't 100% sure where i was headed, so I just commited every time I made a decision.
If the PR is hard to parse, review by commit and you will see my thought process.

I expect 2 more PRs before EngineResolver uses FileCache.
- Implement DownloadJreAsync equivalent in FileCache, and do minor rework of FileCacheTests 
- Make JreCache inherit directly from FileCache and mark a lot of members private/protected, delete IJreCache, and possible IFileCache.


[SCAN4NET-742]: https://sonarsource.atlassian.net/browse/SCAN4NET-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ