### PR TITLE
SCAN4NET-751 Make JreDownloader and FileDownloader stateful

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/CachedDownloaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/CachedDownloaderTests.cs
@@ -96,8 +96,6 @@ public sealed class CachedDownloaderTests : IDisposable
         directoryWrapper.Received(1).CreateDirectory(SonarUserHomeCache);
     }
 
-
-
     [TestMethod]
     public void CacheRoot_ExpectedPath_IsReturned() =>
         cachedDownloader.CacheRoot.Should().Be(SonarUserHomeCache);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/CachedDownloaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/CachedDownloaderTests.cs
@@ -66,7 +66,7 @@ public sealed class CachedDownloaderTests : IDisposable
 
         var cacheRoot = cachedDownloader.EnsureCacheRoot();
 
-        cacheRoot.Should().Be(SonarUserHomeCache);
+        cacheRoot.Should().BeTrue();
         directoryWrapper.Received(1).Exists(SonarUserHomeCache);
         directoryWrapper.Received(1).CreateDirectory(SonarUserHomeCache);
     }
@@ -78,7 +78,7 @@ public sealed class CachedDownloaderTests : IDisposable
 
         var cacheRoot = cachedDownloader.EnsureCacheRoot();
 
-        cacheRoot.Should().Be(SonarUserHomeCache);
+        cacheRoot.Should().BeTrue();
         directoryWrapper.Received(1).Exists(SonarUserHomeCache);
         directoryWrapper.DidNotReceive().CreateDirectory(Arg.Any<string>());
     }
@@ -91,50 +91,12 @@ public sealed class CachedDownloaderTests : IDisposable
 
         var cacheRoot = cachedDownloader.EnsureCacheRoot();
 
-        cacheRoot.Should().BeNull();
+        cacheRoot.Should().BeFalse();
         directoryWrapper.Received(1).Exists(SonarUserHomeCache);
         directoryWrapper.Received(1).CreateDirectory(SonarUserHomeCache);
     }
 
-    [TestMethod]
-    public void EnsureDirectoryExists_DirectoryDoesNotExist_CreatesDirectory()
-    {
-        var dir = "some/dir";
-        directoryWrapper.Exists(dir).Returns(false);
 
-        var result = cachedDownloader.EnsureDirectoryExists(dir);
-
-        result.Should().Be(dir);
-        directoryWrapper.Received(1).Exists(dir);
-        directoryWrapper.Received(1).CreateDirectory(dir);
-    }
-
-    [TestMethod]
-    public void EnsureDirectoryExists_DirectoryExists_DoesNotCreateDirectory()
-    {
-        var dir = "some/dir";
-        directoryWrapper.Exists(dir).Returns(true);
-
-        var result = cachedDownloader.EnsureDirectoryExists(dir);
-
-        result.Should().Be(dir);
-        directoryWrapper.Received(1).Exists(dir);
-        directoryWrapper.DidNotReceive().CreateDirectory(Arg.Any<string>());
-    }
-
-    [TestMethod]
-    public void EnsureDirectoryExists_CreateDirectoryFails_ReturnsNull()
-    {
-        var dir = "some/dir";
-        directoryWrapper.Exists(dir).Returns(false);
-        directoryWrapper.When(x => x.CreateDirectory(dir)).Throw<IOException>();
-
-        var result = cachedDownloader.EnsureDirectoryExists(dir);
-
-        result.Should().BeNull();
-        directoryWrapper.Received(1).Exists(dir);
-        directoryWrapper.Received(1).CreateDirectory(dir);
-    }
 
     [TestMethod]
     public void CacheRoot_ExpectedPath_IsReturned() =>

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreDownloaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreDownloaderTests.cs
@@ -96,6 +96,12 @@ public class JreDownloaderTests
     }
 
     [TestMethod]
+    public void IsFileCached_ThrowsException_WhenFileDescriptorIsNotJreDescriptor() =>
+        ((Action)(() => CreateSutWithSubstitutes().IsFileCached(new FileDescriptor("filename.tar.gz", "sha256"))))
+            .Should().Throw<ArgumentException>()
+            .WithMessage("JreCache must be used with JreDescriptor*");
+
+    [TestMethod]
     public void ExtractedDirectoryDoesNotExists()
     {
         var expectedExtractedPath = Path.Combine(SonarCache, "sha", "filename.tar.gz_extracted");

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreDownloaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreDownloaderTests.cs
@@ -159,14 +159,12 @@ public class JreDownloaderTests
         result.Should().BeOfType<CacheError>().Which.Message.Should().Be($"The file cache directory in '{ShaPath}' could not be created.");
     }
 
-    [TestCategory(TestCategories.NoLinux)]
-    [TestCategory(TestCategories.NoMacOS)]
     [TestMethod]
     public async Task Download_DownloadFileExists_ChecksumInvalid()
     {
         directoryWrapper.Exists(SonarCache).Returns(true);
         directoryWrapper.Exists(ShaPath).Returns(true);
-        fileWrapper.Exists($@"{ShaPath}\filename.tar.gz").Returns(true);
+        fileWrapper.Exists(Path.Combine(ShaPath, "filename.tar.gz")).Returns(true);
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => throw new NotSupportedException("Unreachable"));

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreDownloaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreDownloaderTests.cs
@@ -144,7 +144,7 @@ public class JreDownloaderTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => throw new NotSupportedException("Unreachable"));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be($"The file cache directory in '{ShaPath}' could not be created.");
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be($"The file cache directory in '{ShaPath}' could not be created.");
     }
 
     [TestMethod]
@@ -156,7 +156,7 @@ public class JreDownloaderTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => throw new NotSupportedException("Unreachable"));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be($"The file cache directory in '{ShaPath}' could not be created.");
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be($"The file cache directory in '{ShaPath}' could not be created.");
     }
 
     [TestMethod]
@@ -168,7 +168,7 @@ public class JreDownloaderTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => throw new NotSupportedException("Unreachable"));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be("The checksum of the downloaded file does not match the expected checksum.");
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be("The checksum of the downloaded file does not match the expected checksum.");
         testLogger.DebugMessages.Should().BeEquivalentTo(
             $"The file was already downloaded from the server and stored at '{Path.Combine(ShaPath, "filename.tar.gz")}'.",
             "The checksum of the downloaded file is '' and the expected checksum is 'sha256'.",
@@ -187,7 +187,7 @@ public class JreDownloaderTests
 
         var result = await ExecuteDownloadAndUnpack();
 
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be("The downloaded Java runtime environment could not be extracted.");
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be("The downloaded Java runtime environment could not be extracted.");
         testLogger.DebugMessages.Should().BeEquivalentTo(
             $"The file was already downloaded from the server and stored at '{Path.Combine(ShaPath, "filename.tar.gz")}'.",
             "The checksum of the downloaded file is 'sha256' and the expected checksum is 'sha256'.",
@@ -209,7 +209,7 @@ public class JreDownloaderTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => Task.FromResult<Stream>(new MemoryStream(downloadContentArray)));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
             + "'The checksum of the downloaded file does not match the expected checksum.'.");
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.DidNotReceive().Move(Path.Combine(ShaPath, "xFirst.rnd"), Path.Combine(ShaPath, "filename.tar.gz"));
@@ -237,11 +237,11 @@ public class JreDownloaderTests
         var downloader = new CachedDownloader(testLogger, DirectoryWrapper.Instance, FileWrapper.Instance, new ChecksumSha256(), home);
         var targzUnpacker = UnpackerFactory.Instance.Create(testLogger, DirectoryWrapper.Instance, FileWrapper.Instance, filePermissionsWrapper, file);
 
-        var sut = new JreDownloader(testLogger, directoryWrapperIO, fileWrapperIO, downloader, targzUnpacker, new JreDescriptor("filename.tar.gz", sha, "javaPath"));
+        var sut = new JreDownloader(testLogger, downloader, directoryWrapperIO, fileWrapperIO, targzUnpacker, new JreDescriptor("filename.tar.gz", sha, "javaPath"));
         try
         {
             var result = await sut.DownloadJreAsync(() => Task.FromResult<Stream>(new MemoryStream(downloadContentArray)));
-            result.Should().BeOfType<CacheError>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
+            result.Should().BeOfType<DownloadError>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
                 + "'The checksum of the downloaded file does not match the expected checksum.'.");
             File.Exists(file).Should().BeFalse();
         }
@@ -272,11 +272,11 @@ public class JreDownloaderTests
         var downloader = new CachedDownloader(testLogger, DirectoryWrapper.Instance, FileWrapper.Instance, new ChecksumSha256(), home);
         var targzUnpacker = UnpackerFactory.Instance.Create(testLogger, DirectoryWrapper.Instance, FileWrapper.Instance, filePermissionsWrapper, file);
 
-        var sut = new JreDownloader(testLogger, directoryWrapperIO, fileWrapperIO, downloader, targzUnpacker, new JreDescriptor("filename.tar.gz", sha, "javaPath"));
+        var sut = new JreDownloader(testLogger, downloader, directoryWrapperIO, fileWrapperIO, targzUnpacker, new JreDescriptor("filename.tar.gz", sha, "javaPath"));
         try
         {
             var result = await sut.DownloadJreAsync(() => throw new InvalidOperationException("Download failure simulation."));
-            result.Should().BeOfType<CacheError>().Which.Message.Should().Be(
+            result.Should().BeOfType<DownloadError>().Which.Message.Should().Be(
                 @"The download of the file from the server failed with the exception 'Download failure simulation.'.");
             File.Exists(file).Should().BeFalse();
             Directory.GetFiles(jre).Should().BeEmpty();
@@ -308,7 +308,7 @@ public class JreDownloaderTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => throw new NotSupportedException("Unreachable"));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be(
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be(
             $"The download of the file from the server failed with the exception '{exception.Message}'.");
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.DidNotReceive().Move(Path.Combine(ShaPath, "xFirst.rnd"), Path.Combine(ShaPath, "filename.tar.gz"));
@@ -328,7 +328,7 @@ public class JreDownloaderTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => throw new InvalidOperationException("Download failure simulation."));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be("The download of the file from the server failed with the "
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be("The download of the file from the server failed with the "
             + "exception 'Download failure simulation.'."); // The exception from the failed temp file delete is not visible to the user.
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.Received(1).Delete(Path.Combine(ShaPath, "xFirst.rnd"));
@@ -348,7 +348,7 @@ public class JreDownloaderTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => throw new InvalidOperationException("Download failure simulation."));
-        result.Should().BeOfType<CacheError>().Which.Message.Replace(Environment.NewLine, string.Empty).Should().Be("""
+        result.Should().BeOfType<DownloadError>().Which.Message.Replace(Environment.NewLine, string.Empty).Should().Be("""
             The download of the file from the server failed with the exception 'Cannot access a disposed object.Object name: 'stream'.'.
             """); // This should actually read "Download failure simulation." because the ObjectDisposedException is actually swallowed.
         result.Should().BeOfType<DownloadError>().Which.Message.Replace(Environment.NewLine, string.Empty).Should().Be("""
@@ -376,7 +376,7 @@ public class JreDownloaderTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => throw new InvalidOperationException("Download failure simulation."));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be("The download of the file from the server failed with the exception 'Download failure simulation.'.");
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be("The download of the file from the server failed with the exception 'Download failure simulation.'.");
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.Received(1).Delete(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.DidNotReceive().Move(Path.Combine(ShaPath, "xFirst.rnd"), Path.Combine(ShaPath, "filename.tar.gz"));
@@ -396,7 +396,7 @@ public class JreDownloaderTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => Task.FromResult<Stream>(null));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be(
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be(
             "The download of the file from the server failed with the exception 'The download stream is null. The server likely returned an error status code.'.");
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.Received(1).Delete(Path.Combine(ShaPath, "xFirst.rnd"));
@@ -424,7 +424,7 @@ public class JreDownloaderTests
         checksum.ComputeHash(computeHashStream).Returns("sha256");
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => Task.FromResult<Stream>(new MemoryStream([1, 2, 3])));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be($"The download of the file from the server failed with the exception '{exception.Message}'.");
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be($"The download of the file from the server failed with the exception '{exception.Message}'.");
         fileWrapper.Received(1).Create(Path.Combine(ShaPath, "xFirst.rnd"));
         fileWrapper.Received(1).Move(Path.Combine(ShaPath, "xFirst.rnd"), file);
         fileWrapper.Received(1).Delete(Path.Combine(ShaPath, "xFirst.rnd"));
@@ -510,7 +510,7 @@ public class JreDownloaderTests
         checksum.ComputeHash(fileStream).Returns(fileHashValue);
         var sut = CreateSutWithSubstitutes(new JreDescriptor("filename.tar.gz", expectedHashValue, "javaPath"));
         var result = await sut.DownloadJreAsync(() => Task.FromResult<Stream>(new MemoryStream()));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
             + "'The checksum of the downloaded file does not match the expected checksum.'.");
         testLogger.DebugMessages.Should().BeEquivalentTo(
             "Starting the file download.",
@@ -539,7 +539,7 @@ public class JreDownloaderTests
         checksum.ComputeHash(fileStream).Throws<InvalidOperationException>();
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => Task.FromResult<Stream>(new MemoryStream()));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
             + "'The checksum of the downloaded file does not match the expected checksum.'.");
         testLogger.AssertDebugLogged($"The calculation of the checksum of the file '{Path.Combine(ShaPath, "xFirst.rnd")}' failed with message "
             + "'Operation is not valid due to the current state of the object.'.");
@@ -563,7 +563,7 @@ public class JreDownloaderTests
 
         var sut = CreateSutWithSubstitutes();
         var result = await sut.DownloadJreAsync(() => Task.FromResult<Stream>(new MemoryStream()));
-        result.Should().BeOfType<CacheError>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
+        result.Should().BeOfType<DownloadError>().Which.Message.Should().Be("The download of the file from the server failed with the exception "
             + "'The checksum of the downloaded file does not match the expected checksum.'.");
         testLogger.AssertDebugLogged(@$"The calculation of the checksum of the file '{Path.Combine(ShaPath, "xFirst.rnd")}' failed with message 'I/O error occurred.'.");
         fileWrapper.Received(2).Exists(file); // One before the download and one after the failed download.
@@ -769,7 +769,7 @@ public class JreDownloaderTests
         var downloader = new CachedDownloader(testLogger, DirectoryWrapper.Instance, FileWrapper.Instance, new ChecksumSha256(), home);
         var zipUnpacker = UnpackerFactory.Instance.Create(testLogger, DirectoryWrapper.Instance, FileWrapper.Instance, filePermissionsWrapper, file);
 
-        var sut = new JreDownloader(testLogger, DirectoryWrapper.Instance, FileWrapper.Instance, downloader, zipUnpacker, jreDescriptor);
+        var sut = new JreDownloader(testLogger, downloader, DirectoryWrapper.Instance, FileWrapper.Instance, zipUnpacker, jreDescriptor);
 
         try
         {
@@ -819,7 +819,7 @@ public class JreDownloaderTests
         var downloader = new CachedDownloader(testLogger, DirectoryWrapper.Instance, FileWrapper.Instance, new ChecksumSha256(), home);
         var targzUnpacker = UnpackerFactory.Instance.Create(testLogger, DirectoryWrapper.Instance, FileWrapper.Instance, filePermissionsWrapper, file);
 
-        var sut = new JreDownloader(testLogger, DirectoryWrapper.Instance, FileWrapper.Instance, downloader, targzUnpacker, jreDescriptor);
+        var sut = new JreDownloader(testLogger, downloader, DirectoryWrapper.Instance, FileWrapper.Instance, targzUnpacker, jreDescriptor);
 
         try
         {
@@ -849,7 +849,7 @@ public class JreDownloaderTests
         }
     }
 
-    private async Task<CacheResult> ExecuteDownloadAndUnpack(JreCache cache = null, JreDescriptor descriptor = null, MemoryStream content = null)
+    private async Task<DownloadResult> ExecuteDownloadAndUnpack(JreDownloader downloader = null, JreDescriptor descriptor = null, MemoryStream content = null)
     {
         var jreDescriptor = descriptor ?? new JreDescriptor("filename.tar.gz", "sha256", "javaPath");
         var sut = downloader ?? CreateSutWithSubstitutes(jreDescriptor);
@@ -860,6 +860,6 @@ public class JreDownloaderTests
     private JreDownloader CreateSutWithSubstitutes(JreDescriptor jreDescriptor = null)
     {
         jreDescriptor ??= new JreDescriptor("filename.tar.gz", "sha256", "javaPath");
-        return new JreDownloader(testLogger, directoryWrapper, fileWrapper, cachedDownloader, unpacker, jreDescriptor);
+        return new JreDownloader(testLogger, cachedDownloader, directoryWrapper, fileWrapper, unpacker, jreDescriptor);
     }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreResolverTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreResolverTests.cs
@@ -196,9 +196,12 @@ public class JreResolverTests
         jreDownloader
             .IsJreCached(Arg.Any<JreDescriptor>())
             .Returns(new CacheMiss());
-        jreDownloader
-            .DownloadJreAsync(Arg.Any<JreDescriptor>(), Arg.Any<Func<Task<Stream>>>())
-            .Returns(new DownloadSuccess("path"));
+        downloader
+            .DownloadFileAsync(Arg.Any<FileDescriptor>(), Arg.Any<Func<Task<Stream>>>())
+            .Returns(new CacheHit("downloadPath"));
+        downloader
+            .UnpackJre(Arg.Any<string>(), Arg.Any<JreDescriptor>())
+            .Returns(new CacheHit("path"));
 
         var res = await sut.ResolveJrePath(GetArgs());
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreResolverTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreResolverTests.cs
@@ -47,7 +47,7 @@ public class JreResolverTests
     private TestLogger logger;
     private ISonarWebServer server;
     private JreResolver sut;
-    private IUnpackerFactory unpackerFactory;
+    private UnpackerFactory unpackerFactory;
 
     [TestInitialize]
     public void Initialize()
@@ -60,7 +60,7 @@ public class JreResolverTests
             .DownloadJreMetadataAsync(Arg.Any<string>(), Arg.Any<string>())
             .Returns(Task.FromResult(metadata));
         server.SupportsJreProvisioning.Returns(true);
-        unpackerFactory = Substitute.For<IUnpackerFactory>();
+        unpackerFactory = Substitute.For<UnpackerFactory>();
 
         sut = new JreResolver(server, logger, filePermissionsWrapper, checksum, SonarUserHome, unpackerFactory, directoryWrapper, fileWrapper);
     }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreResolverTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreResolverTests.cs
@@ -60,26 +60,12 @@ public class JreResolverTests
             .Returns(Task.FromResult(metadata));
         server.SupportsJreProvisioning.Returns(true);
         unpackerFactory = Substitute.For<IUnpackerFactory>();
-        var cachedDownloader = Substitute.For<CachedDownloader>(
         cachedDownloader = Substitute.For<CachedDownloader>(
             logger,
-            Substitute.For<IDirectoryWrapper>(),
-            fileWrapper,
-            Substitute.For<IChecksum>(),
-            unpackerFactory,
-            Substitute.For<IFilePermissionsWrapper>(),
             directoryWrapper,
             fileWrapper,
             checksum,
             SonarUserHome);
-        downloader = Substitute.For<JreDownloader>(
-            logger,
-            cachedDownloader,
-            Substitute.For<IDirectoryWrapper>(),
-            Substitute.For<IFileWrapper>(),
-            Substitute.For<UnpackerFactory>(),
-            Substitute.For<IFilePermissionsWrapper>());
-        sut = new JreResolver(server, downloader, logger);
 
         sut = new JreResolver(server, logger, filePermissionsWrapper, cachedDownloader, unpackerFactory, directoryWrapper, fileWrapper);
     }
@@ -189,7 +175,7 @@ public class JreResolverTests
     [TestMethod]
     public async Task ResolveJrePath_IsJreCached_CacheMiss_DownloadSuccess()
     {
-        cachedDownloader.DownloadFileAsync(null, null).ReturnsForAnyArgs(new ResolutionSuccess("path"));
+        cachedDownloader.DownloadFileAsync(null, null).ReturnsForAnyArgs(new DownloadSuccess("path"));
         fileWrapper.Exists(Path.Combine(ShaPath, "javaPath")).Returns(true);
 
         var res = await sut.ResolveJrePath(Args());
@@ -212,7 +198,7 @@ public class JreResolverTests
     [TestMethod]
     public async Task ResolveJrePath_IsJreCached_CacheMiss_DownloadFailure()
     {
-        cachedDownloader.DownloadFileAsync(null, null).ReturnsForAnyArgs(new ResolutionError("Reason."));
+        cachedDownloader.DownloadFileAsync(null, null).ReturnsForAnyArgs(new DownloadError("Reason."));
 
         var res = await sut.ResolveJrePath(Args());
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreResolverTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreResolverTests.cs
@@ -62,7 +62,7 @@ public class JreResolverTests
         server.SupportsJreProvisioning.Returns(true);
         unpackerFactory = Substitute.For<IUnpackerFactory>();
 
-        sut = new JreResolver(server, logger, filePermissionsWrapper, checksum, SonarUserHome,  unpackerFactory, directoryWrapper, fileWrapper);
+        sut = new JreResolver(server, logger, filePermissionsWrapper, checksum, SonarUserHome, unpackerFactory, directoryWrapper, fileWrapper);
     }
 
     [TestMethod]
@@ -176,7 +176,7 @@ public class JreResolverTests
         // mocks successful download from the server, and unpacking of the jre.
         server.DownloadJreAsync(metadata).Returns(content);
         directoryWrapper.GetRandomFileName().Returns("tempFile.zip");
-        fileWrapper.Exists(Path.Combine(tempArchive, JavaExePath)).Returns(true);
+        fileWrapper.Exists(Path.Combine(tempArchive, JavaExePath)).Returns(true); // the temp file created during the download, not the file within the cache
         fileWrapper.Create(tempArchive).Returns(new MemoryStream());
         fileWrapper.Open(tempArchive).Returns(computeHashStream);
         checksum.ComputeHash(computeHashStream).Returns("sha256");

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/CachedDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/CachedDownloader.cs
@@ -69,7 +69,7 @@ public class CachedDownloader
         }
     }
 
-    internal string EnsureCacheRoot() =>
+    public virtual string EnsureCacheRoot() =>
         EnsureDirectoryExists(CacheRoot);
 
     internal string EnsureDirectoryExists(string directory)

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/CachedDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/CachedDownloader.cs
@@ -61,11 +61,11 @@ public class CachedDownloader
             var downloadTarget = Path.Combine(downloadPath, fileDescriptor.Filename);
             return await EnsureFileIsDownloaded(downloadPath, downloadTarget, fileDescriptor, download) is { } cacheFailure
                 ? cacheFailure
-                : new CacheHit(downloadTarget);
+                : new DownloadSuccess(downloadTarget);
         }
         else
         {
-            return new CacheFailure(string.Format(Resources.ERR_CacheDirectoryCouldNotBeCreated, FileRootPath(fileDescriptor)));
+            return new DownloadError(string.Format(Resources.ERR_CacheDirectoryCouldNotBeCreated, FileRootPath(fileDescriptor)));
         }
     }
 
@@ -125,23 +125,7 @@ public class CachedDownloader
         }
     }
 
-    private string EnsureDownloadDirectory(FileDescriptor fileDescriptor) =>
-        EnsureCacheRoot() is not null && EnsureDirectoryExists(FileRootPath(fileDescriptor)) is { } downloadPath ? downloadPath : null;
-
-    private void TryDeleteFile(string tempFile)
-    {
-        try
-        {
-            logger.LogDebug(Resources.MSG_DeletingFile, tempFile);
-            fileWrapper.Delete(tempFile);
-        }
-        catch (Exception ex)
-        {
-            logger.LogDebug(Resources.MSG_DeletingFileFailure, tempFile, ex.Message);
-        }
-    }
-
-    private async Task<DownloadError> EnsureFileIsDownloaded(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download)
+    protected async Task<DownloadError> EnsureFileIsDownloaded(string downloadPath, string downloadTarget, FileDescriptor descriptor, Func<Task<Stream>> download)
     {
         if (fileWrapper.Exists(downloadTarget))
         {

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/CachedDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/CachedDownloader.cs
@@ -25,10 +25,10 @@ namespace SonarScanner.MSBuild.PreProcessor.Caching;
 
 public class CachedDownloader
 {
+    protected readonly IDirectoryWrapper directoryWrapper;
+    protected readonly IFileWrapper fileWrapper;
+    protected readonly ILogger logger;
     private readonly IChecksum checksum;
-    private readonly IDirectoryWrapper directoryWrapper;
-    private readonly IFileWrapper fileWrapper;
-    private readonly ILogger logger;
     private readonly string sonarUserHome;
 
     public string CacheRoot => Path.Combine(sonarUserHome, "cache");

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/CachedDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/CachedDownloader.cs
@@ -72,6 +72,9 @@ public class CachedDownloader
     public virtual string EnsureCacheRoot() =>
         EnsureDirectoryExists(CacheRoot);
 
+    public string FileRootPath(FileDescriptor descriptor) =>
+        Path.Combine(CacheRoot, descriptor.Sha256);
+
     internal string EnsureDirectoryExists(string directory)
     {
         try
@@ -160,9 +163,6 @@ public class CachedDownloader
 
     protected string EnsureDownloadDirectory(FileDescriptor fileDescriptor) =>
         EnsureCacheRoot() is not null && EnsureDirectoryExists(FileRootPath(fileDescriptor)) is { } downloadPath ? downloadPath : null;
-
-    protected string FileRootPath(FileDescriptor descriptor) =>
-        Path.Combine(CacheRoot, descriptor.Sha256);
 
     private void TryDeleteFile(string tempFile)
     {

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/FileDescriptor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/FileDescriptor.cs
@@ -20,14 +20,4 @@
 
 namespace SonarScanner.MSBuild.PreProcessor.Caching;
 
-public record FileDescriptor
-{
-    public string Filename { get; }
-    public string Sha256 { get; }
-
-    public FileDescriptor(string filename, string sha256)
-    {
-        Filename = filename;
-        Sha256 = sha256;
-    }
-}
+public record FileDescriptor(string Filename, string Sha256);

--- a/src/SonarScanner.MSBuild.PreProcessor/EngineResolution/EngineResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/EngineResolution/EngineResolver.cs
@@ -52,7 +52,7 @@ public class EngineResolver : IEngineResolver
             logger.LogDebug(Resources.MSG_EngineResolver_MetadataFailure);
             return null;
         }
-        return cachedDownloader.IsFileCached(metadata.ToDescriptor()) switch
+        return cachedDownloader.IsFileCached() switch
         {
             CacheHit hit => hit.FilePath,
             _ => throw new NotImplementedException("Not yet implemented"),

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreDescriptor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreDescriptor.cs
@@ -25,7 +25,4 @@ namespace SonarScanner.MSBuild.PreProcessor.JreResolution;
 /// <summary>
 /// The descriptor of the JRE as returned from the server /analysis/jres endpoint.
 /// </summary>
-public record JreDescriptor(string Filename, string Sha256, string JavaPath) : FileDescriptor(Filename, Sha256)
-{
-    public string JavaPath { get; } = JavaPath;
-}
+public record JreDescriptor(string Filename, string Sha256, string JavaPath) : FileDescriptor(Filename, Sha256);

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreDownloader.cs
@@ -58,7 +58,6 @@ public class JreDownloader
     {
         if (cachedDownloader.EnsureCacheRoot())
         {
-
             if (directoryWrapper.Exists(jreExtractionPath))
             {
                 return fileWrapper.Exists(extractedJavaExe)

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreDownloader.cs
@@ -27,7 +27,7 @@ using System.Threading.Tasks;
 
 namespace SonarScanner.MSBuild.PreProcessor.JreResolution;
 
-public class JreDownloader
+public class JreDownloader : CachingDownloader
 {
     private readonly ILogger logger;
     private readonly CachedDownloader cachedDownloader;
@@ -38,11 +38,12 @@ public class JreDownloader
     private IUnpacker unpacker;
 
     public JreDownloader(ILogger logger,
-                         CachedDownloader cachedDownloader,
                          IDirectoryWrapper directoryWrapper,
                          IFileWrapper fileWrapper,
-                         UnpackerFactory unpackerFactory,
-                         IFilePermissionsWrapper filePermissionsWrapper)
+                         IChecksum checksum,
+                         IUnpackerFactory unpackerFactory,
+                         IFilePermissionsWrapper filePermissionsWrapper,
+                         string sonarUserHome) : base(logger, directoryWrapper, fileWrapper, checksum, sonarUserHome)
     {
         this.logger = logger;
         this.cachedDownloader = cachedDownloader;

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreDownloader.cs
@@ -20,7 +20,6 @@
 
 using SonarScanner.MSBuild.PreProcessor.Caching;
 using SonarScanner.MSBuild.PreProcessor.Unpacking;
-using System.Threading.Tasks;
 
 namespace SonarScanner.MSBuild.PreProcessor.JreResolution;
 
@@ -34,16 +33,16 @@ public class JreDownloader
     private readonly JreDescriptor jreDescriptor;
 
     public JreDownloader(ILogger logger,
+                         CachedDownloader cachedDownloader,
                          IDirectoryWrapper directoryWrapper,
                          IFileWrapper fileWrapper,
-                         CachedDownloader cachedDownloader,
                          IUnpacker unpacker,
                          JreDescriptor jreDescriptor)
     {
         this.logger = logger;
+        this.cachedDownloader = cachedDownloader;
         this.directoryWrapper = directoryWrapper;
         this.fileWrapper = fileWrapper;
-        this.cachedDownloader = cachedDownloader;
         this.unpacker = unpacker;
         this.jreDescriptor = jreDescriptor;
     }
@@ -71,8 +70,8 @@ public class JreDownloader
     public virtual async Task<DownloadResult> DownloadJreAsync(Func<Task<Stream>> jreDownload)
     {
         logger.LogInfo(Resources.MSG_JreDownloadBottleneck, jreDescriptor.Filename);
-        var resolution = await cachedDownloader.DownloadFileAsync(jreDescriptor, jreDownload);
-        return resolution is ResolutionSuccess resolutionSuccess ? UnpackJre(resolutionSuccess.FilePath) : resolution;
+        var result = await cachedDownloader.DownloadFileAsync(jreDescriptor, jreDownload);
+        return result is DownloadSuccess success ? UnpackJre(success.FilePath) : result;
     }
 
     public virtual DownloadResult UnpackJre(string jreArchive)

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreDownloader.cs
@@ -21,6 +21,9 @@
 using SonarScanner.MSBuild.PreProcessor.Caching;
 using SonarScanner.MSBuild.PreProcessor.Interfaces;
 using SonarScanner.MSBuild.PreProcessor.Unpacking;
+using System;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace SonarScanner.MSBuild.PreProcessor.JreResolution;
 
@@ -32,6 +35,7 @@ public class JreDownloader
     private readonly IFileWrapper fileWrapper;
     private readonly UnpackerFactory unpackerFactory;
     private readonly IFilePermissionsWrapper filePermissionsWrapper;
+    private IUnpacker unpacker;
 
     public JreDownloader(ILogger logger,
                          CachedDownloader cachedDownloader,

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
@@ -33,12 +33,14 @@ public class JreResolver : IJreResolver
     private readonly IDirectoryWrapper directoryWrapper;
     private readonly IFileWrapper fileWrapper;
     private readonly IFilePermissionsWrapper filePermissionsWrapper;
-    private readonly CachedDownloader cachedDownloader;
+    private readonly IChecksum checksum;
+    private readonly string sonarUserHome;
 
     public JreResolver(ISonarWebServer server,
                        ILogger logger,
                        IFilePermissionsWrapper filePermissionsWrapper,
-                       CachedDownloader cachedDownloader,
+                       IChecksum checksum,
+                       string sonarUserHome,
                        IUnpackerFactory unpackerFactory = null,
                        IDirectoryWrapper directoryWrapper = null,
                        IFileWrapper fileWrapper = null)
@@ -46,7 +48,8 @@ public class JreResolver : IJreResolver
         this.server = server;
         this.logger = logger;
         this.filePermissionsWrapper = filePermissionsWrapper;
-        this.cachedDownloader = cachedDownloader;
+        this.checksum = checksum;
+        this.sonarUserHome = sonarUserHome;
         this.unpackerFactory = unpackerFactory ?? UnpackerFactory.Instance;
         this.directoryWrapper = directoryWrapper ?? DirectoryWrapper.Instance;
         this.fileWrapper = fileWrapper ?? FileWrapper.Instance;
@@ -83,7 +86,7 @@ public class JreResolver : IJreResolver
         var descriptor = metadata.ToDescriptor();
         if (unpackerFactory.Create(logger, directoryWrapper, fileWrapper, filePermissionsWrapper, descriptor.Filename) is { } unpacker)
         {
-            var jreDownloader = new JreDownloader(logger, cachedDownloader, directoryWrapper, fileWrapper, unpacker, descriptor);
+            var jreDownloader = new JreDownloader(logger, directoryWrapper, fileWrapper, unpacker, checksum, sonarUserHome, descriptor);
             var result = jreDownloader.IsJreCached();
             switch (result)
             {

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
@@ -87,8 +87,7 @@ public class JreResolver : IJreResolver
         if (unpackerFactory.Create(logger, directoryWrapper, fileWrapper, filePermissionsWrapper, descriptor.Filename) is { } unpacker)
         {
             var jreDownloader = new JreDownloader(logger, directoryWrapper, fileWrapper, unpacker, checksum, sonarUserHome, descriptor);
-            var result = jreDownloader.IsJreCached();
-            switch (result)
+            switch (jreDownloader.IsJreCached())
             {
                 case CacheHit hit:
                     logger.LogDebug(Resources.MSG_JreResolver_CacheHit, hit.FilePath);

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
@@ -29,7 +29,7 @@ public class JreResolver : IJreResolver
 {
     private readonly ISonarWebServer server;
     private readonly ILogger logger;
-    private readonly IUnpackerFactory unpackerFactory;
+    private readonly UnpackerFactory unpackerFactory;
     private readonly IDirectoryWrapper directoryWrapper;
     private readonly IFileWrapper fileWrapper;
     private readonly IFilePermissionsWrapper filePermissionsWrapper;
@@ -41,7 +41,7 @@ public class JreResolver : IJreResolver
                        IFilePermissionsWrapper filePermissionsWrapper,
                        IChecksum checksum,
                        string sonarUserHome,
-                       IUnpackerFactory unpackerFactory = null,
+                       UnpackerFactory unpackerFactory = null,
                        IDirectoryWrapper directoryWrapper = null,
                        IFileWrapper fileWrapper = null)
     {

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
@@ -84,7 +84,7 @@ public class JreResolver : IJreResolver
         if (unpackerFactory.Create(logger, directoryWrapper, fileWrapper, filePermissionsWrapper, descriptor.Filename) is { } unpacker)
         {
             var jreDownloader = new JreDownloader(logger, cachedDownloader, directoryWrapper, fileWrapper, unpacker, descriptor);
-            var result = jreDownloader.IsJrecached();
+            var result = jreDownloader.IsJreCached();
             switch (result)
             {
                 case CacheHit hit:
@@ -97,7 +97,7 @@ public class JreResolver : IJreResolver
                     logger.LogDebug(Resources.MSG_JreResolver_CacheFailure, failure.Message);
                     return null;
                 default:
-                    throw new NotSupportedException("File Resolution is expected to be Success, CacheMiss, or Error.");
+                    throw new NotSupportedException("File Resolution is expected to be CacheHit, CacheMiss, or CacheError.");
             }
         }
         else
@@ -120,7 +120,7 @@ public class JreResolver : IJreResolver
             logger.LogDebug(Resources.MSG_JreResolver_DownloadFailure, error.Message);
             return null;
         }
-        throw new NotSupportedException("Download result is expected to be Hit or Failure.");
+        throw new NotSupportedException("Download result is expected to be DownloadSuccess or DownloadError.");
     }
 
     private bool IsValid(ProcessedArgs args)

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
@@ -96,14 +96,9 @@ public class JreResolver(ISonarWebServer server, JreDownloader downloader, ILogg
     {
         logger.LogInfo(Resources.MSG_JreDownloadBottleneck, descriptor.Filename);
         var downloadResult = await cache.DownloadFileAsync(descriptor, () => server.DownloadJreAsync(metadata));
-        if (downloadResult is CacheHit downloadSucces)
-        {
-            return cache.UnpackJre(downloadSucces.FilePath, descriptor);
-        }
-        else
-        {
-            return downloadResult;
-        }
+        return downloadResult is CacheHit downloadSucces
+            ? cache.UnpackJre(downloadSucces.FilePath, descriptor)
+            : downloadResult;
     }
 
     private bool IsValid(ProcessedArgs args)

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
@@ -83,7 +83,7 @@ public class JreResolver : IJreResolver
         var descriptor = metadata.ToDescriptor();
         if (unpackerFactory.Create(logger, directoryWrapper, fileWrapper, filePermissionsWrapper, descriptor.Filename) is { } unpacker)
         {
-            var jreDownloader = new JreDownloader(logger, directoryWrapper, fileWrapper, cachedDownloader, unpacker, descriptor);
+            var jreDownloader = new JreDownloader(logger, cachedDownloader, directoryWrapper, fileWrapper, unpacker, descriptor);
             var result = jreDownloader.IsJrecached();
             switch (result)
             {
@@ -115,9 +115,9 @@ public class JreResolver : IJreResolver
             logger.LogDebug(Resources.MSG_JreResolver_DownloadSuccess, success.FilePath);
             return success.FilePath;
         }
-        else if (result is CacheFailure downloadFailure)
+        else if (result is DownloadError error)
         {
-            logger.LogDebug(Resources.MSG_JreResolver_DownloadFailure, downloadFailure.Message);
+            logger.LogDebug(Resources.MSG_JreResolver_DownloadFailure, error.Message);
             return null;
         }
         throw new NotSupportedException("Download result is expected to be Hit or Failure.");

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -104,8 +104,7 @@ public class PreprocessorObjectFactory : IPreprocessorObjectFactory
     {
         var filePermissionsWrapper = new FilePermissionsWrapper(new OperatingSystemProvider(FileWrapper.Instance, logger));
         var cachedDownloader = new CachedDownloader(logger, DirectoryWrapper.Instance, FileWrapper.Instance, ChecksumSha256.Instance, sonarUserHome);
-        var jreDownloader = new JreDownloader(logger, cachedDownloader, DirectoryWrapper.Instance, FileWrapper.Instance, UnpackerFactory.Instance, filePermissionsWrapper);
-        return new JreResolver(server, jreDownloader, logger);
+        return new JreResolver(server, logger, filePermissionsWrapper, cachedDownloader);
     }
 
     private bool ValidateServerUrl(string serverUrl)

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -23,7 +23,6 @@ using SonarScanner.MSBuild.PreProcessor.Caching;
 using SonarScanner.MSBuild.PreProcessor.JreResolution;
 using SonarScanner.MSBuild.PreProcessor.Roslyn;
 using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
-using SonarScanner.MSBuild.PreProcessor.Unpacking;
 using SonarScanner.MSBuild.PreProcessor.WebServer;
 
 namespace SonarScanner.MSBuild.PreProcessor;

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -19,7 +19,6 @@
  */
 
 using System.Net;
-using SonarScanner.MSBuild.PreProcessor.Caching;
 using SonarScanner.MSBuild.PreProcessor.JreResolution;
 using SonarScanner.MSBuild.PreProcessor.Roslyn;
 using SonarScanner.MSBuild.PreProcessor.Roslyn.Model;
@@ -102,8 +101,8 @@ public class PreprocessorObjectFactory : IPreprocessorObjectFactory
     public IJreResolver CreateJreResolver(ISonarWebServer server, string sonarUserHome)
     {
         var filePermissionsWrapper = new FilePermissionsWrapper(new OperatingSystemProvider(FileWrapper.Instance, logger));
-        var cachedDownloader = new CachedDownloader(logger, DirectoryWrapper.Instance, FileWrapper.Instance, ChecksumSha256.Instance, sonarUserHome);
-        return new JreResolver(server, logger, filePermissionsWrapper, cachedDownloader);
+
+        return new JreResolver(server, logger, filePermissionsWrapper, ChecksumSha256.Instance, sonarUserHome);
     }
 
     private bool ValidateServerUrl(string serverUrl)


### PR DESCRIPTION
[SCAN4NET-751](https://sonarsource.atlassian.net/browse/SCAN4NET-751)

Part of SCAN4NET-712

based on #2668

I also renamed:
`FileCache` -> `CachingDownloader`
`JreCache` -> `JreDownloader`
`CacheResult` -> `FileResolution`
`CacheHit` -> `ResolutionSuccess`
`CacheMiss` -> `CacheMiss`
`CacheFailure` -> `ResolutionError`


next PR should break the refactor chain and be actual implementation.

[SCAN4NET-751]: https://sonarsource.atlassian.net/browse/SCAN4NET-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ