### PR TITLE
SCAN4NET-745 "EnsureFileIsDownloaded" should attempt to re-download the file if the file in cache is invalid

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/CachedDownloaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/CachedDownloaderTests.cs
@@ -237,7 +237,7 @@ public sealed class CachedDownloaderTests : IDisposable
         result.Should().BeOfType<DownloadSuccess>().Which.FilePath.Should().Be(DownloadFilePath);
         runtime.File.Received(1).Create(TempFilePath);
         runtime.File.Received(1).Move(TempFilePath, DownloadFilePath);
-        runtime.File.DebugMessages.Should().BeEquivalentTo(
+        runtime.Logger.DebugMessages.Should().BeEquivalentTo(
             $"The file was already downloaded from the server and stored at '{DownloadFilePath}'.",
             $"The checksum of the downloaded file is 'someOtherHash' and the expected checksum is '{ExpectedSha}'.",
             $"Deleting file '{DownloadFilePath}'.",

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/CachedDownloaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/CachedDownloaderTests.cs
@@ -237,6 +237,7 @@ public sealed class CachedDownloaderTests : IDisposable
         result.Should().BeOfType<DownloadSuccess>().Which.FilePath.Should().Be(DownloadFilePath);
         runtime.File.Received(1).Delete(DownloadFilePath);
         runtime.File.Received(1).Move(TempFilePath, DownloadFilePath);
+        runtime.File.Received(1).Create(TempFilePath);
         runtime.Logger.DebugMessages.Should().BeEquivalentTo(
             $"The file was already downloaded from the server and stored at '{DownloadFilePath}'.",
             $"The checksum of the downloaded file is 'someOtherHash' and the expected checksum is '{ExpectedSha}'.",

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/CachedDownloaderTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Caching/CachedDownloaderTests.cs
@@ -235,7 +235,7 @@ public sealed class CachedDownloaderTests : IDisposable
         var result = await ExecuteDownloadFileAsync(new MemoryStream(downloadContentArray));
 
         result.Should().BeOfType<DownloadSuccess>().Which.FilePath.Should().Be(DownloadFilePath);
-        runtime.File.Received(1).Create(TempFilePath);
+        runtime.File.Received(1).Delete(DownloadFilePath);
         runtime.File.Received(1).Move(TempFilePath, DownloadFilePath);
         runtime.Logger.DebugMessages.Should().BeEquivalentTo(
             $"The file was already downloaded from the server and stored at '{DownloadFilePath}'.",

--- a/src/SonarScanner.MSBuild.PreProcessor/Caching/CachedDownloader.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Caching/CachedDownloader.cs
@@ -128,9 +128,9 @@ public class CachedDownloader
 
     private async Task<DownloadError> EnsureFileIsDownloaded(Func<Task<Stream>> download)
     {
-        if (fileWrapper.Exists(downloadTarget))
+        if (fileWrapper.Exists(downloadTarget) && ValidateFile() is null)
         {
-            return ValidateFile();
+            return null;
         }
         logger.LogDebug(Resources.MSG_StartingFileDownload);
         if (await DownloadAndValidateFile(download) is { } exception)


### PR DESCRIPTION
[SCAN4NET-745](https://sonarsource.atlassian.net/browse/SCAN4NET-745)



[SCAN4NET-745]: https://sonarsource.atlassian.net/browse/SCAN4NET-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ