### PR TITLE
SCAN4NET-706 Append info about coverage files and trx files in GenerateAndValidatePropertiesFile

### DIFF
--- a/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
@@ -63,7 +63,7 @@ public class PostProcessorTests
         sonarProjectPropertiesValidator = Substitute.For<SonarProjectPropertiesValidator>();
         coverageReportProcessor = Substitute
             .For<BuildVNextCoverageReportProcessor>(Substitute.For<ICoverageReportConverter>(), logger, Substitute.For<IFileWrapper>(), Substitute.For<IDirectoryWrapper>());
-        coverageReportProcessor.ProcessCoverageReports(null, null, null, null).ReturnsForAnyArgs(new AdditionalProperties([@"VS\Test\Path"], [@"VS\XML\Coverage\Path"]));
+        coverageReportProcessor.ProcessCoverageReports(null, null, null).ReturnsForAnyArgs(new AdditionalProperties([@"VS\Test\Path"], [@"VS\XML\Coverage\Path"]));
         fileWrapper = Substitute.For<IFileWrapper>();
         sut = new PostProcessor(
             scanner,
@@ -316,7 +316,7 @@ public class PostProcessorTests
         Execute().Should().BeTrue();
         AssertTfsProcessorConvertCoverageCalledIfNetFramework(false);
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework(false);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null, null);
+        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null);
     }
 
     [TestMethod]
@@ -347,7 +347,7 @@ public class PostProcessorTests
         Execute().Should().BeTrue();
         AssertTfsProcessorConvertCoverageCalledIfNetFramework();
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework();
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null, null);
+        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null);
     }
 
     [TestMethod]
@@ -359,7 +359,7 @@ public class PostProcessorTests
         Execute().Should().BeFalse();
         AssertTfsProcessorConvertCoverageCalledIfNetFramework(false);
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework(false);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null, null);
+        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null);
         logger.AssertErrorLogged("""
             Inconsistent build environment settings: the build Uri in the analysis config file does not match the build uri from the environment variable.
             Build Uri from environment: http://test-build-uri
@@ -379,7 +379,7 @@ public class PostProcessorTests
         Execute().Should().BeTrue();
         AssertTfsProcessorConvertCoverageCalledIfNetFramework(false);
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework();
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null, null);
+        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null);
     }
 
     private bool Execute(string arg) =>
@@ -413,9 +413,9 @@ public class PostProcessorTests
 
     private void AssertProcessCoverageReportsCalledIfNetFramework() =>
 #if NETFRAMEWORK
-        coverageReportProcessor.ReceivedWithAnyArgs().ProcessCoverageReports(null, null, null, null);
+        coverageReportProcessor.ReceivedWithAnyArgs().ProcessCoverageReports(null, null, null);
 #else
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null, null);
+        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null);
 #endif
 
     private void AssertTfsProcessorConvertCoverageCalledIfNetFramework(bool shouldBeCalled = true) =>

--- a/Tests/SonarScanner.MSBuild.TFS.Test/BuildVNextCoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/BuildVNextCoverageReportProcessorTests.cs
@@ -19,6 +19,7 @@
  */
 
 using SonarScanner.MSBuild.TFS.Tests.Infrastructure;
+using static SonarScanner.MSBuild.TFS.BuildVNextCoverageReportProcessor;
 
 namespace SonarScanner.MSBuild.TFS.Test;
 
@@ -88,11 +89,11 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         AssertUsesFallback(false);
         testLogger.Warnings.Should().ContainSingle().Which.StartsWith("None of the following coverage attachments could be found: dummy.coverage");
-        AssertPropertiesFileContainsTestReportsPaths();
-        AssertPropertiesFileContainsCoverageXmlReportsPaths(false);
+        AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
+        AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
     }
 
     [TestMethod]
@@ -127,11 +128,11 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(Properties.TestAndCoverageXmlReportsPathsNull, trx: true, coverage: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         testLogger.AssertWarningsLogged(0);
-        AssertPropertiesFileContainsTestReportsPaths();
-        AssertPropertiesFileContainsCoverageXmlReportsPaths();
+        AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
+        AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties);
     }
 
     [TestMethod]
@@ -139,11 +140,11 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(Properties.TestReportsPathsNotNull, trx: true, coverage: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         testLogger.AssertWarningsLogged(0);
-        AssertPropertiesFileContainsCoverageXmlReportsPaths();
-        AssertPropertiesFileContainsTestReportsPaths(false);
+        AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties);
+        AssertPropertiesFileContainsTestReportsPaths(additionalProperties, false);
     }
 
     [TestMethod]
@@ -151,11 +152,11 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(Properties.CoverageXmlReportsPathsNotNull, trx: true, coverage: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         testLogger.AssertWarningsLogged(0);
-        AssertPropertiesFileContainsTestReportsPaths();
-        AssertPropertiesFileContainsCoverageXmlReportsPaths(false);
+        AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
+        AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
     }
 
     [TestMethod]
@@ -191,10 +192,10 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, coverage: true, coverageXml: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertConvertNotCalled();
         testLogger.AssertWarningsLogged(0);
-        AssertPropertiesFileContainsCoverageXmlReportsPaths();
+        AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties);
     }
 
     [TestMethod]
@@ -204,10 +205,10 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, coverage: true, coverageXml: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertConvertNotCalled();
         testLogger.AssertWarningsLogged(0);
-        AssertPropertiesFileContainsCoverageXmlReportsPaths(false);
+        AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
     }
 
     [TestMethod]
@@ -220,10 +221,10 @@ public class BuildVNextCoverageReportProcessorTests
         SetupPropertiesAndFiles(properties, trx: true, coverage: true);
         converter.ShouldFailConversion = true;
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         testLogger.AssertWarningsLogged(0);
-        AssertPropertiesFileContainsCoverageXmlReportsPaths(false);
+        AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
     }
 
     [TestMethod]
@@ -233,11 +234,11 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, alternate: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback();
-        AssertPropertiesFileContainsAlternateCoverageXmlReportsPaths();
-        AssertPropertiesFileContainsTestReportsPaths(false);
+        AssertPropertiesFileContainsAlternateCoverageXmlReportsPaths(additionalProperties);
+        AssertPropertiesFileContainsTestReportsPaths(additionalProperties, false);
     }
 
     [TestMethod]
@@ -260,11 +261,11 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, alternate: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(0);
         AssertUsesFallback(false);
-        AssertPropertiesFileContainsTestReportsPaths();
-        AssertPropertiesFileContainsCoverageXmlReportsPaths(false);
+        AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
+        AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
     }
 
     [TestMethod]
@@ -274,10 +275,10 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, alternate: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback();
-        AssertPropertiesFileContainsTestReportsPaths(false);
+        AssertPropertiesFileContainsTestReportsPaths(additionalProperties, false);
     }
 
     [TestMethod]
@@ -287,10 +288,10 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, coverage: true, alternate: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback(false);
-        AssertPropertiesFileContainsCoverageXmlReportsPaths();
+        AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties);
     }
 
     [TestMethod]
@@ -301,10 +302,10 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, true, coverage: true, alternate: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback(false);
-        AssertPropertiesFileContainsCoverageXmlReportsPaths(false);
+        AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
     }
 
     [TestMethod]
@@ -314,11 +315,11 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, alternate: true, alternateXml: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
         converter.AssertConvertNotCalled();
         AssertUsesFallback();
-        AssertPropertiesFileContainsAlternateCoverageXmlReportsPaths();
-        AssertPropertiesFileContainsTestReportsPaths(false);
+        AssertPropertiesFileContainsAlternateCoverageXmlReportsPaths(additionalProperties);
+        AssertPropertiesFileContainsTestReportsPaths(additionalProperties, false);
     }
 
     [TestMethod]
@@ -513,42 +514,32 @@ public class BuildVNextCoverageReportProcessorTests
         }
     }
 
-    private void AssertPropertiesFileContainsTestReportsPaths(bool contains = true)
+    private static void AssertPropertiesFileContainsTestReportsPaths(AdditionalProperties additionalProperties, bool contains = true)
     {
         if (contains)
         {
-            fileWrapper.Received().AppendAllText(
-                propertiesFilePath,
-                Arg.Is<string>(x => x.Contains("sonar.cs.vstest.reportsPaths") && x.Contains(PathCombineWithEscape("TestResults", "dummy.trx"))));
+            additionalProperties.VsTestReportsPaths.Should().ContainSingle(x => x.EndsWith(Path.Combine("TestResults", "dummy.trx")));
         }
         else
         {
-            fileWrapper.DidNotReceive().AppendAllText(
-                propertiesFilePath,
-                Arg.Is<string>(x => x.Contains(SonarProperties.VsTestReportsPaths)));
+            additionalProperties.VsTestReportsPaths.Should().BeNull();
         }
     }
 
-    private void AssertPropertiesFileContainsCoverageXmlReportsPaths(bool contains = true)
+    private static void AssertPropertiesFileContainsCoverageXmlReportsPaths(AdditionalProperties additionalProperties, bool contains = true)
     {
         if (contains)
         {
-            fileWrapper.Received().AppendAllText(
-                propertiesFilePath,
-                Arg.Is<string>(x => x.Contains("sonar.cs.vscoveragexml.reportsPaths") && x.Contains(PathCombineWithEscape("TestResults", "dummy", "In", "dummy.coveragexml"))));
+            additionalProperties.VsCoverageXmlReportsPaths.Should().ContainSingle(x => x.EndsWith(Path.Combine("TestResults", "dummy", "In", "dummy.coveragexml")));
         }
         else
         {
-            fileWrapper.DidNotReceive().AppendAllText(
-                propertiesFilePath,
-                Arg.Is<string>(x => x.Contains(SonarProperties.VsCoverageXmlReportsPaths)));
+            additionalProperties.VsCoverageXmlReportsPaths.Should().BeNull();
         }
     }
 
-    private void AssertPropertiesFileContainsAlternateCoverageXmlReportsPaths() =>
-            fileWrapper.Received().AppendAllText(
-                propertiesFilePath,
-                Arg.Is<string>(x => x.Contains("sonar.cs.vscoveragexml.reportsPaths") && x.Contains(PathCombineWithEscape("TestResults", "alternate", "In", "alternate.coveragexml"))));
+    private static void AssertPropertiesFileContainsAlternateCoverageXmlReportsPaths(AdditionalProperties additionalProperties) =>
+        additionalProperties.VsCoverageXmlReportsPaths.Should().ContainSingle(x => x.EndsWith(Path.Combine("TestResults", "alternate", "In", "alternate.coveragexml")));
 
     private void AssertUsesFallback(bool isTrue = true)
     {
@@ -564,21 +555,10 @@ public class BuildVNextCoverageReportProcessorTests
         }
     }
 
-    private static string PathCombineWithEscape(params string[] parts)
-    {
-        var separator = Path.DirectorySeparatorChar.ToString();
-        if (separator == @"\")
-        {
-            separator = @"\\";
-        }
-        return string.Join(separator, parts);
-    }
-
-    private string CreateFile(string path, string fileName, string fileContent = "")
+    private void CreateFile(string path, string fileName, string fileContent = "")
     {
         var filePath = Path.Combine(path, fileName);
         fileWrapper.Exists(filePath).Returns(true);
         fileWrapper.Open(filePath).Returns(new MemoryStream(Encoding.UTF8.GetBytes(fileContent)));
-        return filePath;
     }
 }

--- a/Tests/SonarScanner.MSBuild.TFS.Test/BuildVNextCoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/BuildVNextCoverageReportProcessorTests.cs
@@ -44,7 +44,6 @@ public class BuildVNextCoverageReportProcessorTests
     private readonly string testResultsDir;
     private readonly string coverageDir;
     private readonly string alternateCoverageDir;
-    private readonly string propertiesFilePath;
     private readonly EnvironmentVariableScope environmentVariableScope = new();
 
     private BuildVNextCoverageReportProcessor sut;
@@ -58,7 +57,6 @@ public class BuildVNextCoverageReportProcessorTests
         coverageDir = Path.Combine(testResultsDir, "dummy", "In");
         alternateCoverageDir = Path.Combine(testResultsDir, "alternate", "In");
         directoryWrapper.Exists(alternateCoverageDir).Returns(true);
-        propertiesFilePath = testDir + Path.DirectorySeparatorChar + "sonar-project.properties";
         buildSettings.BuildDirectory = testDir;
         sut = new BuildVNextCoverageReportProcessor(converter, testLogger, fileWrapper, directoryWrapper);
         environmentVariableScope.SetVariable(BuildVNextCoverageReportProcessor.AgentTempDirectory, alternateCoverageDir);  // setup search fallback
@@ -89,7 +87,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         AssertUsesFallback(false);
         testLogger.Warnings.Should().ContainSingle().Which.StartsWith("None of the following coverage attachments could be found: dummy.coverage");
         AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
@@ -103,7 +101,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         testLogger.Warnings.Should().ContainSingle().Which.StartsWith("None of the following coverage attachments could be found: dummy.coverage");
         fileWrapper.DidNotReceiveWithAnyArgs().AppendAllText(null, null);
     }
@@ -117,7 +115,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         AssertUsesFallback();
         testLogger.AssertWarningsLogged(0);
         fileWrapper.DidNotReceiveWithAnyArgs().AppendAllText(null, null);
@@ -128,7 +126,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(Properties.TestAndCoverageXmlReportsPathsNull, trx: true, coverage: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         testLogger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
@@ -140,7 +138,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(Properties.TestReportsPathsNotNull, trx: true, coverage: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         testLogger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties);
@@ -152,7 +150,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(Properties.CoverageXmlReportsPathsNotNull, trx: true, coverage: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         testLogger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
@@ -164,7 +162,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(Properties.TestAndCoverageXmlReportsPathsNotNull, trx: true, coverage: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         testLogger.AssertWarningsLogged(0);
         fileWrapper.DidNotReceiveWithAnyArgs().AppendAllText(null, null);
@@ -179,7 +177,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, coverage: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertExpectedNumberOfConversions(0);
         testLogger.AssertWarningsLogged(0);
         fileWrapper.DidNotReceiveWithAnyArgs().AppendAllText(null, null);
@@ -192,7 +190,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, coverage: true, coverageXml: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertConvertNotCalled();
         testLogger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties);
@@ -205,7 +203,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, coverage: true, coverageXml: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertConvertNotCalled();
         testLogger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
@@ -221,7 +219,7 @@ public class BuildVNextCoverageReportProcessorTests
         SetupPropertiesAndFiles(properties, trx: true, coverage: true);
         converter.ShouldFailConversion = true;
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         testLogger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
@@ -234,7 +232,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, alternate: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback();
         AssertPropertiesFileContainsAlternateCoverageXmlReportsPaths(additionalProperties);
@@ -248,7 +246,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, alternate: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         AssertUsesFallback();
         converter.AssertExpectedNumberOfConversions(1);
         fileWrapper.DidNotReceiveWithAnyArgs().AppendAllText(null, null);
@@ -261,7 +259,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, alternate: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertExpectedNumberOfConversions(0);
         AssertUsesFallback(false);
         AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
@@ -275,7 +273,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, alternate: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback();
         AssertPropertiesFileContainsTestReportsPaths(additionalProperties, false);
@@ -288,7 +286,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, coverage: true, alternate: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback(false);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties);
@@ -302,7 +300,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, true, coverage: true, alternate: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback(false);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
@@ -315,7 +313,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, alternate: true, alternateXml: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertConvertNotCalled();
         AssertUsesFallback();
         AssertPropertiesFileContainsAlternateCoverageXmlReportsPaths(additionalProperties);
@@ -330,7 +328,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, alternate: true, alternateXml: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, propertiesFilePath, testLogger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings, testLogger);
         converter.AssertConvertNotCalled();
         AssertUsesFallback();
         fileWrapper.DidNotReceiveWithAnyArgs().AppendAllText(null, null);
@@ -439,8 +437,8 @@ public class BuildVNextCoverageReportProcessorTests
     [DataRow(new byte[] { 1, 2 }, new byte[] { 2, 1 })]
     [DataRow(new byte[] { }, new byte[] { 1 })]
     public void FileWithContentHash_Equals_DifferentHash_False(byte[] hash1, byte[] hash2) =>
-        new BuildVNextCoverageReportProcessor.FileWithContentHash("c:\\path.txt", hash1)
-            .Equals(new BuildVNextCoverageReportProcessor.FileWithContentHash("c:\\path.txt", hash2))
+        new FileWithContentHash("c:\\path.txt", hash1)
+            .Equals(new FileWithContentHash("c:\\path.txt", hash2))
             .Should().BeFalse();
 
     [TestMethod]
@@ -452,8 +450,8 @@ public class BuildVNextCoverageReportProcessorTests
     [DataRow("", "File.txt")]
     [DataRow(null, "File.txt")]
     public void FileWithContentHash_Equals_SameHash_True(string fileName1, string fileName2) =>
-        new BuildVNextCoverageReportProcessor.FileWithContentHash(fileName1, [1, 2])
-            .Equals(new BuildVNextCoverageReportProcessor.FileWithContentHash(fileName2, [1, 2]))
+        new FileWithContentHash(fileName1, [1, 2])
+            .Equals(new FileWithContentHash(fileName2, [1, 2]))
             .Should().BeTrue();
 
     [TestMethod]
@@ -461,7 +459,7 @@ public class BuildVNextCoverageReportProcessorTests
     [DataRow(42)]
     [DataRow(null)]
     public void FileWithContentHash_Equals_Other_False(object other) =>
-        new BuildVNextCoverageReportProcessor.FileWithContentHash("c:\\path.txt", [1, 2])
+        new FileWithContentHash("c:\\path.txt", [1, 2])
             .Equals(other)
             .Should().BeFalse();
 

--- a/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
@@ -227,7 +227,7 @@ public class PostProcessor : IPostProcessor
         if (settings.BuildEnvironment is BuildEnvironment.TeamBuild)
         {
             logger.LogInfo(Resources.MSG_ConvertingCoverageReports);
-            var additionalProperties = coverageReportProcessor.ProcessCoverageReports(config, settings, propertiesFilePath, logger);
+            var additionalProperties = coverageReportProcessor.ProcessCoverageReports(config, settings, logger);
             WriteProperty(propertiesFilePath, SonarProperties.VsTestReportsPaths, additionalProperties.VsTestReportsPaths);
             WriteProperty(propertiesFilePath, SonarProperties.VsCoverageXmlReportsPaths, additionalProperties.VsCoverageXmlReportsPaths);
         }
@@ -240,8 +240,6 @@ public class PostProcessor : IPostProcessor
         }
     }
 
-#endif
-
     private void WriteProperty(string propertiesFilePath, string property, string[] paths)
     {
         if (paths is not null)
@@ -249,6 +247,8 @@ public class PostProcessor : IPostProcessor
             fileWrapper.AppendAllText(propertiesFilePath, $"{Environment.NewLine}{property}={string.Join(",", paths.Select(x => x.Replace(@"\", @"\\")))}");
         }
     }
+
+#endif
 
     private bool InvokeSonarScanner(IAnalysisPropertyProvider cmdLineArgs, AnalysisConfig config, string propertiesFilePath)
     {

--- a/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
@@ -34,6 +34,7 @@ public class PostProcessor : IPostProcessor
     private readonly SonarProjectPropertiesValidator sonarProjectPropertiesValidator;
     private readonly TfsProcessorWrapper tfsProcessor;
     private readonly BuildVNextCoverageReportProcessor coverageReportProcessor;
+    private readonly IFileWrapper fileWrapper;
 
     private PropertiesFileGenerator propertiesFileGenerator;
 
@@ -43,7 +44,8 @@ public class PostProcessor : IPostProcessor
         TargetsUninstaller targetUninstaller,
         TfsProcessorWrapper tfsProcessor,
         SonarProjectPropertiesValidator sonarProjectPropertiesValidator,
-        BuildVNextCoverageReportProcessor coverageReportProcessor)
+        BuildVNextCoverageReportProcessor coverageReportProcessor,
+        IFileWrapper fileWrapper = null)
     {
         this.sonarScanner = sonarScanner ?? throw new ArgumentNullException(nameof(sonarScanner));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -51,6 +53,7 @@ public class PostProcessor : IPostProcessor
         this.tfsProcessor = tfsProcessor ?? throw new ArgumentNullException(nameof(tfsProcessor));
         this.sonarProjectPropertiesValidator = sonarProjectPropertiesValidator ?? throw new ArgumentNullException(nameof(sonarProjectPropertiesValidator));
         this.coverageReportProcessor = coverageReportProcessor ?? throw new ArgumentNullException(nameof(coverageReportProcessor));
+        this.fileWrapper = fileWrapper ?? FileWrapper.Instance;
     }
 
     public void /* for testing purposes */ SetPropertiesFileGenerator(PropertiesFileGenerator propertiesFileGenerator) =>
@@ -224,7 +227,9 @@ public class PostProcessor : IPostProcessor
         if (settings.BuildEnvironment is BuildEnvironment.TeamBuild)
         {
             logger.LogInfo(Resources.MSG_ConvertingCoverageReports);
-            coverageReportProcessor.ProcessCoverageReports(config, settings, propertiesFilePath, logger);
+            var additionalProperties = coverageReportProcessor.ProcessCoverageReports(config, settings, propertiesFilePath, logger);
+            WriteProperty(propertiesFilePath, SonarProperties.VsTestReportsPaths, additionalProperties.VsTestReportsPaths);
+            WriteProperty(propertiesFilePath, SonarProperties.VsCoverageXmlReportsPaths, additionalProperties.VsCoverageXmlReportsPaths);
         }
         else if (settings.BuildEnvironment is BuildEnvironment.LegacyTeamBuild && !BuildSettings.SkipLegacyCodeCoverageProcessing)
         {
@@ -236,6 +241,14 @@ public class PostProcessor : IPostProcessor
     }
 
 #endif
+
+    private void WriteProperty(string propertiesFilePath, string property, string[] paths)
+    {
+        if (paths is not null)
+        {
+            fileWrapper.AppendAllText(propertiesFilePath, $"{Environment.NewLine}{property}={string.Join(",", paths.Select(x => x.Replace(@"\", @"\\")))}");
+        }
+    }
 
     private bool InvokeSonarScanner(IAnalysisPropertyProvider cmdLineArgs, AnalysisConfig config, string propertiesFilePath)
     {

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -51,7 +51,6 @@ public class BuildVNextCoverageReportProcessor
         {
             if (trxFilePaths.Any())
             {
-                WriteProperty(propertiesFilePath, SonarProperties.VsTestReportsPaths, trxFilePaths.ToArray());
                 vsTestReportsPaths = trxFilePaths.ToArray();
                 reportsPathsPropertyWritten = true;
             }
@@ -67,7 +66,6 @@ public class BuildVNextCoverageReportProcessor
             && coverageReportPaths.Any()
             && config.GetSettingOrDefault(SonarProperties.VsCoverageXmlReportsPaths, true, null, logger) is null)
         {
-            WriteProperty(propertiesFilePath, SonarProperties.VsCoverageXmlReportsPaths, coverageReportPaths.ToArray());
             vsCoverageXmlReportsPaths = coverageReportPaths.ToArray();
         }
         return new(vsTestReportsPaths, vsCoverageXmlReportsPaths);

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -39,7 +39,7 @@ public class BuildVNextCoverageReportProcessor
         this.directoryWrapper = directoryWrapper ?? DirectoryWrapper.Instance;
     }
 
-    public virtual AdditionalProperties ProcessCoverageReports(AnalysisConfig config, IBuildSettings settings, string propertiesFilePath, ILogger logger)
+    public virtual AdditionalProperties ProcessCoverageReports(AnalysisConfig config, IBuildSettings settings, ILogger logger)
     {
         this.logger.LogInfo(Resources.PROC_DIAG_FetchingCoverageReportInfoFromServer);
         string[] vsTestReportsPaths = null;
@@ -177,9 +177,6 @@ public class BuildVNextCoverageReportProcessor
         vsCoverageXmlPaths = xmlFileNames;
         return true;
     }
-
-    private void WriteProperty(string propertiesFilePath, string property, string[] paths) =>
-        fileWrapper.AppendAllText(propertiesFilePath, $"{Environment.NewLine}{property}={string.Join(",", paths.Select(x => x.Replace(@"\", @"\\")))}");
 
     internal class FileWithContentHash
     {

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -46,13 +46,11 @@ public class BuildVNextCoverageReportProcessor
         string[] vsCoverageXmlReportsPaths = null;
         var trxFilePaths = new TrxFileReader(logger, fileWrapper, directoryWrapper).FindTrxFiles(settings.BuildDirectory);
 
-        var reportsPathsPropertyWritten = false;
         if (config.GetSettingOrDefault(SonarProperties.VsTestReportsPaths, true, null, logger) is null)
         {
             if (trxFilePaths.Any())
             {
                 vsTestReportsPaths = trxFilePaths.ToArray();
-                reportsPathsPropertyWritten = true;
             }
         }
         else
@@ -60,7 +58,7 @@ public class BuildVNextCoverageReportProcessor
             this.logger.LogInfo(Resources.TRX_DIAG_SkippingCoverageCheckPropertyProvided);
         }
 
-        var vsCoverageFilePaths = FindVsCoverageFiles(reportsPathsPropertyWritten, trxFilePaths);
+        var vsCoverageFilePaths = FindVsCoverageFiles(trxFilePaths, disableFallback: vsTestReportsPaths is not null);
         if (vsCoverageFilePaths.Any()
             && TryConvertCoverageReports(vsCoverageFilePaths, out var coverageReportPaths)
             && coverageReportPaths.Any()
@@ -137,10 +135,10 @@ public class BuildVNextCoverageReportProcessor
         }
     }
 
-    private IEnumerable<string> FindVsCoverageFiles(bool reportsPathsPropertyWritten, IEnumerable<string> trxFilePaths)
+    private IEnumerable<string> FindVsCoverageFiles(IEnumerable<string> trxFilePaths, bool disableFallback)
     {
         var binaryFilePaths = new TrxFileReader(logger, fileWrapper, directoryWrapper).FindCodeCoverageFiles(trxFilePaths);
-        if (binaryFilePaths.Any() || reportsPathsPropertyWritten)
+        if (binaryFilePaths.Any() || disableFallback)
         {
             logger.LogDebug(Resources.TRX_DIAG_NotUsingFallback);
             return binaryFilePaths;


### PR DESCRIPTION
[SCAN4NET-706](https://sonarsource.atlassian.net/browse/SCAN4NET-706)



[SCAN4NET-706]: https://sonarsource.atlassian.net/browse/SCAN4NET-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ