### PR TITLE
SCAN4NET-869 Use IRuntime in TruststorePropertiesProcessor

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessorTests.cs
@@ -18,10 +18,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using NSubstitute.ReceivedExtensions;
-using SonarScanner.MSBuild.PreProcessor.AnalysisConfigProcessing.Processors;
+#pragma warning disable S3994 // we are specifically testing string urls
 
-namespace SonarScanner.MSBuild.PreProcessor.Test.AnalysisConfigProcessing.Processors;
+using NSubstitute.ReceivedExtensions;
+
+namespace SonarScanner.MSBuild.PreProcessor.AnalysisConfigProcessing.Processors.Test;
 
 [TestClass]
 public class TruststorePropertiesProcessorTests
@@ -79,7 +80,6 @@ public class TruststorePropertiesProcessorTests
     [TestMethod]
     public void Update_TrustStorePropertiesValue_Mapped()
     {
-        // Arrange
         var trustorePath = @"C:\path\to\truststore.pfx";
         var cmdLineArgs = new ListPropertiesProvider();
         cmdLineArgs.AddProperty(SonarProperties.TruststorePath, trustorePath);
@@ -95,7 +95,6 @@ public class TruststorePropertiesProcessorTests
             ]
         };
 
-        // Act
         processor.Update(config);
 
         AssertExpectedScannerOptsSettings("javax.net.ssl.trustStore", @"""C:/path/to/truststore.pfx""", config);
@@ -146,11 +145,11 @@ public class TruststorePropertiesProcessorTests
 
         processor.Update(config);
         config.ScannerOptsSettings.Should().ContainSingle().Which.Should().BeEquivalentTo(
-        new
-        {
-            Id = "javax.net.ssl.trustStore",
-            Value = @"""C:/path/to/truststore.pfx""",
-        });
+            new
+            {
+                Id = "javax.net.ssl.trustStore",
+                Value = @"""C:/path/to/truststore.pfx""",
+            });
         Property.TryGetProperty("javax.net.ssl.trustStore", config.LocalSettings, out _).Should().BeFalse();
         Property.TryGetProperty("javax.net.ssl.trustStorePassword", config.LocalSettings, out _).Should().BeFalse();
         Property.TryGetProperty("javax.net.ssl.trustStorePassword", config.ScannerOptsSettings, out _).Should().BeFalse();
@@ -159,7 +158,6 @@ public class TruststorePropertiesProcessorTests
     [TestMethod]
     public void Update_DefaultPropertyValues()
     {
-        // Arrange
         var sonarUserHome = Path.Combine("~", ".sonar");
         var defaultTruststorePath = Path.Combine(sonarUserHome, SonarPropertiesDefault.TruststorePath);
         var cmdLineArgs = new ListPropertiesProvider();
@@ -170,7 +168,6 @@ public class TruststorePropertiesProcessorTests
         var processor = CreateProcessor(CreateProcessedArgs(cmdLineArgs, fileWrapper));
         var config = new AnalysisConfig { LocalSettings = [new Property(SonarProperties.UserHome, sonarUserHome)] };
 
-        // Act
         processor.Update(config);
 
         config.LocalSettings.Should().ContainSingle(x => x.Id == SonarProperties.UserHome && x.Value == sonarUserHome);
@@ -186,13 +183,11 @@ public class TruststorePropertiesProcessorTests
     [DataRow(SonarProperties.HostUrl, @"http://localhost:9000\")]
     public void Update_UnmappedProperties(string id, string value)
     {
-        // Arrange
         var cmdLineArgs = new ListPropertiesProvider();
         cmdLineArgs.AddProperty(id, value);
         var processor = CreateProcessor(CreateProcessedArgs(cmdLineArgs));
         var config = new AnalysisConfig { LocalSettings = [new Property(id, value)] };
 
-        // Act
         processor.Update(config);
 
         config.LocalSettings.Should().ContainSingle(x => x.Id == id && x.Value == value);
@@ -205,17 +200,14 @@ public class TruststorePropertiesProcessorTests
     [DataRow(@"C:\path\to\My trustore.pfx", @"""C:/path/to/My trustore.pfx""")]
     public void Update_MapsTruststorePathToScannerOpts_Windows(string input, string expected)
     {
-        // Arrange
         var cmdLineArgs = new ListPropertiesProvider();
         cmdLineArgs.AddProperty(SonarProperties.HostUrl, "https://localhost:9000");
         cmdLineArgs.AddProperty(SonarProperties.TruststorePath, input);
         var processor = CreateProcessor(CreateProcessedArgs(cmdLineArgs));
         var config = new AnalysisConfig { LocalSettings = [new Property(SonarProperties.TruststorePath, input)] };
 
-        // Act
         processor.Update(config);
 
-        // Assert
         config.LocalSettings.Should().BeEmpty();
         config.ScannerOptsSettings.Should().ContainSingle();
         config.HasBeginStepCommandLineTruststorePassword.Should().BeFalse();
@@ -232,7 +224,6 @@ public class TruststorePropertiesProcessorTests
     [DataRow(@"""itchange""", @"""itchange""")]
     public void Update_MapsTruststorePasswordToScannerOpts_Windows(string input, string expected)
     {
-        // Arrange
         var cmdLineArgs = new ListPropertiesProvider();
         cmdLineArgs.AddProperty(SonarProperties.TruststorePath, "some/path");
         cmdLineArgs.AddProperty(SonarProperties.TruststorePassword, input);
@@ -247,10 +238,8 @@ public class TruststorePropertiesProcessorTests
             ]
         };
 
-        // Act
         processor.Update(config);
 
-        // Assert
         config.LocalSettings.Should().BeEmpty();
         config.ScannerOptsSettings.Should().ContainSingle();
         config.HasBeginStepCommandLineTruststorePassword.Should().BeTrue();
@@ -262,17 +251,14 @@ public class TruststorePropertiesProcessorTests
     [DataRow("/path/to/my trustore.pfx", "/path/to/my trustore.pfx")]
     public void Update_MapsTruststorePathToScannerOpts_Linux(string input, string expected)
     {
-        // Arrange
         var cmdLineArgs = new ListPropertiesProvider();
         cmdLineArgs.AddProperty(SonarProperties.HostUrl, "https://localhost:9000");
         cmdLineArgs.AddProperty(SonarProperties.TruststorePath, input);
         var processor = CreateProcessor(CreateProcessedArgs(cmdLineArgs), platform: PlatformOS.Linux);
         var config = new AnalysisConfig { LocalSettings = [new Property(SonarProperties.TruststorePath, input)] };
 
-        // Act
         processor.Update(config);
 
-        // Assert
         config.LocalSettings.Should().BeEmpty();
         config.ScannerOptsSettings.Should().ContainSingle();
         config.HasBeginStepCommandLineTruststorePassword.Should().BeFalse();
@@ -286,7 +272,6 @@ public class TruststorePropertiesProcessorTests
     [DataRow("it change", "it change")]
     public void Update_MapsTruststorePasswordToScannerOpts_Linux(string input, string expected)
     {
-        // Arrange
         var cmdLineArgs = new ListPropertiesProvider();
         cmdLineArgs.AddProperty(SonarProperties.HostUrl, "https://localhost:9000");
         cmdLineArgs.AddProperty(SonarProperties.TruststorePassword, input);
@@ -300,10 +285,8 @@ public class TruststorePropertiesProcessorTests
         using var envScope = new EnvironmentVariableScope();
         envScope.SetVariable("JAVA_HOME", javaHome);
 
-        // Act
         processor.Update(config);
 
-        // Assert
         config.LocalSettings.Should().BeEmpty();
         config.ScannerOptsSettings.Should().ContainSingle();
         config.HasBeginStepCommandLineTruststorePassword.Should().BeTrue();
@@ -315,16 +298,13 @@ public class TruststorePropertiesProcessorTests
     [TestMethod]
     public void Update_TrustedByTheSystem_Windows()
     {
-        // Arrange
         var cmdLineArgs = new ListPropertiesProvider();
         cmdLineArgs.AddProperty(SonarProperties.HostUrl, "https://localhost:9000");
         var processor = CreateProcessor(CreateProcessedArgs(cmdLineArgs));
         var config = new AnalysisConfig { LocalSettings = [] };
 
-        // Act
         processor.Update(config);
 
-        // Assert
         config.LocalSettings.Should().BeEmpty();
         config.ScannerOptsSettings.Should().ContainSingle();
         AssertExpectedScannerOptsSettings("javax.net.ssl.trustStoreType", "Windows-ROOT", config);
@@ -334,7 +314,6 @@ public class TruststorePropertiesProcessorTests
     [TestMethod]
     public void Update_TrustedByTheSystemPasswordProvided_Windows()
     {
-        // Arrange
         var javaHome = Path.Combine("C:", "Program Files", "Java", "jre");
         var javaHomeCacerts = Path.Combine(javaHome, "lib", "security", "cacerts");
         var runtime = new TestRuntime();
@@ -347,10 +326,8 @@ public class TruststorePropertiesProcessorTests
         envScope.SetVariable("JAVA_HOME", javaHome);
         envScope.SetVariable("SONAR_SCANNER_OPTS", "-Xmx2048m -Djavax.net.ssl.trustStorePassword=itchange");
 
-        // Act
         processor.Update(config);
 
-        // Assert
         config.LocalSettings.Should().BeEmpty();
         config.ScannerOptsSettings.Should().ContainSingle();
         runtime.File.Received(Quantity.None()).Exists(javaHomeCacerts);
@@ -360,7 +337,6 @@ public class TruststorePropertiesProcessorTests
     [TestMethod]
     public void Update_TrustedByTheSystem_Linux()
     {
-        // Arrange
         var javaHome = Path.Combine("/home", "user", "java");
         var javaHomeCacerts = Path.Combine(javaHome, "lib", "security", "cacerts");
         var runtime = new TestRuntime();
@@ -373,10 +349,8 @@ public class TruststorePropertiesProcessorTests
         using var envScope = new EnvironmentVariableScope();
         envScope.SetVariable("JAVA_HOME", javaHome);
 
-        // Act
         processor.Update(config);
 
-        // Assert
         config.LocalSettings.Should().BeEmpty();
         config.ScannerOptsSettings.Should().ContainSingle();
         AssertExpectedScannerOptsSettings("javax.net.ssl.trustStore", javaHomeCacerts.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), config);
@@ -385,7 +359,6 @@ public class TruststorePropertiesProcessorTests
     [TestMethod]
     public void Update_TrustedByTheSystemCacertNotFound_Linux()
     {
-        // Arrange
         var javaHome = Path.Combine("/home", "user", "java");
         var javaHomeCacerts = Path.Combine(javaHome, "lib", "security", "cacerts");
         var runtime = new TestRuntime();
@@ -398,10 +371,8 @@ public class TruststorePropertiesProcessorTests
         using var envScope = new EnvironmentVariableScope();
         envScope.SetVariable("JAVA_HOME", javaHome);
 
-        // Act
         processor.Update(config);
 
-        // Assert
         config.LocalSettings.Should().BeEmpty();
         config.ScannerOptsSettings.Should().BeEmpty();
         runtime.Logger.AssertDebugLogged($"Unable to find Java Keystore file. Lookup path: '{javaHomeCacerts}'.");
@@ -410,7 +381,6 @@ public class TruststorePropertiesProcessorTests
     [TestMethod]
     public void Update_TrustedByTheSystemNoJavaHome_Linux()
     {
-        // Arrange
         var cmdLineArgs = new ListPropertiesProvider();
         cmdLineArgs.AddProperty(SonarProperties.HostUrl, "https://localhost:9000");
         var processRunner = Substitute.For<IProcessRunner>();
@@ -426,10 +396,8 @@ public class TruststorePropertiesProcessorTests
         using var envScope = new EnvironmentVariableScope();
         envScope.SetVariable("JAVA_HOME", null);
 
-        // Act
         processor.Update(config);
 
-        // Assert
         config.LocalSettings.Should().BeEmpty();
         config.ScannerOptsSettings.Should().ContainSingle();
         AssertExpectedScannerOptsSettings("javax.net.ssl.trustStore", "/java/home/lib/security/cacerts", config);
@@ -441,7 +409,6 @@ public class TruststorePropertiesProcessorTests
     [TestMethod]
     public void Update_TrustedByTheSystemPasswordProvided_Linux()
     {
-        // Arrange
         var javaHome = Path.Combine("/home", "user", "java");
         var javaHomeCacerts = Path.Combine(javaHome, "lib", "security", "cacerts");
         var runtime = new TestRuntime();
@@ -455,10 +422,8 @@ public class TruststorePropertiesProcessorTests
         envScope.SetVariable("JAVA_HOME", javaHome);
         envScope.SetVariable("SONAR_SCANNER_OPTS", "-Xmx2048m -Djavax.net.ssl.trustStorePassword=itchange");
 
-        // Act
         processor.Update(config);
 
-        // Assert
         config.LocalSettings.Should().BeEmpty();
         config.ScannerOptsSettings.Should().ContainSingle();
         config.HasBeginStepCommandLineTruststorePassword.Should().BeFalse();
@@ -468,7 +433,6 @@ public class TruststorePropertiesProcessorTests
     [TestMethod]
     public void Update_TrustedByTheSystemSonarOptsSet_Linux()
     {
-        // Arrange
         var javaHome = Path.Combine("/home", "user", "java");
         var javaHomeCacerts = Path.Combine(javaHome, "lib", "security", "cacerts");
         var runtime = new TestRuntime();
@@ -482,10 +446,8 @@ public class TruststorePropertiesProcessorTests
         envScope.SetVariable("JAVA_HOME", javaHome);
         envScope.SetVariable("SONAR_SCANNER_OPTS", "-Xmx2048m");
 
-        // Act
         processor.Update(config);
 
-        // Assert
         config.LocalSettings.Should().BeEmpty();
         config.ScannerOptsSettings.Should().ContainSingle();
         AssertExpectedScannerOptsSettings("javax.net.ssl.trustStore", javaHomeCacerts.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar), config);
@@ -510,7 +472,8 @@ public class TruststorePropertiesProcessorTests
     }
 
     private static ProcessedArgs CreateProcessedArgs(IAnalysisPropertyProvider cmdLineProvider = null, IFileWrapper fileWrapper = null) =>
-        new("valid.key",
+        new(
+            "valid.key",
             "valid.name",
             "1.0",
             "organization",

--- a/src/SonarScanner.MSBuild.PreProcessor/AnalysisConfigProcessing/AnalysisConfigGenerator.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/AnalysisConfigProcessing/AnalysisConfigGenerator.cs
@@ -95,10 +95,7 @@ public static class AnalysisConfigGenerator
         new TruststorePropertiesProcessor(
             localSettings,
             serverProperties,
-            FileWrapper.Instance,
-            DirectoryWrapper.Instance,
             processRunner,
-            runtime.Logger,
-            runtime.OperatingSystem)
+            runtime)
     ];
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessor.cs
@@ -29,11 +29,8 @@ namespace SonarScanner.MSBuild.PreProcessor.AnalysisConfigProcessing.Processors;
 public class TruststorePropertiesProcessor(
     ProcessedArgs localSettings,
     IDictionary<string, string> serverProperties,
-    IFileWrapper fileWrapper,
-    IDirectoryWrapper directoryWrapper,
     IProcessRunner processRunner,
-    ILogger logger,
-    OperatingSystemProvider operatingSystemProvider)
+    IRuntime runtime)
     : AnalysisConfigProcessorBase(localSettings, serverProperties)
 {
     public override void Update(AnalysisConfig config)
@@ -47,9 +44,9 @@ public class TruststorePropertiesProcessor(
 
         if (truststorePath is null)
         {
-            if (operatingSystemProvider.IsUnix())
+            if (runtime.OperatingSystem.IsUnix())
             {
-                var truststoreResolver = new LocalJreTruststoreResolver(fileWrapper, directoryWrapper, processRunner, logger);
+                var truststoreResolver = new LocalJreTruststoreResolver(runtime.File, runtime.Directory, processRunner, runtime.Logger);
                 truststorePath = truststoreResolver.UnixTruststorePath(LocalSettings);
             }
             else
@@ -89,7 +86,7 @@ public class TruststorePropertiesProcessor(
     private string EnsureSurroundedByQuotes(string str)
     {
         if (str is null
-            || operatingSystemProvider.IsUnix()
+            || runtime.OperatingSystem.IsUnix()
             || (str.StartsWith("\"") && str.EndsWith("\"")))
         {
             return str;

--- a/src/SonarScanner.MSBuild.PreProcessor/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessor.cs
@@ -26,13 +26,18 @@ namespace SonarScanner.MSBuild.PreProcessor.AnalysisConfigProcessing.Processors;
 /// Map property name to another property name and/or value to pass them through the SONAR_SCANNER_OPTS
 /// environment variable to Scanner CLI 5.
 /// </summary>
-public class TruststorePropertiesProcessor(
-    ProcessedArgs localSettings,
-    IDictionary<string, string> serverProperties,
-    IProcessRunner processRunner,
-    IRuntime runtime)
-    : AnalysisConfigProcessorBase(localSettings, serverProperties)
+public class TruststorePropertiesProcessor : AnalysisConfigProcessorBase
 {
+    private readonly IProcessRunner processRunner;
+    private readonly IRuntime runtime;
+
+    public TruststorePropertiesProcessor(ProcessedArgs localSettings, IDictionary<string, string> serverProperties, IProcessRunner processRunner, IRuntime runtime)
+         : base(localSettings, serverProperties)
+    {
+        this.processRunner = processRunner;
+        this.runtime = runtime;
+    }
+
     public override void Update(AnalysisConfig config)
     {
         if (Uri.TryCreate(LocalSettings.ServerInfo.ServerUrl, UriKind.Absolute, out var uri) && uri.Scheme != Uri.UriSchemeHttps)


### PR DESCRIPTION
[SCAN4NET-869](https://sonarsource.atlassian.net/browse/SCAN4NET-869)

Part of SCAN4NET-789

Skip first 5 commits when reviewing, they come from other branches.

[SCAN4NET-869]: https://sonarsource.atlassian.net/browse/SCAN4NET-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ