### PR TITLE
SCAN4NET-705 Rewrite PostProcessor.ProcessCoverageReport

### DIFF
--- a/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
@@ -102,8 +102,6 @@ public class PostProcessorTests
     public void PostProc_NoProjectsToAnalyze_NoExecutionTriggered()
     {
         Execute(withProject: false).Should().BeFalse("Expecting post-processor to have failed");
-        tfsProcessor.DidNotReceiveWithAnyArgs().Execute(null, null, null);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null);
         scanner.DidNotReceiveWithAnyArgs().Execute(null, null, null);
         logger.AssertNoErrorsLogged();
         logger.AssertNoWarningsLogged();
@@ -117,8 +115,6 @@ public class PostProcessorTests
         scanner.WhenForAnyArgs(x => x.Execute(null, null, null)).Do(x => logger.LogError("Errors"));
 
         Execute().Should().BeTrue("Expecting post-processor to have succeeded");
-        tfsProcessor.DidNotReceiveWithAnyArgs().Execute(null, null, null);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null);
         scanner.Received().Execute(
             config,
             Arg.Is<IAnalysisPropertyProvider>(x => !x.GetAllProperties().Any()),
@@ -132,8 +128,6 @@ public class PostProcessorTests
     public void PostProc_FailsOnInvalidArgs()
     {
         Execute("/d:sonar.foo=bar").Should().BeFalse("Expecting post-processor to have failed");
-        tfsProcessor.DidNotReceiveWithAnyArgs().Execute(null, null, null);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null);
         scanner.DidNotReceiveWithAnyArgs().Execute(null, null, null);
         logger.AssertErrorsLogged(1);
         logger.AssertWarningsLogged(0);
@@ -158,8 +152,6 @@ public class PostProcessorTests
         };
 
         Execute(suppliedArgs).Should().BeTrue("Expecting post-processor to have succeeded");
-        tfsProcessor.DidNotReceiveWithAnyArgs().Execute(null, null, null);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null);
         scanner.Received().Execute(
             config,
             Arg.Is<IAnalysisPropertyProvider>(x => x.GetAllProperties().Select(x => x.AsSonarScannerArg()).SequenceEqual(expectedArgs)),
@@ -175,8 +167,6 @@ public class PostProcessorTests
 
         Execute().Should().BeFalse();
         logger.AssertErrorLogged(CredentialsErrorMessage);
-        tfsProcessor.DidNotReceiveWithAnyArgs().Execute(null, null, null);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null);
         scanner.DidNotReceiveWithAnyArgs().Execute(null, null, null);
         VerifyTargetsUninstaller();
     }
@@ -188,8 +178,6 @@ public class PostProcessorTests
 
         Execute().Should().BeFalse();
         logger.AssertErrorLogged(TruststorePasswordErrorMessage);
-        tfsProcessor.DidNotReceiveWithAnyArgs().Execute(null, null, null);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null);
         scanner.DidNotReceiveWithAnyArgs().Execute(null, null, null);
         VerifyTargetsUninstaller();
     }
@@ -248,8 +236,6 @@ public class PostProcessorTests
 
         Execute($"/d:{truststorePasswordProperty}").Should().BeFalse();
         logger.AssertErrorLogged($"The format of the analysis property {truststorePasswordProperty} is invalid");
-        tfsProcessor.DidNotReceiveWithAnyArgs().Execute(null, null, null);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null);
         scanner.DidNotReceiveWithAnyArgs().Execute(null, null, null);
         VerifyTargetsUninstaller();
     }
@@ -262,8 +248,6 @@ public class PostProcessorTests
         env.SetVariable(EnvironmentVariables.SonarScannerOptsVariableName, "-Dsonar.scanner.truststorePassword");
 
         Execute().Should().BeFalse();
-        tfsProcessor.DidNotReceiveWithAnyArgs().Execute(null, null, null);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null);
         scanner.DidNotReceiveWithAnyArgs().Execute(null, null, null);
         VerifyTargetsUninstaller();
     }
@@ -273,8 +257,6 @@ public class PostProcessorTests
     {
         Execute("/d:sonar.token=foo").Should().BeFalse();
         logger.AssertErrorLogged(CredentialsErrorMessage);
-        tfsProcessor.DidNotReceiveWithAnyArgs().Execute(null, null, null);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null);
         scanner.DidNotReceiveWithAnyArgs().Execute(null, null, null);
         VerifyTargetsUninstaller();
     }

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
@@ -312,8 +312,6 @@ public class PostProcessorTests
         AssertTfsProcessorConvertCoverageCalledIfNetFramework(false);
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework(false);
         coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null, null);
-        logger.AssertMessageNotLogged(Resources.MSG_ConvertingCoverageReports);
-        logger.AssertMessageNotLogged(Resources.MSG_TFSLegacyProcessorCalled);
     }
 
     [TestMethod]
@@ -325,8 +323,6 @@ public class PostProcessorTests
         AssertTfsProcessorConvertCoverageCalledIfNetFramework(false);
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework(false);
         AssertProcessCoverageReportsCalledIfNetFramework();
-        logger.AssertInfoLogged("Converting coverage reports.");
-        logger.AssertMessageNotLogged(Resources.MSG_TFSLegacyProcessorCalled);
     }
 
     [TestMethod]
@@ -338,8 +334,6 @@ public class PostProcessorTests
         AssertTfsProcessorConvertCoverageCalledIfNetFramework();
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework();
         coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null, null);
-        logger.AssertMessageNotLogged(Resources.MSG_ConvertingCoverageReports);
-        logger.AssertInfoLogged("Calling legacy TFS processor.");
     }
 
     [TestMethod]
@@ -352,8 +346,6 @@ public class PostProcessorTests
         AssertTfsProcessorConvertCoverageCalledIfNetFramework(false);
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework(false);
         coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null, null);
-        logger.AssertMessageNotLogged(Resources.MSG_ConvertingCoverageReports);
-        logger.AssertMessageNotLogged(Resources.MSG_TFSLegacyProcessorCalled);
         logger.AssertErrorLogged("""
             Inconsistent build environment settings: the build Uri in the analysis config file does not match the build uri from the environment variable.
             Build Uri from environment: http://test-build-uri
@@ -374,8 +366,6 @@ public class PostProcessorTests
         AssertTfsProcessorConvertCoverageCalledIfNetFramework(false);
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework();
         coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null, null);
-        logger.AssertMessageNotLogged(Resources.MSG_ConvertingCoverageReports);
-        logger.AssertMessageNotLogged(Resources.MSG_TFSLegacyProcessorCalled);
     }
 
     private bool Execute(string arg) =>

--- a/Tests/SonarScanner.MSBuild.TFS.Test/BuildVNextCoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/BuildVNextCoverageReportProcessorTests.cs
@@ -25,7 +25,7 @@ namespace SonarScanner.MSBuild.TFS.Test;
 [TestClass]
 public class BuildVNextCoverageReportProcessorTests
 {
-    public enum Settings
+    public enum Properties
     {
         TestAndCoverageXmlReportsPathsNull,
         TestReportsPathsNotNull,
@@ -82,11 +82,11 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNull)]
-    [DataRow(Settings.CoverageXmlReportsPathsNotNull)]
-    public void ProcessCoverageReports_TrxFileFound_WritesPropertiesFile(Settings settings)
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNull)]
+    [DataRow(Properties.CoverageXmlReportsPathsNotNull)]
+    public void ProcessCoverageReports_TrxFileFound_WritesPropertiesFile(Properties properties)
     {
-        SetupSettingsAndFiles(settings, trx: true);
+        SetupPropertiesAndFiles(properties, trx: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         AssertUsesFallback(false);
@@ -96,11 +96,11 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.TestReportsPathsNotNull)]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNotNull)]
-    public void ProcessCoverageReports_TrxFileFound_TestReportsPathsProvided_DoesNotWritePropertiesFile(Settings settings)
+    [DataRow(Properties.TestReportsPathsNotNull)]
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNotNull)]
+    public void ProcessCoverageReports_TrxFileFound_TestReportsPathsProvided_DoesNotWritePropertiesFile(Properties properties)
     {
-        SetupSettingsAndFiles(settings, trx: true);
+        SetupPropertiesAndFiles(properties, trx: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         testLogger.Warnings.Should().ContainSingle().Which.StartsWith("None of the following coverage attachments could be found: dummy.coverage");
@@ -108,13 +108,13 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNull)]
-    [DataRow(Settings.TestReportsPathsNotNull)]
-    [DataRow(Settings.CoverageXmlReportsPathsNotNull)]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNotNull)]
-    public void ProcessCoverageReports_NoTrxFilesFound_DoesNotWritePropertiesFile(Settings settings)
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNull)]
+    [DataRow(Properties.TestReportsPathsNotNull)]
+    [DataRow(Properties.CoverageXmlReportsPathsNotNull)]
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNotNull)]
+    public void ProcessCoverageReports_NoTrxFilesFound_DoesNotWritePropertiesFile(Properties properties)
     {
-        SetupSettingsAndFiles(settings);
+        SetupPropertiesAndFiles(properties);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         AssertUsesFallback();
@@ -125,7 +125,7 @@ public class BuildVNextCoverageReportProcessorTests
     [TestMethod]
     public void ProcessCoverageReports_TrxAndCoverageFileFound_Converts()
     {
-        SetupSettingsAndFiles(Settings.TestAndCoverageXmlReportsPathsNull, trx: true, coverage: true);
+        SetupPropertiesAndFiles(Properties.TestAndCoverageXmlReportsPathsNull, trx: true, coverage: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
@@ -137,7 +137,7 @@ public class BuildVNextCoverageReportProcessorTests
     [TestMethod]
     public void ProcessCoverageReports_TrxAndCoverageFileFound_TestReportsPathsProvided_Converts_DoesNotWriteTestReportsPathsToPropertiesFile()
     {
-        SetupSettingsAndFiles(Settings.TestReportsPathsNotNull, trx: true, coverage: true);
+        SetupPropertiesAndFiles(Properties.TestReportsPathsNotNull, trx: true, coverage: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
@@ -149,7 +149,7 @@ public class BuildVNextCoverageReportProcessorTests
     [TestMethod]
     public void ProcessCoverageReports_TrxAndCoverageFileFound_CoverageXmlReportsPathsProvided_Converts_DoesNotWriteCoverageXmlReportsPathsToPropertiesFile()
     {
-        SetupSettingsAndFiles(Settings.CoverageXmlReportsPathsNotNull, trx: true, coverage: true);
+        SetupPropertiesAndFiles(Properties.CoverageXmlReportsPathsNotNull, trx: true, coverage: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
@@ -161,7 +161,7 @@ public class BuildVNextCoverageReportProcessorTests
     [TestMethod]
     public void ProcessCoverageReports_TrxAndCoverageFileFound_TestReportsAndCoverageXmlPathsProvided_Converts_DoesNotWritePropertiesFile()
     {
-        SetupSettingsAndFiles(Settings.TestAndCoverageXmlReportsPathsNotNull, trx: true, coverage: true);
+        SetupPropertiesAndFiles(Properties.TestAndCoverageXmlReportsPathsNotNull, trx: true, coverage: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
@@ -170,13 +170,13 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNull)]
-    [DataRow(Settings.TestReportsPathsNotNull)]
-    [DataRow(Settings.CoverageXmlReportsPathsNotNull)]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNotNull)]
-    public void ProcessCoverageReports_NoTrxFilesFound_CoverageFileFound_DoesNotConvert(Settings settings)
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNull)]
+    [DataRow(Properties.TestReportsPathsNotNull)]
+    [DataRow(Properties.CoverageXmlReportsPathsNotNull)]
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNotNull)]
+    public void ProcessCoverageReports_NoTrxFilesFound_CoverageFileFound_DoesNotConvert(Properties properties)
     {
-        SetupSettingsAndFiles(settings, coverage: true);
+        SetupPropertiesAndFiles(properties, coverage: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(0);
@@ -185,11 +185,11 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNull)]
-    [DataRow(Settings.TestReportsPathsNotNull)]
-    public void ProcessCoverageReports_CoverageXmlFileAlreadyPresent_DoesNotConvert_WritesCoverageXmlReportsPathsToPropertiesFile(Settings settings)
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNull)]
+    [DataRow(Properties.TestReportsPathsNotNull)]
+    public void ProcessCoverageReports_CoverageXmlFileAlreadyPresent_DoesNotConvert_WritesCoverageXmlReportsPathsToPropertiesFile(Properties properties)
     {
-        SetupSettingsAndFiles(settings, trx: true, coverage: true, coverageXml: true);
+        SetupPropertiesAndFiles(properties, trx: true, coverage: true, coverageXml: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertConvertNotCalled();
@@ -198,11 +198,11 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.CoverageXmlReportsPathsNotNull)]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNotNull)]
-    public void ProcessCoverageReports_CoverageXmlFileAlreadyPresent_CoverageXmlReportsPathsProvided_DoesNotConvert_DoesNotWriteCoverageXmlReportsPathsToPropertiesFile(Settings settings)
+    [DataRow(Properties.CoverageXmlReportsPathsNotNull)]
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNotNull)]
+    public void ProcessCoverageReports_CoverageXmlFileAlreadyPresent_CoverageXmlReportsPathsProvided_DoesNotConvert_DoesNotWriteCoverageXmlReportsPathsToPropertiesFile(Properties properties)
     {
-        SetupSettingsAndFiles(settings, trx: true, coverage: true, coverageXml: true);
+        SetupPropertiesAndFiles(properties, trx: true, coverage: true, coverageXml: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertConvertNotCalled();
@@ -211,13 +211,13 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNull)]
-    [DataRow(Settings.TestReportsPathsNotNull)]
-    [DataRow(Settings.CoverageXmlReportsPathsNotNull)]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNotNull)]
-    public void ProcessCoverageReports_ConversionFails_ReturnsTrue(Settings settings)
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNull)]
+    [DataRow(Properties.TestReportsPathsNotNull)]
+    [DataRow(Properties.CoverageXmlReportsPathsNotNull)]
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNotNull)]
+    public void ProcessCoverageReports_ConversionFails_ReturnsTrue(Properties properties)
     {
-        SetupSettingsAndFiles(settings, trx: true, coverage: true);
+        SetupPropertiesAndFiles(properties, trx: true, coverage: true);
         converter.ShouldFailConversion = true;
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
@@ -227,11 +227,11 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNull)]
-    [DataRow(Settings.TestReportsPathsNotNull)]
-    public void ProcessCoverageReports_NoTrxFilesFound_AlternateCoverageFileFound_Converts(Settings settings)
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNull)]
+    [DataRow(Properties.TestReportsPathsNotNull)]
+    public void ProcessCoverageReports_NoTrxFilesFound_AlternateCoverageFileFound_Converts(Properties properties)
     {
-        SetupSettingsAndFiles(settings, alternate: true);
+        SetupPropertiesAndFiles(properties, alternate: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
@@ -241,11 +241,11 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.CoverageXmlReportsPathsNotNull)]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNotNull)]
-    public void ProcessCoverageReports_NoTrxFilesFound_AlternateCoverageFilesFound_VsCoverageXmlReportsPathsProvided_Converts_DoesNotWritePropertiesFile(Settings settings)
+    [DataRow(Properties.CoverageXmlReportsPathsNotNull)]
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNotNull)]
+    public void ProcessCoverageReports_NoTrxFilesFound_AlternateCoverageFilesFound_VsCoverageXmlReportsPathsProvided_Converts_DoesNotWritePropertiesFile(Properties properties)
     {
-        SetupSettingsAndFiles(settings, alternate: true);
+        SetupPropertiesAndFiles(properties, alternate: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         AssertUsesFallback();
@@ -254,11 +254,11 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNull)]
-    [DataRow(Settings.CoverageXmlReportsPathsNotNull)]
-    public void ProcessCoverageReports_TrxAndAlternateCoverageFileFound_DoesNotUseFallback(Settings settings)
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNull)]
+    [DataRow(Properties.CoverageXmlReportsPathsNotNull)]
+    public void ProcessCoverageReports_TrxAndAlternateCoverageFileFound_DoesNotUseFallback(Properties properties)
     {
-        SetupSettingsAndFiles(settings, trx: true, alternate: true);
+        SetupPropertiesAndFiles(properties, trx: true, alternate: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(0);
@@ -268,11 +268,11 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.TestReportsPathsNotNull)]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNotNull)]
-    public void ProcessCoverageReports_TrxAndAlternateCoverageFileFound_TestReportsPathsProvided_UsesFallback_Converts(Settings settings)
+    [DataRow(Properties.TestReportsPathsNotNull)]
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNotNull)]
+    public void ProcessCoverageReports_TrxAndAlternateCoverageFileFound_TestReportsPathsProvided_UsesFallback_Converts(Properties properties)
     {
-        SetupSettingsAndFiles(settings, trx: true, alternate: true);
+        SetupPropertiesAndFiles(properties, trx: true, alternate: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
@@ -281,11 +281,11 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNull)]
-    [DataRow(Settings.TestReportsPathsNotNull)]
-    public void ProcessCoverageReports_TrxAndCoverageAndAlternateCoverageFileFound_Converts_DoesNotUseFallback(Settings settings)
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNull)]
+    [DataRow(Properties.TestReportsPathsNotNull)]
+    public void ProcessCoverageReports_TrxAndCoverageAndAlternateCoverageFileFound_Converts_DoesNotUseFallback(Properties properties)
     {
-        SetupSettingsAndFiles(settings, trx: true, coverage: true, alternate: true);
+        SetupPropertiesAndFiles(properties, trx: true, coverage: true, alternate: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
@@ -294,12 +294,12 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.CoverageXmlReportsPathsNotNull)]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNotNull)]
+    [DataRow(Properties.CoverageXmlReportsPathsNotNull)]
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNotNull)]
     public void ProcessCoverageReports_TrxAndCoverageAndAlternateCoverageFileFound_CoverageXmlReportsPathsProvided_Converts_DoesNotUseFallback_DoesNotWriteCoverageXmlReportsPathsToPropertiesFile(
-        Settings settings)
+        Properties properties)
     {
-        SetupSettingsAndFiles(settings, true, coverage: true, alternate: true);
+        SetupPropertiesAndFiles(properties, true, coverage: true, alternate: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
@@ -308,11 +308,11 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNull)]
-    [DataRow(Settings.TestReportsPathsNotNull)]
-    public void ProcessCoverageReports_AlternateCoverageFileFound_CoverageXmlFileAlreadyPresent_DoesNotConvert_UsesFallback(Settings settings)
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNull)]
+    [DataRow(Properties.TestReportsPathsNotNull)]
+    public void ProcessCoverageReports_AlternateCoverageFileFound_CoverageXmlFileAlreadyPresent_DoesNotConvert_UsesFallback(Properties properties)
     {
-        SetupSettingsAndFiles(settings, alternate: true, alternateXml: true);
+        SetupPropertiesAndFiles(properties, alternate: true, alternateXml: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertConvertNotCalled();
@@ -322,12 +322,12 @@ public class BuildVNextCoverageReportProcessorTests
     }
 
     [TestMethod]
-    [DataRow(Settings.CoverageXmlReportsPathsNotNull)]
-    [DataRow(Settings.TestAndCoverageXmlReportsPathsNotNull)]
+    [DataRow(Properties.CoverageXmlReportsPathsNotNull)]
+    [DataRow(Properties.TestAndCoverageXmlReportsPathsNotNull)]
     public void ProcessCoverageReports_AlternateCoverageFileFound_CoverageXmlFileAlreadyPresent_CoverageXmlReportsPathsProvided_DoesNotConvert_UsesFallback_DoesNotWritePropertiesFile(
-        Settings settings)
+        Properties properties)
     {
-        SetupSettingsAndFiles(settings, alternate: true, alternateXml: true);
+        SetupPropertiesAndFiles(properties, alternate: true, alternateXml: true);
 
         sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertConvertNotCalled();
@@ -464,14 +464,14 @@ public class BuildVNextCoverageReportProcessorTests
             .Equals(other)
             .Should().BeFalse();
 
-    private void SetupSettingsAndFiles(Settings settings, bool trx = false, bool coverage = false, bool coverageXml = false, bool alternate = false, bool alternateXml = false)
+    private void SetupPropertiesAndFiles(Properties settings, bool trx = false, bool coverage = false, bool coverageXml = false, bool alternate = false, bool alternateXml = false)
     {
         analysisConfig.LocalSettings = settings switch
         {
-            Settings.TestAndCoverageXmlReportsPathsNull => [new Property(SonarProperties.VsTestReportsPaths, null), new Property(SonarProperties.VsCoverageXmlReportsPaths, null)],
-            Settings.TestReportsPathsNotNull => [new Property(SonarProperties.VsTestReportsPaths, "not null"), new Property(SonarProperties.VsCoverageXmlReportsPaths, null)],
-            Settings.CoverageXmlReportsPathsNotNull => [new Property(SonarProperties.VsTestReportsPaths, null), new Property(SonarProperties.VsCoverageXmlReportsPaths, "not null")],
-            Settings.TestAndCoverageXmlReportsPathsNotNull => [new Property(SonarProperties.VsTestReportsPaths, "not null"), new Property(SonarProperties.VsCoverageXmlReportsPaths, "not null")],
+            Properties.TestAndCoverageXmlReportsPathsNull => [new Property(SonarProperties.VsTestReportsPaths, null), new Property(SonarProperties.VsCoverageXmlReportsPaths, null)],
+            Properties.TestReportsPathsNotNull => [new Property(SonarProperties.VsTestReportsPaths, "not null"), new Property(SonarProperties.VsCoverageXmlReportsPaths, null)],
+            Properties.CoverageXmlReportsPathsNotNull => [new Property(SonarProperties.VsTestReportsPaths, null), new Property(SonarProperties.VsCoverageXmlReportsPaths, "not null")],
+            Properties.TestAndCoverageXmlReportsPathsNotNull => [new Property(SonarProperties.VsTestReportsPaths, "not null"), new Property(SonarProperties.VsCoverageXmlReportsPaths, "not null")],
             _ => throw new NotSupportedException(settings + " is not a supported value.")
         };
         if (trx)

--- a/Tests/SonarScanner.MSBuild.TFS.Test/CoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/CoverageReportProcessorTests.cs
@@ -18,151 +18,104 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using NSubstitute;
-using SonarScanner.MSBuild.Common;
-using SonarScanner.MSBuild.Common.Interfaces;
 using SonarScanner.MSBuild.Common.TFS;
-using SonarScanner.MSBuild.TFS;
 using SonarScanner.MSBuild.TFS.Tests.Infrastructure;
-using TestUtilities;
 
-namespace SonarScanner.MSBuild.PostProcessor.Tests;
+namespace SonarScanner.MSBuild.TFS.Test;
 
 [TestClass]
 public class CoverageReportProcessorTests
 {
     private ILegacyTeamBuildFactory legacyFactory;
-    private ICoverageReportConverter reportConverter;
     private CoverageReportProcessor processor;
 
     [TestInitialize]
     public void TestInitialize()
     {
-        reportConverter = Substitute.For<ICoverageReportConverter>();
         legacyFactory = Substitute.For<ILegacyTeamBuildFactory>();
-        processor = new CoverageReportProcessor(legacyFactory, reportConverter, new TestLogger());
+        processor = new CoverageReportProcessor(legacyFactory);
     }
 
+    [TestMethod]
     public void Ctor_WhenLegacyFactoryIsNull_Throws()
     {
-        // Arrange
-        Action act = () => new CoverageReportProcessor(null, reportConverter, new TestLogger());
-
-        // Act & Assert
-        act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("legactTeamBuildFactory");
-    }
-
-    public void Ctor_WhenConverterIsNull_Throws()
-    {
-        // Arrange
-        Action act = () => new CoverageReportProcessor(legacyFactory, null, new TestLogger());
-
-        // Act & Assert
-        act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("coverageReportConverter");
-    }
-
-    public void Ctor_WhenLoggerIsNull_Throws()
-    {
-        // Arrange
-        Action act = () => new CoverageReportProcessor(legacyFactory, reportConverter, null);
-
-        // Act & Assert
-        act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("logger");
+        Action act = () => _ = new CoverageReportProcessor(null);
+        act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("legacyTeamBuildFactory");
     }
 
     [TestMethod]
     public void Initialize_Checks_Arguments_For_Null()
     {
-        // Arrange
-        var analysisConfig = new AnalysisConfig();
-        Action act = () => processor.Initialize(analysisConfig, null, string.Empty);
-
-        // Act & Assert
+        Action act = () => processor.Initialize(new AnalysisConfig(), null, string.Empty);
         act.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("settings");
     }
 
     [TestMethod]
     public void ProcessCoverageReports_LegacyTeamBuild_SkipCoverageIsFalse_WhenProcess_CallsLegacyFactoryThenCallsReturnedProcessor()
     {
-        // Arrange
-        var analysisConfig = new AnalysisConfig { LocalSettings = new AnalysisProperties() };
+        var analysisConfig = new AnalysisConfig { LocalSettings = [] };
         var settingsMock = new MockBuildSettings { BuildEnvironment = BuildEnvironment.LegacyTeamBuild };
         var logger = new TestLogger();
 
         // Set up the factory to return a processor that returns success
-        var processor = Substitute.For<ICoverageReportProcessor>();
-        processor.Initialize(Arg.Any<AnalysisConfig>(), Arg.Any<IBuildSettings>(), Arg.Any<string>()).Returns(true);
-        processor.ProcessCoverageReports(logger).Returns(true);
-        legacyFactory.BuildTfsLegacyCoverageReportProcessor().Returns(processor);
+        var processorSub = Substitute.For<ICoverageReportProcessor>();
+        processorSub.Initialize(Arg.Any<AnalysisConfig>(), Arg.Any<IBuildSettings>(), Arg.Any<string>()).Returns(true);
+        processorSub.ProcessCoverageReports(logger).Returns(true);
+        legacyFactory.BuildTfsLegacyCoverageReportProcessor().Returns(processorSub);
 
-        using (var scope = new EnvironmentVariableScope())
-        {
-            scope.SetVariable(BuildSettings.EnvironmentVariables.SkipLegacyCodeCoverage, "false");
+        using var scope = new EnvironmentVariableScope();
+        scope.SetVariable(BuildSettings.EnvironmentVariables.SkipLegacyCodeCoverage, "false");
 
-            var testSubject = new CoverageReportProcessor(legacyFactory, reportConverter, logger);
-            testSubject.Initialize(analysisConfig, settingsMock, string.Empty);
+        var testSubject = new CoverageReportProcessor(legacyFactory);
+        testSubject.Initialize(analysisConfig, settingsMock, string.Empty);
 
-            // Act
-            var result = testSubject.ProcessCoverageReports(logger);
+        var result = testSubject.ProcessCoverageReports(logger);
 
-            // Assert
-            result.Should().BeTrue();
-            legacyFactory.Received(1).BuildTfsLegacyCoverageReportProcessor();
-            processor.Received(1).Initialize(Arg.Any<AnalysisConfig>(), Arg.Any<IBuildSettings>(), Arg.Any<string>());
-            processor.Received(1).ProcessCoverageReports(logger);
-        }
+        result.Should().BeTrue();
+        legacyFactory.Received(1).BuildTfsLegacyCoverageReportProcessor();
+        processorSub.Received(1).Initialize(Arg.Any<AnalysisConfig>(), Arg.Any<IBuildSettings>(), Arg.Any<string>());
+        processorSub.Received(1).ProcessCoverageReports(logger);
     }
 
     [TestMethod]
     public void ProcessCoverageReports_LegacyTeamBuild_SkipCoverageIsTrue_WhenProcess_CallsLegacyFactoryThenCallsReturnedProcessor()
     {
-        // Arrange
         var analysisConfig = new AnalysisConfig { LocalSettings = [] };
         var settingsMock = new MockBuildSettings { BuildEnvironment = BuildEnvironment.LegacyTeamBuild };
         var logger = new TestLogger();
 
-        using (var scope = new EnvironmentVariableScope())
-        {
-            scope.SetVariable(BuildSettings.EnvironmentVariables.SkipLegacyCodeCoverage, "true");
+        using var scope = new EnvironmentVariableScope();
+        scope.SetVariable(BuildSettings.EnvironmentVariables.SkipLegacyCodeCoverage, "true");
 
-            var testSubject = new CoverageReportProcessor(legacyFactory, reportConverter, logger);
-            testSubject.Initialize(analysisConfig, settingsMock, string.Empty);
+        var testSubject = new CoverageReportProcessor(legacyFactory);
+        testSubject.Initialize(analysisConfig, settingsMock, string.Empty);
 
-            // Act
-            var result = false;
-            using (new AssertIgnoreScope())
-            {
-                result = testSubject.ProcessCoverageReports(logger);
-            }
-
-            // Assert
-            result.Should().BeTrue();
-            legacyFactory.DidNotReceive().BuildTfsLegacyCoverageReportProcessor();
-        }
-    }
-
-    [TestMethod]
-    public void ProcessCoverageReports_Standalone_WhenProcess_ReturnsTrue()
-    {
-        // Arrange
-        var analysisConfig = new AnalysisConfig { LocalSettings = [] };
-        var settings = new MockBuildSettings { BuildEnvironment = BuildEnvironment.NotTeamBuild };
-        var logger = new TestLogger();
-
-        var testSubject = new CoverageReportProcessor(legacyFactory, reportConverter, logger);
-        testSubject.Initialize(analysisConfig, settings, string.Empty);
-
-        // Act
         var result = false;
         using (new AssertIgnoreScope())
         {
             result = testSubject.ProcessCoverageReports(logger);
         }
 
-        // Assert
+        result.Should().BeTrue();
+        legacyFactory.DidNotReceive().BuildTfsLegacyCoverageReportProcessor();
+    }
+
+    [TestMethod]
+    public void ProcessCoverageReports_Standalone_WhenProcess_ReturnsTrue()
+    {
+        var analysisConfig = new AnalysisConfig { LocalSettings = [] };
+        var settings = new MockBuildSettings { BuildEnvironment = BuildEnvironment.NotTeamBuild };
+        var logger = new TestLogger();
+
+        var testSubject = new CoverageReportProcessor(legacyFactory);
+        testSubject.Initialize(analysisConfig, settings, string.Empty);
+
+        var result = false;
+        using (new AssertIgnoreScope())
+        {
+            result = testSubject.ProcessCoverageReports(logger);
+        }
+
         result.Should().BeTrue(); // false would cause the remaining processing to stop
         legacyFactory.DidNotReceive().BuildTfsLegacyCoverageReportProcessor();
     }

--- a/Tests/SonarScanner.MSBuild.TFS.Test/CoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/CoverageReportProcessorTests.cs
@@ -26,11 +26,10 @@ namespace SonarScanner.MSBuild.TFS.Test;
 [TestClass]
 public class CoverageReportProcessorTests
 {
-    private ILegacyTeamBuildFactory legacyFactory;
-    private CoverageReportProcessor processor;
+    private readonly ILegacyTeamBuildFactory legacyFactory;
+    private ICoverageReportProcessor processor;
 
-    [TestInitialize]
-    public void TestInitialize()
+    public CoverageReportProcessorTests()
     {
         legacyFactory = Substitute.For<ILegacyTeamBuildFactory>();
         processor = new CoverageReportProcessor(legacyFactory);
@@ -58,10 +57,10 @@ public class CoverageReportProcessorTests
         var logger = new TestLogger();
 
         // Set up the factory to return a processor that returns success
-        var processorSub = Substitute.For<ICoverageReportProcessor>();
-        processorSub.Initialize(Arg.Any<AnalysisConfig>(), Arg.Any<IBuildSettings>(), Arg.Any<string>()).Returns(true);
-        processorSub.ProcessCoverageReports(logger).Returns(true);
-        legacyFactory.BuildTfsLegacyCoverageReportProcessor().Returns(processorSub);
+        processor = Substitute.For<ICoverageReportProcessor>();
+        processor.Initialize(Arg.Any<AnalysisConfig>(), Arg.Any<IBuildSettings>(), Arg.Any<string>()).Returns(true);
+        processor.ProcessCoverageReports(logger).Returns(true);
+        legacyFactory.BuildTfsLegacyCoverageReportProcessor().Returns(processor);
 
         using var scope = new EnvironmentVariableScope();
         scope.SetVariable(BuildSettings.EnvironmentVariables.SkipLegacyCodeCoverage, "false");
@@ -73,8 +72,8 @@ public class CoverageReportProcessorTests
 
         result.Should().BeTrue();
         legacyFactory.Received(1).BuildTfsLegacyCoverageReportProcessor();
-        processorSub.Received(1).Initialize(Arg.Any<AnalysisConfig>(), Arg.Any<IBuildSettings>(), Arg.Any<string>());
-        processorSub.Received(1).ProcessCoverageReports(logger);
+        processor.Received(1).Initialize(Arg.Any<AnalysisConfig>(), Arg.Any<IBuildSettings>(), Arg.Any<string>());
+        processor.Received(1).ProcessCoverageReports(logger);
     }
 
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.TFS.Test/ProgramTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/ProgramTests.cs
@@ -18,13 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.IO;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarScanner.MSBuild.Common;
-using TestUtilities;
-
 namespace SonarScanner.MSBuild.TFS.Classic.Tests;
 
 [TestClass]
@@ -78,7 +71,8 @@ public class ProgramTests
 
         result.Should().Be(0);
         logger.Errors.Should().HaveCount(0);
-        logger.InfoMessages.Should().Contain("Coverage report conversion completed successfully.");
+        logger.InfoMessages.Should().NotContain("Coverage report conversion completed successfully.");
+        logger.InfoMessages.Should().NotContain("Coverage report conversion has failed. Skipping...");
     }
 
     [TestMethod]

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
@@ -75,7 +75,7 @@ class CodeCoverageTest {
         .end()
         .getLogs();
 
-      assertThat(logs).contains("Coverage report conversion completed successfully.");
+      assertThat(logs).contains("Converting coverage reports.");
       assertThat(logs).containsPattern("Converting coverage file '.*.coverage' to '.*.coveragexml'.");
       assertThat(logs).containsPattern("Parsing the Visual Studio coverage XML report .*coveragexml");
       assertThat(logs).contains("Coverage Report Statistics: 2 files, 1 main files, 1 main files with coverage, 1 test files, 0 project excluded files, 0 other language files.");

--- a/scripts/package-artifacts.ps1
+++ b/scripts/package-artifacts.ps1
@@ -54,6 +54,7 @@ function Package-NetScanner {
     Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.PreProcessor.dll" -Destination $destination
     Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.runtimeconfig.json" -Destination $destination
     Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.Shim.dll" -Destination $destination
+    Copy-Item -Path "$sourceRoot\SonarScanner.MSBuild.TFS.dll" -Destination $destination
     Copy-Item -Path "$sourceRoot\Google.Protobuf.dll" -Destination $destination
     Copy-Item -Path "$sourceRoot\Newtonsoft.Json.dll" -Destination $destination
     Copy-Item -Path "$sourceRoot\ICSharpCode.SharpZipLib.dll" -Destination $destination

--- a/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
@@ -223,11 +223,12 @@ public class PostProcessor : IPostProcessor
     {
         if (settings.BuildEnvironment is BuildEnvironment.TeamBuild)
         {
+            logger.LogInfo(Resources.MSG_ConvertingCoverageReports);
             coverageReportProcessor.ProcessCoverageReports(config, settings, propertiesFilePath, logger);
-            logger.LogInfo("Coverage report conversion completed.");
         }
         else if (settings.BuildEnvironment is BuildEnvironment.LegacyTeamBuild && !BuildSettings.SkipLegacyCodeCoverageProcessing)
         {
+            logger.LogInfo(Resources.MSG_TFSLegacyProcessorCalled);
             logger.IncludeTimestamp = false;
             tfsProcessor.Execute(config, ["ConvertCoverage", sonarAnalysisConfigFilePath, propertiesFilePath], propertiesFilePath);
             logger.IncludeTimestamp = true;

--- a/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
@@ -233,12 +233,8 @@ public class PostProcessor : IPostProcessor
         }
         else if (settings.BuildEnvironment == BuildEnvironment.LegacyTeamBuild && !BuildSettings.SkipLegacyCodeCoverageProcessing)
         {
-            IList<string> args = new List<string>();
-            args.Add("ConvertCoverage");
-            args.Add(sonarAnalysisConfigFilePath);
-            args.Add(propertiesFilePath);
             logger.IncludeTimestamp = false;
-            tfsProcessor.Execute(config, args, propertiesFilePath);
+            tfsProcessor.Execute(config, ["ConvertCoverage", sonarAnalysisConfigFilePath, propertiesFilePath], propertiesFilePath);
             logger.IncludeTimestamp = true;
         }
     }
@@ -247,8 +243,7 @@ public class PostProcessor : IPostProcessor
     {
         if (coverageReportProcessor.Initialize(config, buildSettings, fullPropertiesFilePath))
         {
-            var success = coverageReportProcessor.ProcessCoverageReports(logger);
-            if (success)
+            if (coverageReportProcessor.ProcessCoverageReports(logger))
             {
                 logger.LogInfo("Coverage report conversion completed successfully.");
             }

--- a/src/SonarScanner.MSBuild.PostProcessor/Properties/AssemblyInfo.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/Properties/AssemblyInfo.cs
@@ -18,7 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("SonarScanner.MSBuild.PostProcessor")]
 [assembly: AssemblyProduct("SonarScanner.MSBuild.PostProcessor")]
+[assembly: InternalsVisibleTo("SonarScanner.MSBuild.PostProcessor.Test")]

--- a/src/SonarScanner.MSBuild.PostProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/Resources.Designer.cs
@@ -129,11 +129,29 @@ namespace SonarScanner.MSBuild.PostProcessor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Converting coverage reports..
+        /// </summary>
+        internal static string MSG_ConvertingCoverageReports {
+            get {
+                return ResourceManager.GetString("MSG_ConvertingCoverageReports", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Loading the SonarQube analysis config from {0}.
         /// </summary>
         internal static string MSG_LoadingConfig {
             get {
                 return ResourceManager.GetString("MSG_LoadingConfig", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Calling legacy TFS processor..
+        /// </summary>
+        internal static string MSG_TFSLegacyProcessorCalled {
+            get {
+                return ResourceManager.GetString("MSG_TFSLegacyProcessorCalled", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.PostProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PostProcessor/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -189,5 +189,11 @@ Config file: {5}</value>
   </data>
   <data name="WARN_CannotProcessCoverage" xml:space="preserve">
     <value>Cannot process the code coverage information. Look at the previous warnings for details.</value>
+  </data>
+  <data name="MSG_ConvertingCoverageReports" xml:space="preserve">
+    <value>Converting coverage reports.</value>
+  </data>
+  <data name="MSG_TFSLegacyProcessorCalled" xml:space="preserve">
+    <value>Calling legacy TFS processor.</value>
   </data>
 </root>

--- a/src/SonarScanner.MSBuild.PostProcessor/SonarScanner.MSBuild.PostProcessor.csproj
+++ b/src/SonarScanner.MSBuild.PostProcessor/SonarScanner.MSBuild.PostProcessor.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\SonarScanner.MSBuild.Common\SonarScanner.MSBuild.Common.csproj" />
     <ProjectReference Include="..\SonarScanner.MSBuild.Shim\SonarScanner.MSBuild.Shim.csproj" />
+    <ProjectReference Include="..\SonarScanner.MSBuild.TFS\SonarScanner.MSBuild.TFS.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">

--- a/src/SonarScanner.MSBuild.TFS.Classic/Program.cs
+++ b/src/SonarScanner.MSBuild.TFS.Classic/Program.cs
@@ -18,9 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using SonarScanner.MSBuild.Common;
-using SonarScanner.MSBuild.Common.Interfaces;
 using SonarScanner.MSBuild.TFS.Classic.XamlBuild;
 
 namespace SonarScanner.MSBuild.TFS.Classic;
@@ -91,8 +88,7 @@ public static class Program
 
     private static void ExecuteCoverageConverter(ILogger logger, AnalysisConfig config, ILegacyTeamBuildFactory teamBuildFactory, IBuildSettings buildSettings, string fullPropertiesFilePath)
     {
-        var binaryConverter = new BinaryToXmlCoverageReportConverter(logger);
-        var coverageReportProcessor = new CoverageReportProcessor(teamBuildFactory, binaryConverter, logger);
+        var coverageReportProcessor = new CoverageReportProcessor(teamBuildFactory);
 
         if (coverageReportProcessor.Initialize(config, buildSettings, fullPropertiesFilePath))
         {

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -52,7 +52,7 @@ public class BuildVNextCoverageReportProcessor : ICoverageReportProcessor
         return successfullyInitialized;
     }
 
-    public bool ProcessCoverageReports(ILogger logger)
+    public virtual bool ProcessCoverageReports(ILogger logger)
     {
         if (!successfullyInitialized)
         {

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -22,7 +22,7 @@ using System.Security.Cryptography;
 
 namespace SonarScanner.MSBuild.TFS;
 
-public class BuildVNextCoverageReportProcessor : ICoverageReportProcessor
+public class BuildVNextCoverageReportProcessor
 {
     internal const string AgentTempDirectory = "AGENT_TEMPDIRECTORY";
     private const string XmlReportFileExtension = "coveragexml";
@@ -30,10 +30,6 @@ public class BuildVNextCoverageReportProcessor : ICoverageReportProcessor
     private readonly ILogger logger;
     private readonly IFileWrapper fileWrapper;
     private readonly IDirectoryWrapper directoryWrapper;
-    private AnalysisConfig config;
-    private IBuildSettings settings;
-    private string propertiesFilePath;
-    private bool successfullyInitialized;
 
     public BuildVNextCoverageReportProcessor(ICoverageReportConverter converter, ILogger logger, IFileWrapper fileWrapper = null, IDirectoryWrapper directoryWrapper = null)
     {
@@ -43,22 +39,8 @@ public class BuildVNextCoverageReportProcessor : ICoverageReportProcessor
         this.directoryWrapper = directoryWrapper ?? DirectoryWrapper.Instance;
     }
 
-    public virtual bool Initialize(AnalysisConfig config, IBuildSettings settings, string propertiesFilePath)
+    public virtual void ProcessCoverageReports(AnalysisConfig config, IBuildSettings settings, string propertiesFilePath, ILogger logger)
     {
-        this.config = config ?? throw new ArgumentNullException(nameof(config));
-        this.settings = settings ?? throw new ArgumentNullException(nameof(settings));
-        this.propertiesFilePath = propertiesFilePath ?? throw new ArgumentNullException(nameof(propertiesFilePath));
-        successfullyInitialized = true;
-        return successfullyInitialized;
-    }
-
-    public virtual bool ProcessCoverageReports(ILogger logger)
-    {
-        if (!successfullyInitialized)
-        {
-            throw new InvalidOperationException(Resources.EX_CoverageReportProcessorNotInitialized);
-        }
-
         this.logger.LogInfo(Resources.PROC_DIAG_FetchingCoverageReportInfoFromServer);
         var trxFilePaths = new TrxFileReader(logger, fileWrapper, directoryWrapper).FindTrxFiles(settings.BuildDirectory);
 
@@ -84,8 +66,6 @@ public class BuildVNextCoverageReportProcessor : ICoverageReportProcessor
         {
             WriteProperty(propertiesFilePath, SonarProperties.VsCoverageXmlReportsPaths, coverageReportPaths.ToArray());
         }
-
-        return true;
     }
 
     internal IEnumerable<string> FindFallbackCoverageFiles()

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -43,7 +43,7 @@ public class BuildVNextCoverageReportProcessor : ICoverageReportProcessor
         this.directoryWrapper = directoryWrapper ?? DirectoryWrapper.Instance;
     }
 
-    public bool Initialize(AnalysisConfig config, IBuildSettings settings, string propertiesFilePath)
+    public virtual bool Initialize(AnalysisConfig config, IBuildSettings settings, string propertiesFilePath)
     {
         this.config = config ?? throw new ArgumentNullException(nameof(config));
         this.settings = settings ?? throw new ArgumentNullException(nameof(settings));

--- a/src/SonarScanner.MSBuild.TFS/CoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/CoverageReportProcessor.cs
@@ -24,33 +24,26 @@ namespace SonarScanner.MSBuild.TFS;
 
 public class CoverageReportProcessor : ICoverageReportProcessor
 {
+    private readonly ILegacyTeamBuildFactory legacyTeamBuildFactory;
     private ICoverageReportProcessor processor;
     private bool initializedSuccessfully;
 
-    private readonly ILegacyTeamBuildFactory legacyTeamBuildFactory;
-    private readonly ICoverageReportConverter coverageReportConverter;
-    private readonly ILogger logger;
-
-    public CoverageReportProcessor(ILegacyTeamBuildFactory legacyTeamBuildFactory,
-        ICoverageReportConverter coverageReportConverter, ILogger logger)
+    public CoverageReportProcessor(ILegacyTeamBuildFactory legacyTeamBuildFactory)
     {
         this.legacyTeamBuildFactory
             = legacyTeamBuildFactory ?? throw new ArgumentNullException(nameof(legacyTeamBuildFactory));
-        this.coverageReportConverter
-            = coverageReportConverter ?? throw new ArgumentNullException(nameof(coverageReportConverter));
-        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public bool Initialize(AnalysisConfig config, IBuildSettings settings, string propertiesFilePath)
     {
-        if (settings == null)
+        if (settings is null)
         {
             throw new ArgumentNullException(nameof(settings));
         }
 
         TryCreateCoverageReportProcessor(settings);
 
-        initializedSuccessfully = (processor != null && processor.Initialize(config, settings, propertiesFilePath));
+        initializedSuccessfully = processor is not null && processor.Initialize(config, settings, propertiesFilePath);
         return initializedSuccessfully;
     }
 

--- a/src/SonarScanner.MSBuild.TFS/CoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/CoverageReportProcessor.cs
@@ -18,10 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Diagnostics;
-using SonarScanner.MSBuild.Common;
-using SonarScanner.MSBuild.Common.Interfaces;
 using SonarScanner.MSBuild.Common.TFS;
 
 namespace SonarScanner.MSBuild.TFS;
@@ -71,11 +67,7 @@ public class CoverageReportProcessor : ICoverageReportProcessor
     /// </summary>
     private void TryCreateCoverageReportProcessor(IBuildSettings settings)
     {
-        if (settings.BuildEnvironment == BuildEnvironment.TeamBuild)
-        {
-            processor = new BuildVNextCoverageReportProcessor(coverageReportConverter, logger);
-        }
-        else if (settings.BuildEnvironment == BuildEnvironment.LegacyTeamBuild && !BuildSettings.SkipLegacyCodeCoverageProcessing)
+        if (settings.BuildEnvironment == BuildEnvironment.LegacyTeamBuild && !BuildSettings.SkipLegacyCodeCoverageProcessing)
         {
             processor = legacyTeamBuildFactory.BuildTfsLegacyCoverageReportProcessor();
         }

--- a/src/SonarScanner.MSBuild.TFS/CoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/CoverageReportProcessor.cs
@@ -36,10 +36,7 @@ public class CoverageReportProcessor : ICoverageReportProcessor
 
     public bool Initialize(AnalysisConfig config, IBuildSettings settings, string propertiesFilePath)
     {
-        if (settings is null)
-        {
-            throw new ArgumentNullException(nameof(settings));
-        }
+        _ = settings ?? throw new ArgumentNullException(nameof(settings));
 
         TryCreateCoverageReportProcessor(settings);
 

--- a/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
+++ b/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
@@ -18,17 +18,24 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.PostProcessor;
 using SonarScanner.MSBuild.PostProcessor.Interfaces;
 using SonarScanner.MSBuild.PreProcessor;
 using SonarScanner.MSBuild.Shim;
+using SonarScanner.MSBuild.TFS;
 
 namespace SonarScanner.MSBuild;
 
-public class DefaultProcessorFactory(ILogger logger) : IProcessorFactory
+public class DefaultProcessorFactory : IProcessorFactory
 {
-    private readonly IOperatingSystemProvider operatingSystemProvider = new OperatingSystemProvider(FileWrapper.Instance, logger);
+    private readonly ILogger logger;
+    private readonly IOperatingSystemProvider operatingSystemProvider;
+
+    public DefaultProcessorFactory(ILogger logger)
+    {
+        this.logger = logger;
+        operatingSystemProvider = new OperatingSystemProvider(FileWrapper.Instance, logger);
+    }
 
     public IPostProcessor CreatePostProcessor() =>
         new PostProcessor.PostProcessor(
@@ -36,7 +43,8 @@ public class DefaultProcessorFactory(ILogger logger) : IProcessorFactory
             logger,
             new TargetsUninstaller(logger),
             new TfsProcessorWrapper(logger, operatingSystemProvider),
-            new SonarProjectPropertiesValidator());
+            new SonarProjectPropertiesValidator(),
+            new BuildVNextCoverageReportProcessor(new BinaryToXmlCoverageReportConverter(logger), logger));
 
     public IPreProcessor CreatePreProcessor() =>
         new PreProcessor.PreProcessor(new PreprocessorObjectFactory(logger), logger);


### PR DESCRIPTION
[SCAN4NET-705](https://sonarsource.atlassian.net/browse/SCAN4NET-705)
Can be reviewed per commit, if needed.



[SCAN4NET-705]: https://sonarsource.atlassian.net/browse/SCAN4NET-705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ