### PR TITLE
SCAN4NET-709 Append the coverage file information to the PropertiesJson

### DIFF
--- a/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
@@ -338,8 +338,9 @@ public class PostProcessorTests
         fileWrapper.Received().AppendAllText(
             Arg.Any<string>(),
             Arg.Is<string>(x => x.Contains("sonar.cs.vscoveragexml.reportsPaths") && x.Contains(PathCombineWithEscape("VS", "XML", "Coverage", "Path"))));
-        new ScannerEngineInputReader(scannerEngineInput.ToString()).AssertProperty("sonar.cs.vstest.reportsPaths", Path.Combine("VS", "Test", "Path"));
-        new ScannerEngineInputReader(scannerEngineInput.ToString()).AssertProperty("sonar.cs.vscoveragexml.reportsPaths", Path.Combine("VS", "XML", "Coverage", "Path"));
+        var reader = new ScannerEngineInputReader(scannerEngineInput.ToString());
+        reader.AssertProperty("sonar.cs.vstest.reportsPaths", Path.Combine("VS", "Test", "Path"));
+        reader.AssertProperty("sonar.cs.vscoveragexml.reportsPaths", Path.Combine("VS", "XML", "Coverage", "Path"));
 #endif
     }
 

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
@@ -391,9 +391,6 @@ public class PostProcessorTests
         var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(testContext);
         var projectInfo = TestUtils.CreateProjectWithFiles(testContext, "withFiles1", testDir);
         var propertiesFileGenerator = Substitute.For<PropertiesFileGenerator>(config, logger);
-        propertiesFileGenerator
-            .TryWriteProperties(Arg.Any<PropertiesWriter>(), Arg.Any<ScannerEngineInput>(), out _)
-            .Returns(true);
 
         var projectInfoAnalysisResult = new ProjectInfoAnalysisResult(
             [new(ProjectInfo.Load(projectInfo))],

--- a/Tests/SonarScanner.MSBuild.Shim.Test/ScannerEngineInputTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/ScannerEngineInputTest.cs
@@ -19,7 +19,6 @@
  */
 
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace SonarScanner.MSBuild.Shim.Test;
 
@@ -264,6 +263,48 @@ public class ScannerEngineInputTest
                 },
                 {
                   "key": "5762C17D-1DDF-4C77-86AC-E2B4940926A9.{{expectedPropertyKey}}",
+                  "value": {{JsonConvert.ToString(Path.Combine(TestUtils.DriveRoot(), "dir1", "first") + "," + Path.Combine(TestUtils.DriveRoot(), "dir1", "second"))}}
+                }
+              ]
+            }
+            """);
+    }
+
+    [TestMethod]
+    public void WriteVsTestReportPaths_WritesEncodedPaths()
+    {
+        var sut = new ScannerEngineInput(new AnalysisConfig());
+        sut.WriteVsTestReportPaths([Path.Combine(TestUtils.DriveRoot(), "dir1", "first"), Path.Combine(TestUtils.DriveRoot(), "dir1", "second")]);
+        sut.ToString().Should().BeIgnoringLineEndings($$"""
+            {
+              "scannerProperties": [
+                {
+                  "key": "sonar.modules",
+                  "value": ""
+                },
+                {
+                  "key": "sonar.cs.vstest.reportsPaths",
+                  "value": {{JsonConvert.ToString(Path.Combine(TestUtils.DriveRoot(), "dir1", "first") + "," + Path.Combine(TestUtils.DriveRoot(), "dir1", "second"))}}
+                }
+              ]
+            }
+            """);
+    }
+
+    [TestMethod]
+    public void WriteVsXmlCoverageReportPaths_WritesEncodedPaths()
+    {
+        var sut = new ScannerEngineInput(new AnalysisConfig());
+        sut.WriteVsXmlCoverageReportPaths([Path.Combine(TestUtils.DriveRoot(), "dir1", "first"), Path.Combine(TestUtils.DriveRoot(), "dir1", "second")]);
+        sut.ToString().Should().BeIgnoringLineEndings($$"""
+            {
+              "scannerProperties": [
+                {
+                  "key": "sonar.modules",
+                  "value": ""
+                },
+                {
+                  "key": "sonar.cs.vscoveragexml.reportsPaths",
                   "value": {{JsonConvert.ToString(Path.Combine(TestUtils.DriveRoot(), "dir1", "first") + "," + Path.Combine(TestUtils.DriveRoot(), "dir1", "second"))}}
                 }
               ]

--- a/src/SonarScanner.MSBuild.Shim/ScannerEngineInput.cs
+++ b/src/SonarScanner.MSBuild.Shim/ScannerEngineInput.cs
@@ -168,6 +168,12 @@ public class ScannerEngineInput
         AppendKeyValue(project.Guid, property, project.RoslynReportFilePaths);
     }
 
+    public void WriteVsTestReportPaths(string[] paths) =>
+        AppendKeyValue(SonarProperties.VsTestReportsPaths, paths);
+
+    public void WriteVsXmlCoverageReportPaths(string[] paths) =>
+        AppendKeyValue(SonarProperties.VsCoverageXmlReportsPaths, paths);
+
     /// <summary>
     /// Write the supplied global settings into the file.
     /// </summary>
@@ -213,6 +219,9 @@ public class ScannerEngineInput
 
     internal void AppendKeyValue(string keyPrefix, string keySuffix, IEnumerable<string> values) =>
         AppendKeyValue($"{keyPrefix}.{keySuffix}", ToMultiValueProperty(values));
+
+    internal void AppendKeyValue(string key, IEnumerable<string> values) =>
+        AppendKeyValue(key, ToMultiValueProperty(values));
 
     private void AppendKeyValue(string keyPrefix, string keySuffix, IEnumerable<FileInfo> paths) =>
         AppendKeyValue(keyPrefix, keySuffix, paths.Select(x => x.FullName));

--- a/src/SonarScanner.MSBuild.Shim/ScannerEngineInput.cs
+++ b/src/SonarScanner.MSBuild.Shim/ScannerEngineInput.cs
@@ -220,14 +220,14 @@ public class ScannerEngineInput
     internal void AppendKeyValue(string keyPrefix, string keySuffix, IEnumerable<string> values) =>
         AppendKeyValue($"{keyPrefix}.{keySuffix}", ToMultiValueProperty(values));
 
-    internal void AppendKeyValue(string key, IEnumerable<string> values) =>
-        AppendKeyValue(key, ToMultiValueProperty(values));
-
     private void AppendKeyValue(string keyPrefix, string keySuffix, IEnumerable<FileInfo> paths) =>
         AppendKeyValue(keyPrefix, keySuffix, paths.Select(x => x.FullName));
 
     private void AppendKeyValue(string keyPrefix, string keySuffix, string value) =>
         AppendKeyValue(keyPrefix + "." + keySuffix, value);
+
+    private void AppendKeyValue(string key, IEnumerable<string> values) =>
+        AppendKeyValue(key, ToMultiValueProperty(values));
 
     private JProperty AppendKeyValue(string key, string value)
     {

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -39,9 +39,8 @@ public class BuildVNextCoverageReportProcessor
         this.directoryWrapper = directoryWrapper ?? DirectoryWrapper.Instance;
     }
 
-    // The logic in this method is flawed:
-    // https://sonarsource.atlassian.net/browse/SCAN4NET-786
-    // https://sonarsource.atlassian.net/browse/SCAN4NET-787
+    // ToDo: SCAN4NET-786 Test report discovery is flawed
+    // ToDo: SCAN4NET-787 Coverage fallback should be in AzDo Extension
     public virtual AdditionalProperties ProcessCoverageReports(AnalysisConfig config, IBuildSettings settings, ILogger logger)
     {
         this.logger.LogInfo(Resources.PROC_DIAG_FetchingCoverageReportInfoFromServer);

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -39,6 +39,9 @@ public class BuildVNextCoverageReportProcessor
         this.directoryWrapper = directoryWrapper ?? DirectoryWrapper.Instance;
     }
 
+    // The logic in this method is flawed:
+    // https://sonarsource.atlassian.net/browse/SCAN4NET-786
+    // https://sonarsource.atlassian.net/browse/SCAN4NET-787
     public virtual AdditionalProperties ProcessCoverageReports(AnalysisConfig config, IBuildSettings settings, ILogger logger)
     {
         this.logger.LogInfo(Resources.PROC_DIAG_FetchingCoverageReportInfoFromServer);


### PR DESCRIPTION
[SCAN4NET-709](https://sonarsource.atlassian.net/browse/SCAN4NET-709)



[SCAN4NET-709]: https://sonarsource.atlassian.net/browse/SCAN4NET-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ