### PR TITLE
SCAN4NET-837 Find Java.exe in SonarEngineWrapper

### DIFF
--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
@@ -31,8 +31,6 @@ public class SonarEngineWrapperTest
         }
         """;
 
-    private readonly TestRuntime runtime = new();
-
     [TestMethod]
     public void Ctor_Runtime_ThrowsArgumentNullException()
     {
@@ -43,14 +41,14 @@ public class SonarEngineWrapperTest
     [TestMethod]
     public void Ctor_ProcessRunner_ThrowsArgumentNullException()
     {
-        Action act = () => new SonarEngineWrapper(runtime, null);
+        Action act = () => new SonarEngineWrapper(new TestRuntime(), null);
         act.Should().Throw<ArgumentNullException>().WithParameterName("processRunner");
     }
 
     [TestMethod]
     public void Execute_Config_ThrowsArgumentNullException()
     {
-        var wrapper = new SonarEngineWrapper(runtime, Substitute.For<IProcessRunner>());
+        var wrapper = new SonarEngineWrapper(new TestRuntime(), Substitute.For<IProcessRunner>());
 
         Action act = () => wrapper.Execute(null, "{}");
         act.Should().Throw<ArgumentNullException>().WithParameterName("config");
@@ -59,26 +57,123 @@ public class SonarEngineWrapperTest
     [TestMethod]
     public void Execute_Success()
     {
-        var runner = new MockProcessRunner(true);
-        var engine = new SonarEngineWrapper(runtime, runner);
-        var result = engine.Execute(new AnalysisConfig() { JavaExePath = "java.exe", EngineJarPath = "engine.jar" }, SampleInput);
-        result.Should().BeTrue();
-        runner.SuppliedArguments.Should().BeEquivalentTo(new
+        var context = new Context();
+        context.Execute().Should().BeTrue();
+
+        context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
-            ExeName = "java.exe",
+            ExeName = context.ResolvedJavaExe,
             CmdLineArgs = (string[])["-jar", "engine.jar"],
             StandardInput = SampleInput,
         });
-        runtime.Logger.AssertInfoLogged("The scanner engine has finished successfully");
+        context.AssertInfoLogs("The scanner engine has finished successfully");
     }
 
     [TestMethod]
     public void Execute_Failure()
     {
-        var runner = new MockProcessRunner(false);
-        var engine = new SonarEngineWrapper(runtime, runner);
-        var result = engine.Execute(new AnalysisConfig() { JavaExePath = "java.exe", EngineJarPath = "engine.jar" }, SampleInput);
-        result.Should().BeFalse();
-        runtime.Logger.AssertErrorLogged("The scanner engine did not complete successfully");
+        var context = new Context(new MockProcessRunner(false));
+
+        context.Execute().Should().BeFalse();
+
+        context.Runtime.Logger.AssertErrorLogged("The scanner engine did not complete successfully");
+    }
+
+    [TestMethod]
+    public void FindJavaExe_ConfiguredPath_Exists()
+    {
+        var context = new Context();
+        context.Runtime.File.Exists(context.ResolvedJavaExe).Returns(true);
+
+        context.Execute().Should().BeTrue();
+
+        context.Runner.SuppliedArguments.ExeName.Should().Be(context.ResolvedJavaExe);
+        context.AssertInfoLogs($"Using Java found in Analysis Config: {context.ResolvedJavaExe}");
+    }
+
+    [TestMethod]
+    public void FindJavaExe_ConfiguredPath_DoesNotExist()
+    {
+        var context = new Context();
+        context.Runtime.File.Exists(context.ResolvedJavaExe).Returns(false);
+
+        context.Execute().Should().BeTrue();
+
+        context.Runner.SuppliedArguments.ExeName.Should().Be(context.JavaFileName);
+        context.AssertInfoLogs(
+            $"Could not find Java in Analysis Config: {context.ResolvedJavaExe}",
+            "'JAVA_HOME' environment variable not set",
+            $"Could not find Java, falling back to using PATH: {context.JavaFileName}");
+    }
+
+    [TestMethod]
+    public void FindJavaExe_JavaHomeSet_Exists()
+    {
+        var context = new Context();
+        using var environmentVariableScope = new EnvironmentVariableScope();
+        environmentVariableScope.SetVariable(EnvironmentVariables.JavaHomeVariableName, context.JavaHome);
+        context.Runtime.File.Exists(context.ResolvedJavaExe).Returns(false);
+        context.Runtime.File.Exists(context.JavaHomeExePath).Returns(true);
+
+        context.Execute().Should().BeTrue();
+
+        context.Runner.SuppliedArguments.ExeName.Should().Be(context.JavaHomeExePath);
+        context.AssertInfoLogs(
+            $"Could not find Java in Analysis Config: {context.ResolvedJavaExe}",
+            $"Found 'JAVA_HOME': {context.JavaHome}",
+            $"Using Java found in JAVA_HOME: {context.JavaHomeExePath}");
+    }
+
+    [TestMethod]
+    public void FindJavaExe_JavaHomeSet_DoesNotExist()
+    {
+        var context = new Context();
+        using var environmentVariableScope = new EnvironmentVariableScope();
+        environmentVariableScope.SetVariable(EnvironmentVariables.JavaHomeVariableName, context.JavaHome);
+        context.Runtime.File.Exists(context.ResolvedJavaExe).Returns(false);
+        context.Runtime.File.Exists(context.JavaHomeExePath).Returns(false);
+
+        context.Execute().Should().BeTrue();
+
+        context.Runner.SuppliedArguments.ExeName.Should().Be(context.JavaFileName);
+        context.AssertInfoLogs(
+            $"Could not find Java in Analysis Config: {context.ResolvedJavaExe}",
+            $"Found 'JAVA_HOME': {context.JavaHome}",
+            $"Could not find Java in JAVA_HOME: {context.JavaHomeExePath}",
+            $"Could not find Java, falling back to using PATH: {context.JavaFileName}");
+    }
+
+    private sealed class Context
+    {
+        public readonly SonarEngineWrapper Engine;
+        public readonly MockProcessRunner Runner;
+        public readonly TestRuntime Runtime = new();
+
+        public readonly string ResolvedJavaExe = "resolved-java.exe";
+        public readonly string JavaHome = Path.Combine("Java", "Home");
+        public readonly string JavaFileName;
+        public readonly string JavaHomeExePath;
+
+        public Context(MockProcessRunner runner = null)
+        {
+            Runner = runner ?? new MockProcessRunner(true);
+            Engine = new SonarEngineWrapper(Runtime, Runner);
+            JavaFileName = Runtime.OperatingSystem.IsUnix() ? "java" : "java.exe";
+            JavaHomeExePath = Path.Combine(JavaHome, "bin", JavaFileName);
+            Runtime.File.Exists(ResolvedJavaExe).Returns(true);
+        }
+
+        public bool Execute(AnalysisConfig config = null, string standardInput = null) =>
+            Engine.Execute(
+                config ?? new AnalysisConfig { JavaExePath = ResolvedJavaExe, EngineJarPath = "engine.jar" },
+                standardInput ?? SampleInput);
+
+        public void AssertInfoLogs(params string[] messages)
+        {
+            foreach (var message in messages)
+            {
+                Runtime.Logger.AssertInfoLogged(message);
+            }
+        }
     }
 }

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
@@ -32,27 +32,16 @@ public class SonarEngineWrapperTest
         """;
 
     [TestMethod]
-    public void Ctor_Runtime_ThrowsArgumentNullException()
-    {
-        Action act = () => new SonarEngineWrapper(null, Substitute.For<IProcessRunner>());
-        act.Should().Throw<ArgumentNullException>().WithParameterName("runtime");
-    }
+    public void Ctor_Runtime_ThrowsArgumentNullException() =>
+        FluentActions.Invoking(() => new SonarEngineWrapper(null, Substitute.For<IProcessRunner>())).Should().Throw<ArgumentNullException>().WithParameterName("runtime");
 
     [TestMethod]
-    public void Ctor_ProcessRunner_ThrowsArgumentNullException()
-    {
-        Action act = () => new SonarEngineWrapper(new TestRuntime(), null);
-        act.Should().Throw<ArgumentNullException>().WithParameterName("processRunner");
-    }
+    public void Ctor_ProcessRunner_ThrowsArgumentNullException() =>
+        FluentActions.Invoking(() => new SonarEngineWrapper(new TestRuntime(), null)).Should().Throw<ArgumentNullException>().WithParameterName("processRunner");
 
     [TestMethod]
-    public void Execute_Config_ThrowsArgumentNullException()
-    {
-        var wrapper = new SonarEngineWrapper(new TestRuntime(), Substitute.For<IProcessRunner>());
-
-        Action act = () => wrapper.Execute(null, "{}");
-        act.Should().Throw<ArgumentNullException>().WithParameterName("config");
-    }
+    public void Execute_Config_ThrowsArgumentNullException() =>
+        new SonarEngineWrapper(new TestRuntime(), Substitute.For<IProcessRunner>()).Invoking(x => x.Execute(null, "{}")).Should().Throw<ArgumentNullException>().WithParameterName("config");
 
     [TestMethod]
     public void Execute_Success()

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
@@ -75,6 +75,7 @@ public class SonarEngineWrapperTest
     [TestMethod]
     public void FindJavaExe_ConfiguredPath_DoesNotExist(bool isUnix)
     {
+        using var scope = new EnvironmentVariableScope().SetVariable(EnvironmentVariables.JavaHomeVariableName, null);
         var context = new Context(isUnix);
         context.Runtime.File.Exists(context.ResolvedJavaExe).Returns(false);
 

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
@@ -140,7 +140,7 @@ public class SonarEngineWrapperTest
         public Context(bool isUnix = false, bool processSucceeds = true)
         {
             Runner = new MockProcessRunner(processSucceeds);
-            Runtime.OperatingSystem.IsUnix().Returns(isUnix);
+            Runtime.OperatingSystem.OperatingSystem().Returns(isUnix ? PlatformOS.Linux : PlatformOS.Windows);
             Engine = new SonarEngineWrapper(Runtime, Runner);
             Runtime.File.Exists(ResolvedJavaExe).Returns(true);
         }

--- a/Tests/SonarScanner.MSBuild.Test/BootstrapperClassTests.cs
+++ b/Tests/SonarScanner.MSBuild.Test/BootstrapperClassTests.cs
@@ -286,7 +286,7 @@ public class BootstrapperClassTests
         preProcessor = Substitute.For<PreProcessor.PreProcessor>(Substitute.For<PreProcessor.IPreprocessorObjectFactory>(), Substitute.For<ILogger>());
         postProcessor = Substitute.For<PostProcessor.PostProcessor>(
             Substitute.For<SonarScannerWrapper>(Substitute.For<IRuntime>()),
-            Substitute.For<SonarEngineWrapper>(Substitute.For<IRuntime>(), Substitute.For<IProcessRunner>()),
+            Substitute.For<SonarEngineWrapper>(new TestRuntime(), Substitute.For<IProcessRunner>()),
             Substitute.For<IRuntime>(),
             Substitute.For<TargetsUninstaller>(Substitute.For<ILogger>()),
             Substitute.For<TfsProcessorWrapper>(Substitute.For<IRuntime>()),

--- a/Tests/TestUtilities/TestLogger.cs
+++ b/Tests/TestUtilities/TestLogger.cs
@@ -199,6 +199,14 @@ public class TestLogger : ILogger
         matches.Should().BeEmpty("Not expecting any errors to contain the specified strings: {0}", string.Join(",", expected));
     }
 
+    public void AssertInfoLogs(params string[] messages)
+    {
+        foreach (var message in messages)
+        {
+            AssertInfoLogged(message);
+        }
+    }
+
     public void AssertVerbosity(LoggerVerbosity expected) =>
         Verbosity.Should().Be(expected, "Logger verbosity mismatch");
 

--- a/src/SonarScanner.MSBuild.Shim/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.Shim/Resources.Designer.cs
@@ -159,6 +159,51 @@ namespace SonarScanner.MSBuild.Shim {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Using Java found in {0}: {1}.
+        /// </summary>
+        internal static string MSG_JavaExe_Found {
+            get {
+                return ResourceManager.GetString("MSG_JavaExe_Found", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not find Java in {0}: {1}.
+        /// </summary>
+        internal static string MSG_JavaExe_NotFound {
+            get {
+                return ResourceManager.GetString("MSG_JavaExe_NotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not find Java, falling back to using PATH: {0}.
+        /// </summary>
+        internal static string MSG_JavaExe_UsePath {
+            get {
+                return ResourceManager.GetString("MSG_JavaExe_UsePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;JAVA_HOME&apos; environment variable not set.
+        /// </summary>
+        internal static string MSG_JavaHomeNotSet {
+            get {
+                return ResourceManager.GetString("MSG_JavaHomeNotSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found &apos;JAVA_HOME&apos;: {0}.
+        /// </summary>
+        internal static string MSG_JavaHomeSet {
+            get {
+                return ResourceManager.GetString("MSG_JavaHomeSet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Analysis property is already correctly set: {0}={1}.
         /// </summary>
         internal static string MSG_MandatorySettingIsCorrectlySpecified {

--- a/src/SonarScanner.MSBuild.Shim/Resources.resx
+++ b/src/SonarScanner.MSBuild.Shim/Resources.resx
@@ -231,12 +231,6 @@ Possible causes:
     <value>The following projects do not have a valid ProjectGuid and were not built using a valid solution (.sln) thus will be skipped from analysis...
 {0}</value>
   </data>
-  <data name="DEBUG_DumpSonarProjectProperties" xml:space="preserve">
-    <value>Dumping content of sonar-project.properties
-------------------------------------------------------------------------
-{0}
-------------------------------------------------------------------------</value>
-  </data>
   <data name="ERR_TFSProcessorExecutionFailed" xml:space="preserve">
     <value>The TFS Processor did not complete successfully</value>
   </data>
@@ -275,5 +269,26 @@ Possible causes:
   </data>
   <data name="ERR_ScannerEngineExecutionFailed" xml:space="preserve">
     <value>The scanner engine did not complete successfully</value>
+  </data>
+  <data name="MSG_JavaExe_Found" xml:space="preserve">
+    <value>Using Java found in {0}: {1}</value>
+  </data>
+  <data name="MSG_JavaExe_NotFound" xml:space="preserve">
+    <value>Could not find Java in {0}: {1}</value>
+  </data>
+  <data name="DEBUG_DumpSonarProjectProperties" xml:space="preserve">
+    <value>Dumping content of sonar-project.properties
+------------------------------------------------------------------------
+{0}
+------------------------------------------------------------------------</value>
+  </data>
+  <data name="MSG_JavaHomeSet" xml:space="preserve">
+    <value>Found 'JAVA_HOME': {0}</value>
+  </data>
+  <data name="MSG_JavaHomeNotSet" xml:space="preserve">
+    <value>'JAVA_HOME' environment variable not set</value>
+  </data>
+  <data name="MSG_JavaExe_UsePath" xml:space="preserve">
+    <value>Could not find Java, falling back to using PATH: {0}</value>
   </data>
 </root>

--- a/src/SonarScanner.MSBuild.Shim/SonarEngineWrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarEngineWrapper.cs
@@ -24,11 +24,13 @@ public class SonarEngineWrapper
 {
     private readonly IRuntime runtime;
     private readonly IProcessRunner processRunner;
+    private readonly string javaFileName;
 
     public SonarEngineWrapper(IRuntime runtime, IProcessRunner processRunner)
     {
         this.runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
         this.processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
+        javaFileName = runtime.OperatingSystem.IsUnix() ? "java" : "java.exe";
     }
 
     public virtual bool Execute(AnalysisConfig config, string standardInput)
@@ -79,7 +81,7 @@ public class SonarEngineWrapper
         if (Environment.GetEnvironmentVariable(EnvironmentVariables.JavaHomeVariableName) is { Length: > 0 } javaHome)
         {
             runtime.Logger.LogInfo(Resources.MSG_JavaHomeSet, javaHome);
-            var javaHomeExe = Path.Combine(javaHome, "bin", runtime.OperatingSystem.IsUnix() ? "java" : "java.exe");
+            var javaHomeExe = Path.Combine(javaHome, "bin", javaFileName);
             if (runtime.File.Exists(javaHomeExe))
             {
                 runtime.Logger.LogInfo(Resources.MSG_JavaExe_Found, EnvironmentVariables.JavaHomeVariableName, javaHomeExe);
@@ -100,7 +102,7 @@ public class SonarEngineWrapper
 
     private string JavaFromPath()
     {
-        runtime.Logger.LogInfo(Resources.MSG_JavaExe_UsePath, runtime.OperatingSystem.IsUnix() ? "java" : "java.exe");
-        return runtime.OperatingSystem.IsUnix() ? "java" : "java.exe"; // Rely on Proccess inbuilt PATH support
+        runtime.Logger.LogInfo(Resources.MSG_JavaExe_UsePath, javaFileName);
+        return javaFileName; // Rely on Proccess inbuilt PATH support
     }
 }


### PR DESCRIPTION
[SCAN4NET-837](https://sonarsource.atlassian.net/browse/SCAN4NET-837)

`We need the "Find java.exe like the batch/bash scripts" task next.`
[V5 ScannerCli .bat](https://github.com/SonarSource/sonar-scanner-cli/blob/5.0.2.4997/src/main/assembly/bin/sonar-scanner.bat)

The above script has 3 main logical steps for finding the java.exe:

- Check embedded java if `use_embedded_jre` 
- Check `JAVA_HOME` if `JAVA_HOME`
- fallback to the system `PATH`

from Martin regarding `use_embedded_jre` 
> The emebbed JRE is not relevant for us. It is used by the standalone scanner-cli only.

from Martin regarding the %PATH% fallback:
> Regarding the "PATH" fallback:
> I think it is the best to rely on the Process own logic. We set [UseShellExecute = false](https://github.com/SonarSource/sonar-scanner-msbuild/blob/4bd3987abe203922b423dbe877c5b52ea908624b/src/SonarScanner.MSBuild.Common/ProcessRunner.cs?plain=1#L64C1-L64C88) and this enables %PATH% support out of the box: https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-diagnostics-processstartinfo-useshellexecute#workingdirectory
> When [UseShellExecute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.useshellexecute#system-diagnostics-processstartinfo-useshellexecute) is false, the [FileName](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.filename#system-diagnostics-processstartinfo-filename) property can be either a fully qualified path to the executable, or a simple executable name that the system will attempt to find within folders specified by the PATH environment variable. The interpretation of the search path depends on the operating system. For more information, enter HELP PATH or man sh at a command prompt.
> 

> Alexander Meseldzija
>   perfect :D
>   So its just
>   CheckJavaExePath
>   Check JAVA_HOME
>   fallback to path
> Martin Strecker
>   Sounds good to me.

[SCAN4NET-837]: https://sonarsource.atlassian.net/browse/SCAN4NET-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ