### PR TITLE
SCAN4NET-833 Use IRuntime in TarGzUnpacker

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreDownloaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreDownloaderTests.cs
@@ -232,7 +232,7 @@ public class JreDownloaderTests
             Directory = DirectoryWrapper.Instance,
             File = FileWrapper.Instance
         };
-        var targzUnpacker = new TarGzUnpacker(runtimeIO.Logger, runtimeIO.Directory, runtimeIO.File, runtimeIO.OperatingSystem);
+        var targzUnpacker = new TarGzUnpacker(runtimeIO);
         var downloadContentArray = new byte[] { 1, 2, 3 };
 
         var sut = new JreDownloader(runtimeIO, targzUnpacker, ChecksumSha256.Instance, home, new JreDescriptor("filename.tar.gz", sha, "javaPath"));
@@ -271,7 +271,7 @@ public class JreDownloaderTests
             Directory = DirectoryWrapper.Instance,
             File = FileWrapper.Instance
         };
-        var targzUnpacker = new TarGzUnpacker(runtimeIO.Logger, runtimeIO.Directory, runtimeIO.File, runtimeIO.OperatingSystem);
+        var targzUnpacker = new TarGzUnpacker(runtimeIO);
 
         var sut = new JreDownloader(runtimeIO, targzUnpacker, ChecksumSha256.Instance, home, new JreDescriptor("filename.tar.gz", sha, "javaPath"));
         try
@@ -834,7 +834,7 @@ public class JreDownloaderTests
             Directory = DirectoryWrapper.Instance,
             File = FileWrapper.Instance
         };
-        var targzUnpacker = new TarGzUnpacker(runtimeIO.Logger, runtimeIO.Directory, runtimeIO.File, runtimeIO.OperatingSystem);
+        var targzUnpacker = new TarGzUnpacker(runtimeIO);
 
         var sut = new JreDownloader(runtimeIO, targzUnpacker, ChecksumSha256.Instance, home, jreDescriptor);
 

--- a/src/SonarScanner.MSBuild.PreProcessor/Unpacking/TarGzUnpacker.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Unpacking/TarGzUnpacker.cs
@@ -31,12 +31,12 @@ public class TarGzUnpacker : IUnpacker
     private readonly IFileWrapper fileWrapper;
     private readonly OperatingSystemProvider operatingSystem;
 
-    public TarGzUnpacker(ILogger logger, IDirectoryWrapper directoryWrapper, IFileWrapper fileWrapper, OperatingSystemProvider operatingSystem)
+    public TarGzUnpacker(IRuntime runtime)
     {
-        this.logger = logger;
-        this.directoryWrapper = directoryWrapper;
-        this.fileWrapper = fileWrapper;
-        this.operatingSystem = operatingSystem;
+        logger = runtime.Logger;
+        directoryWrapper = runtime.Directory;
+        fileWrapper = runtime.File;
+        operatingSystem = runtime.OperatingSystem;
     }
 
     // ref https://github.com/icsharpcode/SharpZipLib/blob/ff2d7c30bdb2474d507f001bc555405e9f02a0bb/src/ICSharpCode.SharpZipLib/Tar/TarArchive.cs#L608

--- a/src/SonarScanner.MSBuild.PreProcessor/Unpacking/UnpackerFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Unpacking/UnpackerFactory.cs
@@ -33,7 +33,7 @@ public class UnpackerFactory
         archivePath switch
         {
             _ when archivePath.EndsWith(".ZIP", StringComparison.OrdinalIgnoreCase) => new ZipUnpacker(),
-            _ when archivePath.EndsWith(".TAR.GZ", StringComparison.OrdinalIgnoreCase) => new TarGzUnpacker(runtime.Logger, runtime.Directory, runtime.File, runtime.OperatingSystem),
+            _ when archivePath.EndsWith(".TAR.GZ", StringComparison.OrdinalIgnoreCase) => new TarGzUnpacker(runtime),
             _ => null
         };
 }


### PR DESCRIPTION
[SCAN4NET-833](https://sonarsource.atlassian.net/browse/SCAN4NET-833)
Part of SCAN4NET-789

Skip the first two commits for review. They are coming from #2746.

[SCAN4NET-833]: https://sonarsource.atlassian.net/browse/SCAN4NET-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ