### PR TITLE
SCAN4NET-900 Publish test results in Azure Devops

### DIFF
--- a/Tests/SonarScanner.MSBuild.Shim.Test/AdditionalFilesServiceTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/AdditionalFilesServiceTest.cs
@@ -52,7 +52,7 @@ public class AdditionalFilesServiceTest
     {
         var files = sut.AdditionalFiles(new() { ScanAllAnalysis = true, ServerSettings = null }, ProjectBaseDir);
 
-        files.Sources.Should().NotBeEmpty(because: "this is just for testing");
+        files.Sources.Should().BeEmpty();
         files.Tests.Should().BeEmpty();
         runtime.Directory.ReceivedWithAnyArgs(1).EnumerateDirectories(null, null, default);
         runtime.Directory.ReceivedWithAnyArgs(1).EnumerateFiles(null, null, default);

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -326,7 +326,7 @@ stages:
             condition: succeededOrFailed()
             inputs:
               testRunner: VSTest
-              testResultsFiles: $(Build.SourcesDirectory)/TestResults/*.trx
+              testResultsFiles: $(Build.SourcesDirectory)/TestResults/*.trx # Not **/*.trx because there are invalid trx files from test resources in subdirectories
               testRunTitle: UTs Windows
 
           - task: PublishBuildArtifacts@1

--- a/templates/unix-qa-stage.yml
+++ b/templates/unix-qa-stage.yml
@@ -31,7 +31,7 @@ stages:
             displayName: 'Run dotnet test'
             inputs:
               command: 'custom'
-              custom: 'test'
+              custom: 'test' # Run test as custom command, because we need to control the test result upload via PublishTestResults (see there for details)
               arguments: '--framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=No${{ parameters.name }}" --logger trx --results-directory "$(Build.SourcesDirectory)/TestResults"'
             env:
               ARTIFACTORY_USER: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
@@ -41,7 +41,7 @@ stages:
             inputs:
               testRunTitle: UTs ${{ parameters.name }}
               testRunner: VSTest
-              testResultsFiles: '$(Build.SourcesDirectory)/TestResults/*.trx'
+              testResultsFiles: '$(Build.SourcesDirectory)/TestResults/*.trx' # Not **/*.trx because there are invalid trx files from test resources in subdirectories
 
       - template: ./its-jobs.yml
         parameters:


### PR DESCRIPTION
[SCAN4NET-900](https://sonarsource.atlassian.net/browse/SCAN4NET-900)

Part of SCAN4NET-710

See SCAN4NET-900 for a summary of all UT trx upload failures.

The test results are published correctly now:
https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=124174&view=ms.vss-test-web.build-test-results-tab

<img width="1628" height="802" alt="image" src="https://github.com/user-attachments/assets/16268b21-a109-488f-82f6-b83a22aaa710" />


[SCAN4NET-900]: https://sonarsource.atlassian.net/browse/SCAN4NET-900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ