### PR TITLE
SCAN4NET-802 Untangle ScannerEngineInput and ScannerEngineInputGenerator

### DIFF
--- a/Tests/SonarScanner.MSBuild.Shim.Test/ScannerEngineInputGeneratorTest.TryWriteProperties.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/ScannerEngineInputGeneratorTest.TryWriteProperties.cs
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Newtonsoft.Json;
+
 namespace SonarScanner.MSBuild.Shim.Test;
 
 public partial class ScannerEngineInputGeneratorTest
@@ -25,7 +27,7 @@ public partial class ScannerEngineInputGeneratorTest
     [TestMethod]
     public void TryWriteProperties_WhenThereIsNoCommonPath_LogsError()
     {
-        var outPath = Path.Combine(TestContext.TestRunDirectory!, ".sonarqube", "out");
+        var outPath = Path.Combine(TestContext.TestRunDirectory, ".sonarqube", "out");
         Directory.CreateDirectory(outPath);
         var fileToAnalyzePath = TestUtils.CreateEmptyFile(TestContext.TestRunDirectory, "file.cs");
         var filesToAnalyzePath = TestUtils.CreateFile(TestContext.TestRunDirectory, TestUtils.FilesToAnalyze, fileToAnalyzePath);
@@ -133,6 +135,163 @@ public partial class ScannerEngineInputGeneratorTest
         new ScannerEngineInputReader(engineInput.ToString()).AssertProperty("sonar.host.url", "http://localhost:9000");
     }
 
+    [TestMethod]
+    public void WriteAnalyzerOutputPaths_ForUnexpectedLanguage_DoNotWritesOutPaths()
+    {
+        var input = new ScannerEngineInput(new());
+        ScannerEngineInputGenerator.WriteAnalyzerOutputPaths(input, CreateProjectDataWithPaths("unexpected", analyzerOutPaths: [@"c:\dir1\dir2"]));
+
+        input.ToString().Should().BeIgnoringLineEndings("""
+            {
+              "scannerProperties": [
+                {
+                  "key": "sonar.modules",
+                  "value": ""
+                }
+              ]
+            }
+            """);
+    }
+
+    [TestMethod]
+    [DataRow(ProjectLanguages.CSharp, "sonar.cs.analyzer.projectOutPaths")]
+    [DataRow(ProjectLanguages.VisualBasic, "sonar.vbnet.analyzer.projectOutPaths")]
+    public void WriteAnalyzerOutputPaths_WritesEncodedPaths(string language, string expectedPropertyKey)
+    {
+        var input = new ScannerEngineInput(new());
+        ScannerEngineInputGenerator.WriteAnalyzerOutputPaths(input, CreateProjectDataWithPaths(
+            language,
+            analyzerOutPaths: [Path.Combine(TestUtils.DriveRoot(), "dir1", "first"), Path.Combine(TestUtils.DriveRoot(), "dir1", "second")]));
+
+        input.ToString().Should().BeIgnoringLineEndings($$"""
+            {
+              "scannerProperties": [
+                {
+                  "key": "sonar.modules",
+                  "value": ""
+                },
+                {
+                  "key": "5762C17D-1DDF-4C77-86AC-E2B4940926A9.{{expectedPropertyKey}}",
+                  "value": {{JsonConvert.ToString(Path.Combine(TestUtils.DriveRoot(), "dir1", "first") + "," + Path.Combine(TestUtils.DriveRoot(), "dir1", "second"))}}
+                }
+              ]
+            }
+            """);
+    }
+
+    [TestMethod]
+    public void WriteRoslynReportPaths_ForUnexpectedLanguage_DoNotWritesOutPaths()
+    {
+        var input = new ScannerEngineInput(new());
+        ScannerEngineInputGenerator.WriteRoslynReportPaths(input, CreateProjectDataWithPaths("unexpected"));
+
+        input.ToString().Should().BeIgnoringLineEndings("""
+            {
+              "scannerProperties": [
+                {
+                  "key": "sonar.modules",
+                  "value": ""
+                }
+              ]
+            }
+            """);
+    }
+
+    [TestMethod]
+    [DataRow(ProjectLanguages.CSharp, "sonar.cs.roslyn.reportFilePaths")]
+    [DataRow(ProjectLanguages.VisualBasic, "sonar.vbnet.roslyn.reportFilePaths")]
+    public void WriteRoslynReportPaths_WritesEncodedPaths(string language, string expectedPropertyKey)
+    {
+        var input = new ScannerEngineInput(new());
+        ScannerEngineInputGenerator.WriteRoslynReportPaths(input, CreateProjectDataWithPaths(language, roslynOutPaths: [
+            Path.Combine(TestUtils.DriveRoot(), "dir1", "first"),
+            Path.Combine(TestUtils.DriveRoot(), "dir1", "second")]));
+
+        input.ToString().Should().BeIgnoringLineEndings($$"""
+            {
+              "scannerProperties": [
+                {
+                  "key": "sonar.modules",
+                  "value": ""
+                },
+                {
+                  "key": "5762C17D-1DDF-4C77-86AC-E2B4940926A9.{{expectedPropertyKey}}",
+                  "value": {{JsonConvert.ToString(Path.Combine(TestUtils.DriveRoot(), "dir1", "first") + "," + Path.Combine(TestUtils.DriveRoot(), "dir1", "second"))}}
+                }
+              ]
+            }
+            """);
+    }
+
+    [TestMethod]
+    public void Telemetry_ForUnexpectedLanguage_DoNotWritePaths()
+    {
+        var input = new ScannerEngineInput(new());
+        ScannerEngineInputGenerator.WriteTelemetryPaths(input, CreateProjectDataWithPaths("unexpected", telemetryPaths: [@"c:\dir1\dir2\Telemetry.json"]));
+
+        input.ToString().Should().BeIgnoringLineEndings("""
+            {
+              "scannerProperties": [
+                {
+                  "key": "sonar.modules",
+                  "value": ""
+                }
+              ]
+            }
+            """);
+    }
+
+    [TestMethod]
+    [DataRow(ProjectLanguages.CSharp, "sonar.cs.scanner.telemetry")]
+    [DataRow(ProjectLanguages.VisualBasic, "sonar.vbnet.scanner.telemetry")]
+    public void Telemetry_WritesEncodedPaths(string language, string expectedPropertyKey)
+    {
+        var input = new ScannerEngineInput(new());
+        ScannerEngineInputGenerator.WriteTelemetryPaths(input, CreateProjectDataWithPaths(language, telemetryPaths: [
+            Path.Combine(TestUtils.DriveRoot(), "dir1", "first", "Telemetry.json"),
+            Path.Combine(TestUtils.DriveRoot(), "dir1", "second", "Telemetry.json")]));
+
+        input.ToString().Should().BeIgnoringLineEndings($$"""
+            {
+              "scannerProperties": [
+                {
+                  "key": "sonar.modules",
+                  "value": ""
+                },
+                {
+                  "key": "5762C17D-1DDF-4C77-86AC-E2B4940926A9.{{expectedPropertyKey}}",
+                  "value": {{JsonConvert.ToString(Path.Combine(TestUtils.DriveRoot(), "dir1", "first", "Telemetry.json") + "," + Path.Combine(TestUtils.DriveRoot(), "dir1", "second", "Telemetry.json"))}}
+                }
+              ]
+            }
+            """);
+    }
+
+    [TestMethod]
+    public void TryWriteProperties_ProjectAnalysisSettings_Propagated()
+    {
+        var config = new AnalysisConfig { SonarOutputDir = TestContext.TestRunDirectory };
+        var input = new ScannerEngineInput(config);
+        var project = CreateProjectDataWithPaths(ProjectLanguages.CSharp);
+        project.Status = ProjectInfoValidity.Valid;
+        project.Project.FullPath = TestUtils.CreateEmptyFile(TestContext.TestRunDirectory, "Project.proj");
+        project.Project.AnalysisSettings =
+        [
+            new("my.setting1", "setting1"),
+            new("my.setting2", "setting 2 with spaces"),
+            new("my.setting.3", @"c:\dir1\dir2\foo.txt")
+        ];
+        project.ReferencedFiles.Add(new(TestUtils.CreateEmptyFile(TestContext.TestRunDirectory, "File.cs")));
+        var sut = new ScannerEngineInputGenerator(config, logger);
+        sut.TryWriteProperties(config.ToAnalysisProperties(logger), [project], new PropertiesWriter(config), input);
+
+        logger.AssertNoErrorsLogged();
+        var reader = new ScannerEngineInputReader(input.ToString());
+        reader.AssertProperty("5762C17D-1DDF-4C77-86AC-E2B4940926A9.my.setting1", "setting1");
+        reader.AssertProperty("5762C17D-1DDF-4C77-86AC-E2B4940926A9.my.setting2", "setting 2 with spaces");
+        reader.AssertProperty("5762C17D-1DDF-4C77-86AC-E2B4940926A9.my.setting.3", @"c:\dir1\dir2\foo.txt");
+    }
+
     private void TryWriteProperties_HostUrl_Execute(AnalysisConfig config, PropertiesWriter legacyWriter, ScannerEngineInput engineInput)
     {
         Directory.CreateDirectory(config.SonarOutputDir);
@@ -155,5 +314,26 @@ public partial class ScannerEngineInputGeneratorTest
             legacyWriter,
             engineInput)
             .Should().BeTrue();
+    }
+
+    private static ProjectData CreateProjectDataWithPaths(string language, string[] analyzerOutPaths = null, string[] roslynOutPaths = null, string[] telemetryPaths = null)
+    {
+        analyzerOutPaths ??= [];
+        roslynOutPaths ??= [];
+        telemetryPaths ??= [];
+        var projectData = new[] { new ProjectInfo { ProjectGuid = new("5762C17D-1DDF-4C77-86AC-E2B4940926A9"), ProjectLanguage = language } }.ToProjectData(true, Substitute.For<ILogger>()).Single();
+        foreach (var path in analyzerOutPaths)
+        {
+            projectData.AnalyzerOutPaths.Add(new FileInfo(path));
+        }
+        foreach (var path in roslynOutPaths)
+        {
+            projectData.RoslynReportFilePaths.Add(new FileInfo(path));
+        }
+        foreach (var path in telemetryPaths)
+        {
+            projectData.TelemetryPaths.Add(new FileInfo(path));
+        }
+        return projectData;
     }
 }

--- a/Tests/SonarScanner.MSBuild.Shim.Test/ScannerEngineInputTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/ScannerEngineInputTest.cs
@@ -176,91 +176,6 @@ public class ScannerEngineInputTest
     }
 
     [TestMethod]
-    public void WriteAnalyzerOutputPaths_ForUnexpectedLanguage_DoNotWritesOutPaths()
-    {
-        var sut = new ScannerEngineInput(new AnalysisConfig());
-        sut.WriteAnalyzerOutputPaths(CreateTestProjectDataWithPaths("unexpected", analyzerOutPaths: [@"c:\dir1\dir2"]));
-
-        sut.ToString().Should().BeIgnoringLineEndings("""
-            {
-              "scannerProperties": [
-                {
-                  "key": "sonar.modules",
-                  "value": ""
-                }
-              ]
-            }
-            """);
-    }
-
-    [TestMethod]
-    [DataRow(ProjectLanguages.CSharp, "sonar.cs.analyzer.projectOutPaths")]
-    [DataRow(ProjectLanguages.VisualBasic, "sonar.vbnet.analyzer.projectOutPaths")]
-    public void WriteAnalyzerOutputPaths_WritesEncodedPaths(string language, string expectedPropertyKey)
-    {
-        var sut = new ScannerEngineInput(new AnalysisConfig());
-        sut.WriteAnalyzerOutputPaths(CreateTestProjectDataWithPaths(
-            language,
-            analyzerOutPaths: [Path.Combine(TestUtils.DriveRoot(), "dir1", "first"), Path.Combine(TestUtils.DriveRoot(), "dir1", "second")]));
-        sut.ToString().Should().BeIgnoringLineEndings($$"""
-            {
-              "scannerProperties": [
-                {
-                  "key": "sonar.modules",
-                  "value": ""
-                },
-                {
-                  "key": "5762C17D-1DDF-4C77-86AC-E2B4940926A9.{{expectedPropertyKey}}",
-                  "value": {{JsonConvert.ToString(Path.Combine(TestUtils.DriveRoot(), "dir1", "first") + "," + Path.Combine(TestUtils.DriveRoot(), "dir1", "second"))}}
-                }
-              ]
-            }
-            """);
-    }
-
-    [TestMethod]
-    public void WriteRoslynReportPaths_ForUnexpectedLanguage_DoNotWritesOutPaths()
-    {
-        var sut = new ScannerEngineInput(new AnalysisConfig());
-        sut.WriteRoslynReportPaths(CreateTestProjectDataWithPaths("unexpected"));
-        sut.ToString().Should().BeIgnoringLineEndings("""
-            {
-              "scannerProperties": [
-                {
-                  "key": "sonar.modules",
-                  "value": ""
-                }
-              ]
-            }
-            """);
-    }
-
-    [TestMethod]
-    [DataRow(ProjectLanguages.CSharp, "sonar.cs.roslyn.reportFilePaths")]
-    [DataRow(ProjectLanguages.VisualBasic, "sonar.vbnet.roslyn.reportFilePaths")]
-    public void WriteRoslynReportPaths_WritesEncodedPaths(string language, string expectedPropertyKey)
-    {
-        var sut = new ScannerEngineInput(new AnalysisConfig());
-        sut.WriteRoslynReportPaths(CreateTestProjectDataWithPaths(language, roslynOutPaths: [
-            Path.Combine(TestUtils.DriveRoot(), "dir1", "first"),
-            Path.Combine(TestUtils.DriveRoot(), "dir1", "second")]));
-        sut.ToString().Should().BeIgnoringLineEndings($$"""
-            {
-              "scannerProperties": [
-                {
-                  "key": "sonar.modules",
-                  "value": ""
-                },
-                {
-                  "key": "5762C17D-1DDF-4C77-86AC-E2B4940926A9.{{expectedPropertyKey}}",
-                  "value": {{JsonConvert.ToString(Path.Combine(TestUtils.DriveRoot(), "dir1", "first") + "," + Path.Combine(TestUtils.DriveRoot(), "dir1", "second"))}}
-                }
-              ]
-            }
-            """);
-    }
-
-    [TestMethod]
     public void WriteVsTestReportPaths_WritesEncodedPaths()
     {
         var sut = new ScannerEngineInput(new AnalysisConfig());
@@ -296,48 +211,6 @@ public class ScannerEngineInputTest
                 {
                   "key": "sonar.cs.vscoveragexml.reportsPaths",
                   "value": {{JsonConvert.ToString(Path.Combine(TestUtils.DriveRoot(), "dir1", "first") + "," + Path.Combine(TestUtils.DriveRoot(), "dir1", "second"))}}
-                }
-              ]
-            }
-            """);
-    }
-
-    [TestMethod]
-    public void Telemetry_ForUnexpectedLanguage_DoNotWritePaths()
-    {
-        var sut = new ScannerEngineInput(new AnalysisConfig());
-        sut.WriteTelemetryPaths(CreateTestProjectDataWithPaths("unexpected", telemetryPaths: [@"c:\dir1\dir2\Telemetry.json"]));
-        sut.ToString().Should().BeIgnoringLineEndings("""
-            {
-              "scannerProperties": [
-                {
-                  "key": "sonar.modules",
-                  "value": ""
-                }
-              ]
-            }
-            """);
-    }
-
-    [TestMethod]
-    [DataRow(ProjectLanguages.CSharp, "sonar.cs.scanner.telemetry")]
-    [DataRow(ProjectLanguages.VisualBasic, "sonar.vbnet.scanner.telemetry")]
-    public void Telemetry_WritesEncodedPaths(string language, string expectedPropertyKey)
-    {
-        var sut = new ScannerEngineInput(new AnalysisConfig());
-        sut.WriteTelemetryPaths(CreateTestProjectDataWithPaths(language, telemetryPaths: [
-            Path.Combine(TestUtils.DriveRoot(), "dir1", "first", "Telemetry.json"),
-            Path.Combine(TestUtils.DriveRoot(), "dir1", "second", "Telemetry.json")]));
-        sut.ToString().Should().BeIgnoringLineEndings($$"""
-            {
-              "scannerProperties": [
-                {
-                  "key": "sonar.modules",
-                  "value": ""
-                },
-                {
-                  "key": "5762C17D-1DDF-4C77-86AC-E2B4940926A9.{{expectedPropertyKey}}",
-                  "value": {{JsonConvert.ToString(Path.Combine(TestUtils.DriveRoot(), "dir1", "first", "Telemetry.json") + "," + Path.Combine(TestUtils.DriveRoot(), "dir1", "second", "Telemetry.json"))}}
                 }
               ]
             }
@@ -559,33 +432,6 @@ public class ScannerEngineInputTest
             """);
     }
 
-    // Tests that analysis settings in the ProjectInfo are written to the file
-    [TestMethod]
-    public void AnalysisSettingsWritten()
-    {
-        var projectBaseDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext, "ScannerEngineInputBuilderTest_AnalysisSettingsWritten");
-        var productProject = CreateEmptyFile(projectBaseDir, "MyProduct.csproj");
-        var productFile = CreateEmptyFile(projectBaseDir, "File.cs");
-        var productFiles = new List<FileInfo> { productFile };
-        var productFileListFilePath = Path.Combine(projectBaseDir, "productManagedFiles.txt");
-        var product = CreateProjectData("AnalysisSettingsTest.proj", "7B3B7244-5031-4D74-9BBD-3316E6B5E7D5", productProject, false, productFiles, productFileListFilePath, null, "language");
-        // These are the settings we are going to check. The other analysis values are not checked.
-        product.Project.AnalysisSettings =
-        [
-            new("my.setting1", "setting1"),
-            new("my.setting2", "setting 2 with spaces"),
-            new("my.setting.3", @"c:\dir1\dir2\foo.txt")
-        ];
-        product.ReferencedFiles.Add(productFile);
-        var sut = new ScannerEngineInput(new AnalysisConfig { SonarOutputDir = @"C:\my_folder" });
-        sut.WriteSettingsForProject(product);
-
-        var reader = new ScannerEngineInputReader(sut.ToString());
-        reader.AssertProperty("7B3B7244-5031-4D74-9BBD-3316E6B5E7D5.my.setting1", "setting1");
-        reader.AssertProperty("7B3B7244-5031-4D74-9BBD-3316E6B5E7D5.my.setting2", "setting 2 with spaces");
-        reader.AssertProperty("7B3B7244-5031-4D74-9BBD-3316E6B5E7D5.my.setting.3", @"c:\dir1\dir2\foo.txt");
-    }
-
     // Tests that .sonar.working.directory is explicitly set per module
     [TestMethod]
     public void WorkdirPerModuleExplicitlySet()
@@ -705,26 +551,5 @@ public class ScannerEngineInputTest
         var fullPath = Path.Combine(parentDir, fileName);
         File.WriteAllText(fullPath, content);
         return fullPath;
-    }
-
-    private static ProjectData CreateTestProjectDataWithPaths(string language, string[] analyzerOutPaths = null, string[] roslynOutPaths = null, string[] telemetryPaths = null)
-    {
-        analyzerOutPaths ??= [];
-        roslynOutPaths ??= [];
-        telemetryPaths ??= [];
-        var projectData = CreateProjectData("Name", "5762C17D-1DDF-4C77-86AC-E2B4940926A9", new FileInfo("Name.proj"), false, [], null, null, language);
-        foreach (var path in analyzerOutPaths)
-        {
-            projectData.AnalyzerOutPaths.Add(new FileInfo(path));
-        }
-        foreach (var path in roslynOutPaths)
-        {
-            projectData.RoslynReportFilePaths.Add(new FileInfo(path));
-        }
-        foreach (var path in telemetryPaths)
-        {
-            projectData.TelemetryPaths.Add(new FileInfo(path));
-        }
-        return projectData;
     }
 }


### PR DESCRIPTION
[SCAN4NET-802](https://sonarsource.atlassian.net/browse/SCAN4NET-802)

In `ScannerEngineInput`, there's a ton of logic that depends on `ScannerEngineInputGenerator` that should be in `ScannerEngineInputGenerator`.

It's so duplicated, that it's not very visible on first sight. PR to deduplicate it will follow. This was meant to keep the code as much as-is as possible to make the review eas~~y~~ier

[SCAN4NET-802]: https://sonarsource.atlassian.net/browse/SCAN4NET-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ