### PR TITLE
SCAN4NET-811 Remove logger parameter from ProcessCoverageReports

### DIFF
--- a/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Test/PostProcessorTests.cs
@@ -63,7 +63,7 @@ public class PostProcessorTests
         sonarProjectPropertiesValidator = Substitute.For<SonarProjectPropertiesValidator>();
         coverageReportProcessor = Substitute
             .For<BuildVNextCoverageReportProcessor>(Substitute.For<ICoverageReportConverter>(), runtime);
-        coverageReportProcessor.ProcessCoverageReports(null, null, null).ReturnsForAnyArgs(new AdditionalProperties([@"VS\Test\Path"], [@"VS\XML\Coverage\Path"]));
+        coverageReportProcessor.ProcessCoverageReports(null, null).ReturnsForAnyArgs(new AdditionalProperties([@"VS\Test\Path"], [@"VS\XML\Coverage\Path"]));
         scannerEngineInput = new ScannerEngineInput(config);
         sut = new PostProcessor(
             scanner,
@@ -316,7 +316,7 @@ public class PostProcessorTests
         Execute().Should().BeTrue();
         AssertTfsProcessorConvertCoverageCalledIfNetFramework(false);
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework(false);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null);
+        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null);
     }
 
     [TestMethod]
@@ -350,7 +350,7 @@ public class PostProcessorTests
         Execute().Should().BeTrue();
         AssertTfsProcessorConvertCoverageCalledIfNetFramework();
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework();
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null);
+        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null);
     }
 
     [TestMethod]
@@ -362,7 +362,7 @@ public class PostProcessorTests
         Execute().Should().BeFalse();
         AssertTfsProcessorConvertCoverageCalledIfNetFramework(false);
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework(false);
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null);
+        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null);
         runtime.Logger.AssertErrorLogged("""
             Inconsistent build environment settings: the build Uri in the analysis config file does not match the build uri from the environment variable.
             Build Uri from environment: http://test-build-uri
@@ -382,7 +382,7 @@ public class PostProcessorTests
         Execute().Should().BeTrue();
         AssertTfsProcessorConvertCoverageCalledIfNetFramework(false);
         AssertTfsProcessorSummaryReportBuilderCalledIfNetFramework();
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null);
+        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null);
     }
 
     private bool Execute(string arg) =>
@@ -407,9 +407,9 @@ public class PostProcessorTests
 
     private void AssertProcessCoverageReportsCalledIfNetFramework() =>
 #if NETFRAMEWORK
-        coverageReportProcessor.ReceivedWithAnyArgs().ProcessCoverageReports(null, null, null);
+        coverageReportProcessor.ReceivedWithAnyArgs().ProcessCoverageReports(null, null);
 #else
-        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null, null);
+        coverageReportProcessor.DidNotReceiveWithAnyArgs().ProcessCoverageReports(null, null);
 #endif
 
     private void AssertTfsProcessorConvertCoverageCalledIfNetFramework(bool shouldBeCalled = true) =>

--- a/Tests/SonarScanner.MSBuild.TFS.Test/BuildVNextCoverageReportProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/BuildVNextCoverageReportProcessorTests.cs
@@ -85,7 +85,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         AssertUsesFallback(false);
         runtime.Logger.Warnings.Should().ContainSingle().Which.StartsWith("None of the following coverage attachments could be found: dummy.coverage");
         AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
@@ -99,7 +99,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings);
         runtime.Logger.Warnings.Should().ContainSingle().Which.StartsWith("None of the following coverage attachments could be found: dummy.coverage");
         runtime.File.DidNotReceiveWithAnyArgs().AppendAllText(null, null);
     }
@@ -113,7 +113,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings);
         AssertUsesFallback();
         runtime.Logger.AssertWarningsLogged(0);
         runtime.File.DidNotReceiveWithAnyArgs().AppendAllText(null, null);
@@ -124,7 +124,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(Properties.TestAndCoverageXmlReportsPathsNull, trx: true, coverage: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertExpectedNumberOfConversions(1);
         runtime.Logger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
@@ -136,7 +136,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(Properties.TestReportsPathsNotNull, trx: true, coverage: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertExpectedNumberOfConversions(1);
         runtime.Logger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties);
@@ -148,7 +148,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(Properties.CoverageXmlReportsPathsNotNull, trx: true, coverage: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertExpectedNumberOfConversions(1);
         runtime.Logger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
@@ -160,7 +160,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(Properties.TestAndCoverageXmlReportsPathsNotNull, trx: true, coverage: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertExpectedNumberOfConversions(1);
         runtime.Logger.AssertWarningsLogged(0);
         runtime.File.DidNotReceiveWithAnyArgs().AppendAllText(null, null);
@@ -175,7 +175,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, coverage: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertExpectedNumberOfConversions(0);
         runtime.Logger.AssertWarningsLogged(0);
         runtime.File.DidNotReceiveWithAnyArgs().AppendAllText(null, null);
@@ -188,7 +188,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, coverage: true, coverageXml: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertConvertNotCalled();
         runtime.Logger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties);
@@ -201,7 +201,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, coverage: true, coverageXml: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertConvertNotCalled();
         runtime.Logger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
@@ -217,7 +217,7 @@ public class BuildVNextCoverageReportProcessorTests
         SetupPropertiesAndFiles(properties, trx: true, coverage: true);
         converter.ShouldFailConversion = true;
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertExpectedNumberOfConversions(1);
         runtime.Logger.AssertWarningsLogged(0);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
@@ -230,7 +230,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, alternate: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback();
         AssertPropertiesFileContainsAlternateCoverageXmlReportsPaths(additionalProperties);
@@ -244,7 +244,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, alternate: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings);
         AssertUsesFallback();
         converter.AssertExpectedNumberOfConversions(1);
         runtime.File.DidNotReceiveWithAnyArgs().AppendAllText(null, null);
@@ -257,7 +257,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, alternate: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertExpectedNumberOfConversions(0);
         AssertUsesFallback(false);
         AssertPropertiesFileContainsTestReportsPaths(additionalProperties);
@@ -271,7 +271,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, alternate: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback();
         AssertPropertiesFileContainsTestReportsPaths(additionalProperties, false);
@@ -284,7 +284,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, trx: true, coverage: true, alternate: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback(false);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties);
@@ -298,7 +298,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, true, coverage: true, alternate: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertExpectedNumberOfConversions(1);
         AssertUsesFallback(false);
         AssertPropertiesFileContainsCoverageXmlReportsPaths(additionalProperties, false);
@@ -311,7 +311,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, alternate: true, alternateXml: true);
 
-        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        var additionalProperties = sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertConvertNotCalled();
         AssertUsesFallback();
         AssertPropertiesFileContainsAlternateCoverageXmlReportsPaths(additionalProperties);
@@ -326,7 +326,7 @@ public class BuildVNextCoverageReportProcessorTests
     {
         SetupPropertiesAndFiles(properties, alternate: true, alternateXml: true);
 
-        sut.ProcessCoverageReports(analysisConfig, buildSettings, runtime.Logger);
+        sut.ProcessCoverageReports(analysisConfig, buildSettings);
         converter.AssertConvertNotCalled();
         AssertUsesFallback();
         runtime.File.DidNotReceiveWithAnyArgs().AppendAllText(null, null);

--- a/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
@@ -227,7 +227,7 @@ public class PostProcessor : IPostProcessor
         if (settings.BuildEnvironment is BuildEnvironment.TeamBuild)
         {
             logger.LogInfo(Resources.MSG_ConvertingCoverageReports);
-            var additionalProperties = coverageReportProcessor.ProcessCoverageReports(config, settings, logger);
+            var additionalProperties = coverageReportProcessor.ProcessCoverageReports(config, settings);
             WriteProperty(projectInfoAnalysisResult.FullPropertiesFilePath, SonarProperties.VsTestReportsPaths, additionalProperties.VsTestReportsPaths);
             WriteProperty(projectInfoAnalysisResult.FullPropertiesFilePath, SonarProperties.VsCoverageXmlReportsPaths, additionalProperties.VsCoverageXmlReportsPaths);
             projectInfoAnalysisResult.ScannerEngineInput.WriteVsTestReportPaths(additionalProperties.VsTestReportsPaths);

--- a/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
+++ b/src/SonarScanner.MSBuild.TFS/BuildVNextCoverageReportProcessor.cs
@@ -36,14 +36,14 @@ public class BuildVNextCoverageReportProcessor
 
     // ToDo: SCAN4NET-786 Test report discovery is flawed
     // ToDo: SCAN4NET-787 Coverage fallback should be in AzDo Extension
-    public virtual AdditionalProperties ProcessCoverageReports(AnalysisConfig config, IBuildSettings settings, ILogger logger)
+    public virtual AdditionalProperties ProcessCoverageReports(AnalysisConfig config, IBuildSettings settings)
     {
         runtime.Logger.LogInfo(Resources.PROC_DIAG_FetchingCoverageReportInfoFromServer);
         string[] vsTestReportsPaths = null;
         string[] vsCoverageXmlReportsPaths = null;
-        var trxFilePaths = new TrxFileReader(logger, runtime.File, runtime.Directory).FindTrxFiles(settings.BuildDirectory);
+        var trxFilePaths = new TrxFileReader(runtime.Logger, runtime.File, runtime.Directory).FindTrxFiles(settings.BuildDirectory);
 
-        if (config.GetSettingOrDefault(SonarProperties.VsTestReportsPaths, true, null, logger) is null)
+        if (config.GetSettingOrDefault(SonarProperties.VsTestReportsPaths, true, null, runtime.Logger) is null)
         {
             if (trxFilePaths.Any())
             {
@@ -59,7 +59,7 @@ public class BuildVNextCoverageReportProcessor
         if (vsCoverageFilePaths.Any()
             && TryConvertCoverageReports(vsCoverageFilePaths, out var coverageReportPaths)
             && coverageReportPaths.Any()
-            && config.GetSettingOrDefault(SonarProperties.VsCoverageXmlReportsPaths, true, null, logger) is null)
+            && config.GetSettingOrDefault(SonarProperties.VsCoverageXmlReportsPaths, true, null, runtime.Logger) is null)
         {
             vsCoverageXmlReportsPaths = coverageReportPaths.ToArray();
         }


### PR DESCRIPTION
[SCAN4NET-811](https://sonarsource.atlassian.net/browse/SCAN4NET-811)

Part of SCAN4NET-789

[SCAN4NET-811]: https://sonarsource.atlassian.net/browse/SCAN4NET-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ