### PR TITLE
SCAN4NET-826 AnalysisResult usages cleanup: Remove noise

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfo/ProjectInfoExtensionsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfo/ProjectInfoExtensionsTests.cs
@@ -18,12 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.IO;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using TestUtilities;
-
 namespace SonarScanner.MSBuild.Common.Test;
 
 [TestClass]

--- a/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfo/ProjectInfoExtensionsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfo/ProjectInfoExtensionsTests.cs
@@ -28,110 +28,88 @@ public class ProjectInfoExtensionsTests
     [TestMethod]
     public void TryGetAnalysisSetting_WhenProjectInfoIsNull_ThrowsArgumentNullException()
     {
-        // Arrange
         Action action = () => ProjectInfoExtensions.TryGetAnalyzerResult(null, "foo", out var result);
 
-        // Assert
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("projectInfo");
     }
 
     [TestMethod]
     public void TryGetAnalyzerResult_WhenProjectInfoIsNull_ThrowsArgumentNullException()
     {
-        // Arrange
         Action action = () => ProjectInfoExtensions.TryGetAnalysisSetting(null, "foo", out var result);
 
-        // Assert
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("projectInfo");
     }
 
     [TestMethod]
     public void AddAnalyzerResult_WhenProjectInfoIsNull_ThrowsArgumentNullException()
     {
-        // Arrange
         Action action = () => ProjectInfoExtensions.AddAnalyzerResult(null, "foo", "bar");
 
-        // Assert
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("projectInfo");
     }
 
     [TestMethod]
     public void AddAnalyzerResult_WhenIdIsNull_ThrowsArgumentNullException()
     {
-        // Arrange
         Action action = () => ProjectInfoExtensions.AddAnalyzerResult(new ProjectInfo(), null, "bar");
 
-        // Assert
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("id");
     }
 
     [TestMethod]
     public void AddAnalyzerResult_WhenIdIsEmpty_ThrowsArgumentNullException()
     {
-        // Arrange
         Action action = () => ProjectInfoExtensions.AddAnalyzerResult(new ProjectInfo(), "", "bar");
 
-        // Assert
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("id");
     }
 
     [TestMethod]
     public void AddAnalyzerResult_WhenIdIsWhitespaces_ThrowsArgumentNullException()
     {
-        // Arrange
         Action action = () => ProjectInfoExtensions.AddAnalyzerResult(new ProjectInfo(), "   ", "bar");
 
-        // Assert
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("id");
     }
 
     [TestMethod]
     public void AddAnalyzerResult_WhenLocationIsNull_ThrowsArgumentNullException()
     {
-        // Arrange
         Action action = () => ProjectInfoExtensions.AddAnalyzerResult(new ProjectInfo(), "foo", null);
 
-        // Assert
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("location");
     }
 
     [TestMethod]
     public void AddAnalyzerResult_WhenLocationIsEmpty_ThrowsArgumentNullException()
     {
-        // Arrange
         Action action = () => ProjectInfoExtensions.AddAnalyzerResult(new ProjectInfo(), "foo", "");
 
-        // Assert
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("location");
     }
 
     [TestMethod]
     public void AddAnalyzerResult_WhenLocationIsWhitespaces_ThrowsArgumentNullException()
     {
-        // Arrange
         Action action = () => ProjectInfoExtensions.AddAnalyzerResult(new ProjectInfo(), "foo", "   ");
 
-        // Assert
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("location");
     }
 
     [TestMethod]
     public void GetDirectory_WhenProjectInfoIsNull_ThrowsArgumentNullException()
     {
-        // Arrange
         Action action = () => ProjectInfoExtensions.GetDirectory(null);
 
-        // Assert
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("projectInfo");
     }
 
     [TestMethod]
     public void GetProjectGuidAsString_WhenProjectInfoIsNull_ThrowsArgumentNullException()
     {
-        // Arrange
         Action action = () => ProjectInfoExtensions.GetProjectGuidAsString(null);
 
-        // Assert
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("projectInfo");
     }
 

--- a/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfo/ProjectInfoExtensionsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfo/ProjectInfoExtensionsTests.cs
@@ -60,7 +60,7 @@ public class ProjectInfoExtensionsTests
     [TestMethod]
     public void AddAnalyzerResult_WhenIdIsEmpty_ThrowsArgumentNullException()
     {
-        Action action = () => ProjectInfoExtensions.AddAnalyzerResult(new ProjectInfo(), "", "bar");
+        Action action = () => ProjectInfoExtensions.AddAnalyzerResult(new ProjectInfo(), string.Empty, "bar");
 
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("id");
     }
@@ -84,7 +84,7 @@ public class ProjectInfoExtensionsTests
     [TestMethod]
     public void AddAnalyzerResult_WhenLocationIsEmpty_ThrowsArgumentNullException()
     {
-        Action action = () => ProjectInfoExtensions.AddAnalyzerResult(new ProjectInfo(), "foo", "");
+        Action action = () => ProjectInfoExtensions.AddAnalyzerResult(new ProjectInfo(), "foo", string.Empty);
 
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("location");
     }

--- a/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfo/ProjectInfoExtensionsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfo/ProjectInfoExtensionsTests.cs
@@ -100,7 +100,7 @@ public class ProjectInfoExtensionsTests
     [TestMethod]
     public void GetDirectory_WhenProjectInfoIsNull_ThrowsArgumentNullException()
     {
-        Action action = () => ProjectInfoExtensions.GetDirectory(null);
+        Action action = () => ProjectInfoExtensions.ProjectFileDirectory(null);
 
         action.Should().ThrowExactly<ArgumentNullException>().And.ParamName.Should().Be("projectInfo");
     }

--- a/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfoTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfoTests.cs
@@ -18,13 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using TestUtilities;
-
 namespace SonarScanner.MSBuild.Common.Test;
 
 [TestClass]

--- a/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfoTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/ProjectInfoTests.cs
@@ -25,8 +25,6 @@ public class ProjectInfoTests
 {
     public TestContext TestContext { get; set; }
 
-    #region Tests
-
     [TestMethod]
     public void ProjectInfo_Serialization_InvalidFileName()
     {
@@ -102,10 +100,6 @@ public class ProjectInfoTests
         SaveAndReloadProjectInfo(originalProjectInfo, Path.Combine(testFolder, "ProjectInfo_AnalysisResults3.xml"));
     }
 
-    #endregion Tests
-
-    #region Helper methods
-
     private void SaveAndReloadProjectInfo(ProjectInfo original, string outputFileName)
     {
         File.Exists(outputFileName).Should().BeFalse("Test error: file should not exist at the start of the test. File: {0}", outputFileName);
@@ -118,6 +112,4 @@ public class ProjectInfoTests
 
         ProjectInfoAssertions.AssertExpectedValues(original, reloadedProjectInfo);
     }
-
-    #endregion Helper methods
 }

--- a/Tests/SonarScanner.MSBuild.Shim.Test/ProjectLoaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/ProjectLoaderTest.cs
@@ -28,7 +28,6 @@ public class ProjectLoaderTest
     [TestMethod]
     public void ProjectLoader()
     {
-        // Arrange
         var testSourcePath = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
 
         // Create sub-directories, some with project info XML files and some without
@@ -71,17 +70,11 @@ public class ProjectLoaderTest
         };
         validNonTestNoReportsProject.AddContentFile("SomeFile.cs", true);
         CreateFilesFromDescriptor(validNonTestNoReportsProject, "SomeList.txt", null);
-
-        // Act
         IEnumerable<ProjectInfo> projects = SonarScanner.MSBuild.Shim.ProjectLoader.LoadFrom(testSourcePath);
 
-        // Assert
         projects.Should().HaveCount(3);
-
         AssertProjectResultExists(validTestProject.ProjectName, projects);
-
         AssertProjectResultExists(validNonTestProject.ProjectName, projects);
-
         AssertProjectResultExists(validNonTestNoReportsProject.ProjectName, projects);
     }
 
@@ -89,10 +82,8 @@ public class ProjectLoaderTest
     [Description("Checks that the loader only looks in the top-level folder for project folders")]
     public void ProjectLoader_NonRecursive()
     {
-        // 0. Setup
         var rootTestDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
         var childDir = Path.Combine(rootTestDir, "Child1");
-
         // Create a valid project in the child directory
         var validNonTestProject = new ProjectDescriptor()
         {

--- a/Tests/SonarScanner.MSBuild.Shim.Test/ProjectLoaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/ProjectLoaderTest.cs
@@ -70,7 +70,7 @@ public class ProjectLoaderTest
         };
         validNonTestNoReportsProject.AddContentFile("SomeFile.cs", true);
         CreateFilesFromDescriptor(validNonTestNoReportsProject, "SomeList.txt", null);
-        IEnumerable<ProjectInfo> projects = SonarScanner.MSBuild.Shim.ProjectLoader.LoadFrom(testSourcePath);
+        var projects = Shim.ProjectLoader.LoadFrom(testSourcePath);
 
         projects.Should().HaveCount(3);
         AssertProjectResultExists(validTestProject.ProjectName, projects);
@@ -98,7 +98,7 @@ public class ProjectLoaderTest
         CreateFilesFromDescriptor(validNonTestProject, "CompileList.txt", null);
 
         // 1. Run against the root dir -> not expecting the project to be found
-        IEnumerable<ProjectInfo> projects = SonarScanner.MSBuild.Shim.ProjectLoader.LoadFrom(rootTestDir);
+        var projects = Shim.ProjectLoader.LoadFrom(rootTestDir);
         projects.Should().BeEmpty();
 
         // 2. Run against the child dir -> project should be found

--- a/Tests/SonarScanner.MSBuild.Shim.Test/ProjectLoaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/ProjectLoaderTest.cs
@@ -18,15 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarScanner.MSBuild.Common;
-using TestUtilities;
-
 namespace SonarScanner.MSBuild.Shim.Test;
 
 [TestClass]

--- a/Tests/SonarScanner.MSBuild.Shim.Test/ProjectLoaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/ProjectLoaderTest.cs
@@ -25,8 +25,6 @@ public class ProjectLoaderTest
 {
     public TestContext TestContext { get; set; }
 
-    #region Tests
-
     [TestMethod]
     public void ProjectLoader()
     {
@@ -117,10 +115,6 @@ public class ProjectLoaderTest
         projects.Should().ContainSingle();
     }
 
-    #endregion Tests
-
-    #region Helper methods
-
     /// <summary>
     /// Creates a folder containing a ProjectInfo.xml and compiled file list as
     /// specified in the supplied descriptor
@@ -160,15 +154,9 @@ public class ProjectLoaderTest
         projectInfo.Save(Path.Combine(descriptor.FullDirectoryPath, FileConstants.ProjectInfoFileName));
     }
 
-    #endregion Helper methods
-
-    #region Assertions
-
     private static void AssertProjectResultExists(string expectedProjectName, IEnumerable<ProjectInfo> actualProjects)
     {
         var actual = actualProjects.FirstOrDefault(p => expectedProjectName.Equals(p.ProjectName));
         actual.Should().NotBeNull("Failed to find project with the expected name: {0}", expectedProjectName);
     }
-
-    #endregion Assertions
 }

--- a/Tests/SonarScanner.MSBuild.Shim.Test/ProjectLoaderTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/ProjectLoaderTest.cs
@@ -106,10 +106,6 @@ public class ProjectLoaderTest
         projects.Should().ContainSingle();
     }
 
-    /// <summary>
-    /// Creates a folder containing a ProjectInfo.xml and compiled file list as
-    /// specified in the supplied descriptor
-    /// </summary>
     private static void CreateFilesFromDescriptor(ProjectDescriptor descriptor, string compileFiles, string visualStudioCodeCoverageReportFileName)
     {
         if (!Directory.Exists(descriptor.FullDirectoryPath))

--- a/Tests/TestUtilities/ProjectDescriptor.cs
+++ b/Tests/TestUtilities/ProjectDescriptor.cs
@@ -18,13 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using SonarScanner.MSBuild.Common;
-
 namespace TestUtilities;
 
 /// <summary>
@@ -38,7 +31,7 @@ public class ProjectDescriptor
     private const string ContentItemGroup = "Content";
 
     /// <summary>
-    /// Data class to describe a single file in a project
+    /// Data class to describe a single file in a project.
     /// </summary>
     public class FileInProject
     {

--- a/Tests/TestUtilities/ProjectDescriptor.cs
+++ b/Tests/TestUtilities/ProjectDescriptor.cs
@@ -21,10 +21,9 @@
 namespace TestUtilities;
 
 /// <summary>
-/// Describes the expected contents of a single project
+/// Describes the expected contents of a single project.
 /// </summary>
-/// <remarks>Used to dynamically create folders and files for tests,
-/// and to check actual results against</remarks>
+/// <remarks>Used to dynamically create folders and files for tests, and to check actual results against.</remarks>
 public class ProjectDescriptor
 {
     private const string CompilerInputItemGroup = "Compile";
@@ -52,19 +51,10 @@ public class ProjectDescriptor
 
     public List<AnalysisResult> AnalysisResults { get; private set; }
 
-    /// <summary>
-    /// The full path to the parent directory
-    /// </summary>
     public string ParentDirectoryPath { get; set; }
 
-    /// <summary>
-    /// The name of the folder in which the project exists
-    /// </summary>
     public string ProjectFolderName { get; set; }
 
-    /// <summary>
-    /// The name of the project file
-    /// </summary>
     public string ProjectFileName { get; set; }
 
     public string FullDirectoryPath
@@ -77,9 +67,6 @@ public class ProjectDescriptor
         get { return Path.Combine(FullDirectoryPath, ProjectFileName); }
     }
 
-    /// <summary>
-    /// The user-friendly name for the project
-    /// </summary>
     public string ProjectName
     {
         get
@@ -96,9 +83,6 @@ public class ProjectDescriptor
         }
     }
 
-    /// <summary>
-    /// List of files that should not be analyzed
-    /// </summary>
     public IEnumerable<string> FilesNotToAnalyse
     {
         get
@@ -151,24 +135,12 @@ public class ProjectDescriptor
         Files.Add(new FileInProject(ProjectDescriptor.CompilerInputItemGroup, filePath, shouldAnalyse));
     }
 
-    /// <summary>
-    /// Data class to describe a single file in a project.
-    /// </summary>
     public class FileInProject
     {
-        /// <summary>
-        /// The path to the file
-        /// </summary>
         public string FilePath { get; set; }
 
-        /// <summary>
-        /// The ItemGroup to which the file belongs
-        /// </summary>
         public string ItemGroup { get; set; }
 
-        /// <summary>
-        /// Whether the file should be include in analysis or not
-        /// </summary>
         public bool ShouldBeAnalysed { get; set; }
 
         public FileInProject(string itemGroup, string filePath, bool shouldAnalyse)

--- a/Tests/TestUtilities/ProjectDescriptor.cs
+++ b/Tests/TestUtilities/ProjectDescriptor.cs
@@ -30,44 +30,7 @@ public class ProjectDescriptor
     private const string CompilerInputItemGroup = "Compile";
     private const string ContentItemGroup = "Content";
 
-    /// <summary>
-    /// Data class to describe a single file in a project.
-    /// </summary>
-    public class FileInProject
-    {
-        public FileInProject(string itemGroup, string filePath, bool shouldAnalyse)
-        {
-            ItemGroup = itemGroup;
-            FilePath = filePath;
-            ShouldBeAnalysed = shouldAnalyse;
-        }
-
-        /// <summary>
-        /// The path to the file
-        /// </summary>
-        public string FilePath { get; set; }
-
-        /// <summary>
-        /// The ItemGroup to which the file belongs
-        /// </summary>
-        public string ItemGroup { get; set; }
-
-        /// <summary>
-        /// Whether the file should be include in analysis or not
-        /// </summary>
-        public bool ShouldBeAnalysed { get; set; }
-    }
-
     public IList<FileInProject> Files { get; set; }
-
-    public ProjectDescriptor()
-    {
-        AnalysisResults = new List<AnalysisResult>();
-        Files = new List<FileInProject>();
-
-        // set default encoding
-        Encoding = Encoding.UTF8;
-    }
 
     #region Public properties
 
@@ -156,6 +119,15 @@ public class ProjectDescriptor
 
     #endregion Public properties
 
+    public ProjectDescriptor()
+    {
+        AnalysisResults = new List<AnalysisResult>();
+        Files = new List<FileInProject>();
+
+        // set default encoding
+        Encoding = Encoding.UTF8;
+    }
+
     #region Public methods
 
     public ProjectInfo CreateProjectInfo()
@@ -186,4 +158,32 @@ public class ProjectDescriptor
     }
 
     #endregion Public methods
+
+    /// <summary>
+    /// Data class to describe a single file in a project.
+    /// </summary>
+    public class FileInProject
+    {
+        /// <summary>
+        /// The path to the file
+        /// </summary>
+        public string FilePath { get; set; }
+
+        /// <summary>
+        /// The ItemGroup to which the file belongs
+        /// </summary>
+        public string ItemGroup { get; set; }
+
+        /// <summary>
+        /// Whether the file should be include in analysis or not
+        /// </summary>
+        public bool ShouldBeAnalysed { get; set; }
+
+        public FileInProject(string itemGroup, string filePath, bool shouldAnalyse)
+        {
+            ItemGroup = itemGroup;
+            FilePath = filePath;
+            ShouldBeAnalysed = shouldAnalyse;
+        }
+    }
 }

--- a/Tests/TestUtilities/ProjectDescriptor.cs
+++ b/Tests/TestUtilities/ProjectDescriptor.cs
@@ -32,8 +32,6 @@ public class ProjectDescriptor
 
     public IList<FileInProject> Files { get; set; }
 
-    #region Public properties
-
     public string ProjectLanguage { get; set; }
 
     public Guid ProjectGuid { get; set; }
@@ -117,8 +115,6 @@ public class ProjectDescriptor
         }
     }
 
-    #endregion Public properties
-
     public ProjectDescriptor()
     {
         AnalysisResults = new List<AnalysisResult>();
@@ -127,8 +123,6 @@ public class ProjectDescriptor
         // set default encoding
         Encoding = Encoding.UTF8;
     }
-
-    #region Public methods
 
     public ProjectInfo CreateProjectInfo()
     {
@@ -156,8 +150,6 @@ public class ProjectDescriptor
     {
         Files.Add(new FileInProject(ProjectDescriptor.CompilerInputItemGroup, filePath, shouldAnalyse));
     }
-
-    #endregion Public methods
 
     /// <summary>
     /// Data class to describe a single file in a project.

--- a/Tests/TestUtilities/ProjectInfoAssertions.cs
+++ b/Tests/TestUtilities/ProjectInfoAssertions.cs
@@ -18,14 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using FluentAssertions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarScanner.MSBuild.Common;
-
 namespace TestUtilities;
 
 public static class ProjectInfoAssertions

--- a/Tests/TestUtilities/ProjectInfoAssertions.cs
+++ b/Tests/TestUtilities/ProjectInfoAssertions.cs
@@ -85,9 +85,12 @@ public static class ProjectInfoAssertions
     public static AnalysisResult AssertAnalysisResultExists(this ProjectInfo projectInfo, string resultId, string expectedLocation)
     {
         var result = AssertAnalysisResultExists(projectInfo, resultId);
-        result.Location.Should().Be(expectedLocation,
+        result.Location.Should().Be(
+            expectedLocation,
             "Analysis result exists but does not have the expected location. Id: {0}, expected: {1}, actual: {2}",
-                resultId, expectedLocation, result.Location);
+            resultId,
+            expectedLocation,
+            result.Location);
         return result;
     }
 
@@ -103,7 +106,7 @@ public static class ProjectInfoAssertions
         }
         else
         {
-            foreach(var expectedResult in expected.AnalysisResults)
+            foreach (var expectedResult in expected.AnalysisResults)
             {
                 AssertAnalysisResultExists(actual, expectedResult.Id, expectedResult.Location);
             }

--- a/Tests/TestUtilities/ProjectInfoAssertions.cs
+++ b/Tests/TestUtilities/ProjectInfoAssertions.cs
@@ -56,12 +56,6 @@ public static class ProjectInfoAssertions
         CompareAnalysisResults(expected, actual);
     }
 
-    public static void AssertNoProjectInfoFilesExists(string rootOutputFolder)
-    {
-        var items = GetProjectInfosFromOutputFolder(rootOutputFolder);
-        items.Should().BeEmpty("Not expecting any project info files to exist");
-    }
-
     public static ProjectInfo AssertProjectInfoExists(string rootOutputFolder, string fullProjectFileName)
     {
         var items = GetProjectInfosFromOutputFolder(rootOutputFolder);
@@ -70,11 +64,6 @@ public static class ProjectInfoAssertions
         var match = items.FirstOrDefault(pi => fullProjectFileName.Equals(pi.FullPath, StringComparison.OrdinalIgnoreCase));
         match.Should().NotBeNull("Failed to retrieve a project info file for the specified project: {0}", fullProjectFileName);
         return match;
-    }
-
-    public static void AssertNoAnalysisResultsExist(this ProjectInfo projectInfo)
-    {
-        projectInfo.AnalysisResults.Should().BeNullOrEmpty("Not expecting analysis results to exist. Count: {0}", projectInfo.AnalysisResults.Count);
     }
 
     public static void AssertAnalysisResultDoesNotExists(this ProjectInfo projectInfo, string resultId)

--- a/Tests/TestUtilities/ProjectInfoAssertions.cs
+++ b/Tests/TestUtilities/ProjectInfoAssertions.cs
@@ -23,10 +23,9 @@ namespace TestUtilities;
 public static class ProjectInfoAssertions
 {
     /// <summary>
-    /// Returns the list of project info objects beneath the specified root output folder
+    /// Returns the list of project info objects beneath the specified root output folder.
     /// </summary>
-    /// <param name="rootOutputFolder">The root Sonary analysis output folder. Project info files will be searched for in
-    /// immediate sub-directories of this folder only.</param>
+    /// <param name="rootOutputFolder">The root Sonar analysis output folder. Project info files will be searched for in immediate sub-directories of this folder only.</param>
     public static IList<ProjectInfo> GetProjectInfosFromOutputFolder(string rootOutputFolder)
     {
         var items = new List<ProjectInfo>();
@@ -43,9 +42,6 @@ public static class ProjectInfoAssertions
         return items;
     }
 
-    /// <summary>
-    /// Checks that the project info contains the expected values
-    /// </summary>
     public static void AssertExpectedValues(ProjectInfo expected, ProjectInfo actual)
     {
         actual.Should().NotBeNull("Supplied ProjectInfo should not be null");
@@ -60,21 +56,12 @@ public static class ProjectInfoAssertions
         CompareAnalysisResults(expected, actual);
     }
 
-    /// <summary>
-    /// Checks that not project info files exist under the output folder
-    /// </summary>
-    /// <param name="rootOutputFolder">The root SonarQube analysis output folder i.e. the folder that contains the per-project folders</param>
     public static void AssertNoProjectInfoFilesExists(string rootOutputFolder)
     {
         var items = GetProjectInfosFromOutputFolder(rootOutputFolder);
         items.Should().BeEmpty("Not expecting any project info files to exist");
     }
 
-    /// <summary>
-    /// Checks that a project info file exists for the specified project
-    /// </summary>
-    /// <param name="rootOutputFolder">The root SonarQube analysis output folder i.e. the folder that contains the per-project folders</param>
-    /// <param name="fullProjectFileName">The full path and file name of the project file to which the project info file relates</param>
     public static ProjectInfo AssertProjectInfoExists(string rootOutputFolder, string fullProjectFileName)
     {
         var items = GetProjectInfosFromOutputFolder(rootOutputFolder);

--- a/Tests/TestUtilities/ProjectInfoAssertions.cs
+++ b/Tests/TestUtilities/ProjectInfoAssertions.cs
@@ -22,8 +22,6 @@ namespace TestUtilities;
 
 public static class ProjectInfoAssertions
 {
-    #region Public methods
-
     /// <summary>
     /// Returns the list of project info objects beneath the specified root output folder
     /// </summary>
@@ -44,10 +42,6 @@ public static class ProjectInfoAssertions
         }
         return items;
     }
-
-    #endregion Public methods
-
-    #region Assertions
 
     /// <summary>
     /// Checks that the project info contains the expected values
@@ -121,10 +115,6 @@ public static class ProjectInfoAssertions
         return result;
     }
 
-    #endregion Assertions
-
-    #region Private methods
-
     private static void CompareAnalysisResults(ProjectInfo expected, ProjectInfo actual)
     {
         // We're assuming the actual analysis results have been reloaded by the serializer
@@ -145,6 +135,4 @@ public static class ProjectInfoAssertions
             actual.AnalysisResults.Should().HaveCount(expected.AnalysisResults.Count, "Unexpected additional analysis results found");
         }
     }
-
-    #endregion Private methods
 }

--- a/src/SonarScanner.MSBuild.Common/ProjectInfo/AnalysisResult.cs
+++ b/src/SonarScanner.MSBuild.Common/ProjectInfo/AnalysisResult.cs
@@ -32,8 +32,6 @@ public class AnalysisResult
     /// </summary>
     public static readonly IEqualityComparer<string> ResultKeyComparer = StringComparer.Ordinal;
 
-    #region Data
-
     /// <summary>
     /// The identifier for the type of analyzer
     /// </summary>
@@ -47,10 +45,4 @@ public class AnalysisResult
     /// <remarks>This will normally be an absolute file path</remarks>
     [XmlAttribute]
     public string Location { get; set; }
-
-    #endregion Data
-
-    #region Static helpers
-
-    #endregion Static helpers
 }

--- a/src/SonarScanner.MSBuild.Common/ProjectInfo/AnalysisResult.cs
+++ b/src/SonarScanner.MSBuild.Common/ProjectInfo/AnalysisResult.cs
@@ -18,10 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Xml.Serialization;
-
 namespace SonarScanner.MSBuild.Common;
 
 /// <summary>

--- a/src/SonarScanner.MSBuild.Common/ProjectInfo/AnalysisResult.cs
+++ b/src/SonarScanner.MSBuild.Common/ProjectInfo/AnalysisResult.cs
@@ -27,6 +27,11 @@ namespace SonarScanner.MSBuild.Common;
 /// Examples of types of analyzer: CodeCoverage, Roslyn Analyzers...</remarks>
 public class AnalysisResult
 {
+    /// <summary>
+    /// Comparer to use when comparing keys of analysis results
+    /// </summary>
+    public static readonly IEqualityComparer<string> ResultKeyComparer = StringComparer.Ordinal;
+
     #region Data
 
     /// <summary>
@@ -46,11 +51,6 @@ public class AnalysisResult
     #endregion Data
 
     #region Static helpers
-
-    /// <summary>
-    /// Comparer to use when comparing keys of analysis results
-    /// </summary>
-    public static readonly IEqualityComparer<string> ResultKeyComparer = StringComparer.Ordinal;
 
     #endregion Static helpers
 }

--- a/src/SonarScanner.MSBuild.Common/ProjectInfo/AnalysisResult.cs
+++ b/src/SonarScanner.MSBuild.Common/ProjectInfo/AnalysisResult.cs
@@ -21,28 +21,13 @@
 namespace SonarScanner.MSBuild.Common;
 
 /// <summary>
-/// Data class to describe the output of a single type of analyzer
+/// Data class to describe the output of a single type of analyzer.
 /// </summary>
-/// <remarks>The class is XML-serializable.
-/// Examples of types of analyzer: CodeCoverage, Roslyn Analyzers...</remarks>
+/// <remarks>The class is XML-serializable. Examples of types of analyzer: CodeCoverage, Roslyn Analyzers...</remarks>
 public class AnalysisResult
 {
-    /// <summary>
-    /// Comparer to use when comparing keys of analysis results
-    /// </summary>
     public static readonly IEqualityComparer<string> ResultKeyComparer = StringComparer.Ordinal;
 
-    /// <summary>
-    /// The identifier for the type of analyzer
-    /// </summary>
-    /// <remarks>Each type </remarks>
-    [XmlAttribute]
-    public string Id { get; set; }
-
-    /// <summary>
-    /// The location of the output produced by the analyzer
-    /// </summary>
-    /// <remarks>This will normally be an absolute file path</remarks>
-    [XmlAttribute]
-    public string Location { get; set; }
+    [XmlAttribute] public string Id { get; set; }
+    [XmlAttribute] public string Location { get; set; }
 }

--- a/src/SonarScanner.MSBuild.Common/ProjectInfo/AnalysisResult.cs
+++ b/src/SonarScanner.MSBuild.Common/ProjectInfo/AnalysisResult.cs
@@ -28,6 +28,9 @@ public class AnalysisResult
 {
     public static readonly IEqualityComparer<string> ResultKeyComparer = StringComparer.Ordinal;
 
-    [XmlAttribute] public string Id { get; set; }
-    [XmlAttribute] public string Location { get; set; }
+    [XmlAttribute]
+    public string Id { get; set; }
+
+    [XmlAttribute]
+    public string Location { get; set; }
 }

--- a/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfo.cs
+++ b/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfo.cs
@@ -21,83 +21,29 @@
 namespace SonarScanner.MSBuild.Common;
 
 /// <summary>
-/// Data class to describe a single project
+/// XML-serializable data class to describe a single project.
 /// </summary>
-/// <remarks>The class is XML-serializable</remarks>
 [XmlRoot(Namespace = XmlNamespace)]
 public class ProjectInfo
 {
     public const string XmlNamespace = "http://www.sonarsource.com/msbuild/integration/2015/1";
 
-    /// <summary>
-    /// The project file name
-    /// </summary>
     public string ProjectName { get; set; }
-
-    /// <summary>
-    /// The project language
-    /// </summary>
     public string ProjectLanguage { get; set; }
-
-    /// <summary>
-    /// The kind of the project
-    /// </summary>
     public ProjectType ProjectType { get; set; }
-
-    /// <summary>
-    /// Unique identifier for the project
-    /// </summary>
     public Guid ProjectGuid { get; set; }
-
-    /// <summary>
-    /// The full name and path of the project file
-    /// </summary>
-    public string FullPath { get; set; }
-
-    /// <summary>
-    /// Flag indicating whether the project should be excluded from processing
-    /// </summary>
+    public string FullPath { get; set; }    // Path to csproj/vbproj/*proj
     public bool IsExcluded { get; set; }
-
-    /// <summary>
-    /// Encoding used for source files if no BOM is present
-    /// </summary>
-    public string Encoding { get; set; }
-
-    /// <summary>
-    /// List of analysis results for the project
-    /// </summary>
+    public string Encoding { get; set; }    // Default encoding for files without BOM
     public List<AnalysisResult> AnalysisResults { get; set; }
-
-    /// <summary>
-    /// List of additional analysis settings
-    /// </summary>
     public AnalysisProperties AnalysisSettings { get; set; }
-
-    /// <summary>
-    /// MSBuild configuration for the current build
-    /// </summary>
-    public string Configuration { get; set; }
-
-    /// <summary>
-    /// MSBuild platform for the current build
-    /// </summary>
-    public string Platform { get; set; }
-
-    /// <summary>
-    /// MSBuild target framework for the current build
-    /// </summary>
+    public string Configuration { get; set; }   // MsBuild /p:Configuration:Release|Debug|SomethingElse parameter
+    public string Platform { get; set; }        // MsBuild /p:Platform parameter
     public string TargetFramework { get; set; }
 
-    /// <summary>
-    /// Saves the project to the specified file as XML
-    /// </summary>
     public void Save(string fileName) =>
         Serializer.SaveModel(this, fileName);
 
-    /// <summary>
-    /// Loads and returns project info from the specified XML file
-    /// </summary>
     public static ProjectInfo Load(string fileName) =>
         Serializer.LoadModel<ProjectInfo>(fileName);
 }

--- a/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfo.cs
+++ b/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfo.cs
@@ -29,8 +29,6 @@ public class ProjectInfo
 {
     public const string XmlNamespace = "http://www.sonarsource.com/msbuild/integration/2015/1";
 
-    #region Public properties
-
     /// <summary>
     /// The project file name
     /// </summary>
@@ -91,10 +89,6 @@ public class ProjectInfo
     /// </summary>
     public string TargetFramework { get; set; }
 
-    #endregion Public properties
-
-    #region Serialization
-
     /// <summary>
     /// Saves the project to the specified file as XML
     /// </summary>
@@ -106,6 +100,4 @@ public class ProjectInfo
     /// </summary>
     public static ProjectInfo Load(string fileName) =>
         Serializer.LoadModel<ProjectInfo>(fileName);
-
-    #endregion Serialization
 }

--- a/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfo.cs
+++ b/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfo.cs
@@ -18,10 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Xml.Serialization;
-
 namespace SonarScanner.MSBuild.Common;
 
 /// <summary>

--- a/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfoExtensions.cs
+++ b/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfoExtensions.cs
@@ -97,9 +97,7 @@ public static class ProjectInfoExtensions
             throw new ArgumentNullException(nameof(projectInfo));
         }
 
-        return !string.IsNullOrWhiteSpace(projectInfo.FullPath)
-            ? new FileInfo(projectInfo.FullPath).Directory
-            : null;
+        return string.IsNullOrWhiteSpace(projectInfo.FullPath) ? null : new FileInfo(projectInfo.FullPath).Directory;
     }
 
     public static string GetProjectGuidAsString(this ProjectInfo projectInfo)

--- a/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfoExtensions.cs
+++ b/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfoExtensions.cs
@@ -22,24 +22,13 @@ using System.Globalization;
 
 namespace SonarScanner.MSBuild.Common;
 
-/// <summary>
-/// Extension methods for <see cref="ProjectInfo"/>
-/// </summary>
 public static class ProjectInfoExtensions
 {
-    /// <summary>
-    /// Attempts to find and return the analyzer result with the specified id
-    /// </summary>
-    /// <returns>True if the analyzer result was found, otherwise false</returns>
     public static bool TryGetAnalyzerResult(this ProjectInfo projectInfo, AnalysisResultFileType fileType, out AnalysisResult result)
     {
         return TryGetAnalyzerResult(projectInfo, fileType.ToString(), out result);
     }
 
-    /// <summary>
-    /// Attempts to find and return the analyzer result with the specified id
-    /// </summary>
-    /// <returns>True if the analyzer result was found, otherwise false</returns>
     public static bool TryGetAnalyzerResult(this ProjectInfo projectInfo, string id, out AnalysisResult result)
     {
         if (projectInfo == null)
@@ -56,10 +45,6 @@ public static class ProjectInfoExtensions
         return result != null;
     }
 
-    /// <summary>
-    /// Attempts to find and return the analysis setting with the specified id
-    /// </summary>
-    /// <returns>True if the setting was found, otherwise false</returns>
     public static bool TryGetAnalysisSetting(this ProjectInfo projectInfo, string id, out Property result)
     {
         if (projectInfo == null)
@@ -76,19 +61,11 @@ public static class ProjectInfoExtensions
         return result != null;
     }
 
-    /// <summary>
-    /// Adds an analysis result of the specified type
-    /// </summary>
-    /// <remarks>The method does not check whether an analysis result with the same id already exists i.e. duplicate results are allowed</remarks>
     public static void AddAnalyzerResult(this ProjectInfo projectInfo, AnalysisResultFileType fileType, string location)
     {
         AddAnalyzerResult(projectInfo, fileType.ToString(), location);
     }
 
-    /// <summary>
-    /// Adds an analysis result of the specified kind
-    /// </summary>
-    /// <remarks>The method does not check whether an analysis result with the same id already exists i.e. duplicate results are allowed</remarks>
     public static void AddAnalyzerResult(this ProjectInfo projectInfo, string id, string location)
     {
         if (projectInfo == null)
@@ -113,10 +90,7 @@ public static class ProjectInfoExtensions
         projectInfo.AnalysisResults.Add(result);
     }
 
-    /// <summary>
-    /// Returns the full path of the directory containing the project file
-    /// </summary>
-    public static DirectoryInfo GetDirectory(this ProjectInfo projectInfo)
+    public static DirectoryInfo ProjectFileDirectory(this ProjectInfo projectInfo)
     {
         if (projectInfo == null)
         {
@@ -128,9 +102,6 @@ public static class ProjectInfoExtensions
             : null;
     }
 
-    /// <summary>
-    /// Returns the ProjectGuid formatted as a string
-    /// </summary>
     public static string GetProjectGuidAsString(this ProjectInfo projectInfo)
     {
         if (projectInfo == null)
@@ -141,11 +112,6 @@ public static class ProjectInfoExtensions
         return projectInfo.ProjectGuid.ToString("D", CultureInfo.InvariantCulture).ToUpperInvariant();
     }
 
-    /// <summary>
-    /// Attempts to return the file location for the specified type of analysis result.
-    /// Returns null if there is not a result for the specified type.
-    /// Note that callers must check if the file exists before attempting to read.
-    /// </summary>
     public static string TryGetAnalysisFileLocation(this ProjectInfo projectInfo, AnalysisResultFileType fileType)
     {
         if (projectInfo.TryGetAnalyzerResult(fileType, out var result))
@@ -156,10 +122,6 @@ public static class ProjectInfoExtensions
         return null;
     }
 
-    /// <summary>
-    /// Returns the list of files to be analyzed. If there are no files to be analyzed
-    /// then an empty list will be returned.
-    /// </summary>
     public static FileInfo[] GetAllAnalysisFiles(this ProjectInfo projectInfo, ILogger logger)
     {
         var compiledFilesPath = projectInfo.TryGetAnalysisFileLocation(AnalysisResultFileType.FilesToAnalyze);

--- a/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfoExtensions.cs
+++ b/src/SonarScanner.MSBuild.Common/ProjectInfo/ProjectInfoExtensions.cs
@@ -18,11 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 
 namespace SonarScanner.MSBuild.Common;
 

--- a/src/SonarScanner.MSBuild.Shim/PropertiesWriter.cs
+++ b/src/SonarScanner.MSBuild.Shim/PropertiesWriter.cs
@@ -108,7 +108,7 @@ public class PropertiesWriter
 
         AppendKeyValue(guid, SonarProperties.ProjectKey, config.SonarProjectKey + ":" + guid);
         AppendKeyValue(guid, SonarProperties.ProjectName, projectData.Project.ProjectName);
-        AppendKeyValue(guid, SonarProperties.ProjectBaseDir, projectData.Project.GetDirectory().FullName);
+        AppendKeyValue(guid, SonarProperties.ProjectBaseDir, projectData.Project.ProjectFileDirectory().FullName);
 
         if (!string.IsNullOrWhiteSpace(projectData.Project.Encoding))
         {

--- a/src/SonarScanner.MSBuild.Shim/ScannerEngineInput.cs
+++ b/src/SonarScanner.MSBuild.Shim/ScannerEngineInput.cs
@@ -76,7 +76,7 @@ public class ScannerEngineInput
         modules.Value = string.Join(",", moduleKeys);
         Add(guid, SonarProperties.ProjectKey, config.SonarProjectKey + ":" + guid);
         Add(guid, SonarProperties.ProjectName, project.Project.ProjectName);
-        Add(guid, SonarProperties.ProjectBaseDir, project.Project.GetDirectory().FullName);
+        Add(guid, SonarProperties.ProjectBaseDir, project.Project.ProjectFileDirectory().FullName);
         Add(guid, SonarProperties.WorkingDirectory, Path.Combine(config.SonarOutputDir, ".sonar", $"mod{moduleKeys.Count - 1}"));    // zero-based index
         if (!string.IsNullOrWhiteSpace(project.Project.Encoding))
         {

--- a/src/SonarScanner.MSBuild.Shim/ScannerEngineInputGenerator.cs
+++ b/src/SonarScanner.MSBuild.Shim/ScannerEngineInputGenerator.cs
@@ -127,7 +127,7 @@ public class ScannerEngineInputGenerator
             return false;
         }
 
-        var projectDirectories = validProjects.Select(x => x.Project.GetDirectory()).ToArray();
+        var projectDirectories = validProjects.Select(x => x.Project.ProjectFileDirectory()).ToArray();
         var projectBaseDir = ComputeProjectBaseDir(projectDirectories);
         if (projectBaseDir is null)
         {
@@ -242,7 +242,7 @@ public class ScannerEngineInputGenerator
         var closestProjects = new List<ProjectData>();
         foreach (var project in projects)
         {
-            var projectDirectory = project.Project.GetDirectory();
+            var projectDirectory = project.Project.ProjectFileDirectory();
             if (fileInfo.IsInDirectory(projectDirectory))
             {
                 if (projectDirectory.FullName.Length == length)

--- a/src/SonarScanner.MSBuild.Shim/SonarProjectPropertiesValidator.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarProjectPropertiesValidator.cs
@@ -31,7 +31,7 @@ public class SonarProjectPropertiesValidator
     {
         invalidFolders = projects
             .Where(x => x.Status == ProjectInfoValidity.Valid)
-            .Select(x => x.Project.GetDirectory().FullName)
+            .Select(x => x.Project.ProjectFileDirectory().FullName)
             .Union([sonarScannerCwd])
             .Where(SonarProjectPropertiesExists)
             .ToList();

--- a/src/SonarScanner.MSBuild.Tasks/WriteProjectInfoFile.cs
+++ b/src/SonarScanner.MSBuild.Tasks/WriteProjectInfoFile.cs
@@ -179,16 +179,9 @@ public class WriteProjectInfoFile(IEncodingProvider encodingProvider) : Task
         return null;
     }
 
-    /// <summary>
-    /// Attempts to convert the supplied task items into a list of <see cref="AnalysisResult"/> objects.
-    /// </summary>
     private List<AnalysisResult> TryCreateAnalysisResults(ITaskItem[] resultItems) =>
         resultItems?.Select(TryCreateResultFromItem).Where(x => x is not null).ToList() ?? [];
 
-    /// <summary>
-    /// Attempts to create an <see cref="AnalysisResult"/> from the supplied task item.
-    /// Returns null if the task item does not have the required metadata.
-    /// </summary>
     private AnalysisResult TryCreateResultFromItem(ITaskItem taskItem)
     {
         Debug.Assert(taskItem is not null, "Supplied task item should not be null");
@@ -221,9 +214,6 @@ public class WriteProjectInfoFile(IEncodingProvider encodingProvider) : Task
         };
     }
 
-    /// <summary>
-    /// Attempts to convert the supplied task items into a list of <see cref="ConfigSetting"/> objects.
-    /// </summary>
     private AnalysisProperties TryCreateAnalysisSettings(ITaskItem[] resultItems)
     {
         var settings = new AnalysisProperties();
@@ -231,10 +221,6 @@ public class WriteProjectInfoFile(IEncodingProvider encodingProvider) : Task
         return settings;
     }
 
-    /// <summary>
-    /// Attempts to create an <see cref="ConfigSetting"/> from the supplied task item.
-    /// Returns null if the task item does not have the required metadata.
-    /// </summary>
     private Property TryCreateSettingFromItem(ITaskItem taskItem)
     {
         Debug.Assert(taskItem is not null, "Supplied task item should not be null");
@@ -245,10 +231,6 @@ public class WriteProjectInfoFile(IEncodingProvider encodingProvider) : Task
             : null;
     }
 
-    /// <summary>
-    /// Attempts to extract the setting id from the supplied task item.
-    /// Logs warnings if the task item does not contain valid data.
-    /// </summary>
     private bool TryGetSettingId(ITaskItem taskItem, out string settingId)
     {
         settingId = null;
@@ -265,11 +247,6 @@ public class WriteProjectInfoFile(IEncodingProvider encodingProvider) : Task
         return isValid;
     }
 
-    /// <summary>
-    /// Attempts to return the value to use for the setting.
-    /// Logs warnings if the task item does not contain valid data.
-    /// </summary>
-    /// <remarks>The task should have a "Value" metadata item.</remarks>
     private bool TryGetSettingValue(ITaskItem taskItem, out string metadataValue)
     {
         bool success;

--- a/src/SonarScanner.MSBuild.Tasks/WriteProjectInfoFile.cs
+++ b/src/SonarScanner.MSBuild.Tasks/WriteProjectInfoFile.cs
@@ -18,17 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Text;
 using System.Xml.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using SonarScanner.MSBuild.Common;
 using SonarScanner.MSBuild.Common.Interfaces;
 
 namespace SonarScanner.MSBuild.Tasks;


### PR DESCRIPTION
[SCAN4NET-826](https://sonarsource.atlassian.net/browse/SCAN4NET-826)

Part of SCAN4NET-821

Prerequisite for SCAN4NET-823 - this pre-cleans up files that will be touched later. There will be more PRs like this.

Review per commit is highly recommended, as each commit fixes the same thing in multiple files

[SCAN4NET-826]: https://sonarsource.atlassian.net/browse/SCAN4NET-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ