### PR TITLE
SCAN4NET-839 Enable scanner-engine code path

### DIFF
--- a/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
+++ b/src/SonarScanner.MSBuild/DefaultProcessorFactory.cs
@@ -1,22 +1,22 @@
 ﻿/*
- * SonarScanner for .NET
- * Copyright (C) 2016-2025 SonarSource SA
- * mailto: info AT sonarsource DOT com
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- */
+* SonarScanner for .NET
+* Copyright (C) 2016-2025 SonarSource SA
+* mailto: info AT sonarsource DOT com
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 3 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program; if not, write to the Free Software Foundation,
+* Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
 
 using SonarScanner.MSBuild.PostProcessor;
 using SonarScanner.MSBuild.PostProcessor.Interfaces;
@@ -36,6 +36,7 @@ public class DefaultProcessorFactory : IProcessorFactory
     public IPostProcessor CreatePostProcessor() =>
         new PostProcessor.PostProcessor(
             new SonarScannerWrapper(runtime),
+            new SonarEngineWrapper(runtime, new ProcessRunner(runtime.Logger)),
             runtime.Logger,
             new TargetsUninstaller(runtime.Logger),
             new TfsProcessorWrapper(runtime),


### PR DESCRIPTION
[SCAN4NET-839](https://sonarsource.atlassian.net/browse/SCAN4NET-839)

Part of SCAN4NET-710

Feature branch that enables the scanner-engine code path.

Replaces #2757

[SCAN4NET-839]: https://sonarsource.atlassian.net/browse/SCAN4NET-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ