### PR TITLE
SCAN4NET-832 Disable analysis for dev build

### DIFF
--- a/Tests/Directory.Build.targets
+++ b/Tests/Directory.Build.targets
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ProjectName)' != 'LogArgs'">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -314,6 +314,7 @@ stages:
               solution: '$(SOLUTION)'
               platform: '$(BUILD_PLATFORM)'
               configuration: '$(BUILD_CONFIGURATION)'
+              msbuildArgs: '/p:RunAnalyzers=true /p:RunAnalyzersDuringBuild=true'
 
           - powershell: .\scripts\run-unit-tests.ps1 -sourcesDirectory "$(Build.SourcesDirectory)" -buildConfiguration "$(BUILD_CONFIGURATION)"
             displayName: 'Run UTs and compute coverage'

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -2,6 +2,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[SCAN4NET-832](https://sonarsource.atlassian.net/browse/SCAN4NET-832)

Same as on `sonar-dotnet`

Local build in VS should not waste time running all analyzers. For standalone build, as well as for build before running UTs.

This keeps analyzers working in the IDE.

[SCAN4NET-832]: https://sonarsource.atlassian.net/browse/SCAN4NET-832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ