### PR TITLE
SCAN4NET-860 Scanner Engine: Fix Proxy ITs

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/ProcessRunnerTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/ProcessRunnerTests.cs
@@ -375,7 +375,7 @@ public class ProcessRunnerTests
     public void ProcRunner_ArgumentQuoting()
     {
         var testDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
-        var expected = new[]
+        var expected = new ProcessRunnerArguments.Argument[]
         {
             "unquoted",
             "\"quoted\"",
@@ -414,10 +414,10 @@ public class ProcessRunnerTests
         {
             ProcessArgs = new ProcessRunnerArguments(LogArgsPath(), false)
             {
-                CmdLineArgs = new ProcessRunnerArguments.ArgumentList([
+                CmdLineArgs = [
                     new("arg1", true),
                     new("\"arg2\"", true),
-                    new("\"arg with spaces\"", true)]),
+                    new("\"arg with spaces\"", true)],
                 WorkingDirectory = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext)
             }
         };
@@ -433,10 +433,10 @@ public class ProcessRunnerTests
         {
             ProcessArgs = new ProcessRunnerArguments(LogArgsPath(), false)
             {
-                CmdLineArgs = new ProcessRunnerArguments.ArgumentList([
+                CmdLineArgs = [
                     new("arg1", false),
                     new("\"arg2\"", false),
-                    new("\"arg with spaces\"", false)]),
+                    new("\"arg with spaces\"", false)],
                 WorkingDirectory = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext)
             }
         };
@@ -448,7 +448,7 @@ public class ProcessRunnerTests
     [TestMethod]
     public void ProcRunner_ArgumentQuotingForwardedByBatchScript()
     {
-        var expected = new[]
+        var expected = new ProcessRunnerArguments.Argument[]
         {
             "unquoted",
             "\"quoted\"",
@@ -476,7 +476,7 @@ public class ProcessRunnerTests
     [TestMethod]
     public void ProcRunner_ArgumentQuotingScanner()
     {
-        var expected = new[]
+        var expected = new ProcessRunnerArguments.Argument[]
         {
             @"-Dsonar.scanAllFiles=true",
             @"-Dproject.settings=D:\DevLibTest\ClassLibraryTest.sonarqube\out\sonar-project.properties",
@@ -535,13 +535,13 @@ public class ProcessRunnerTests
     public void ProcRunner_DoNotLogSensitiveData()
     {
         // Public args - should appear in the log
-        var publicArgs = new[]
+        var publicArgs = new ProcessRunnerArguments.Argument[]
         {
             "public1",
             "public2",
             "/d:sonar.projectKey=my.key"
         };
-        var sensitiveArgs = new[]
+        var sensitiveArgs = new ProcessRunnerArguments.Argument[]
         {
             // Public args - should appear in the log
             "public1", "public2", "/dmy.key=value",
@@ -585,7 +585,7 @@ public class ProcessRunnerTests
         // Check public arguments are logged but private ones are not
         foreach (var arg in publicArgs)
         {
-            context.Logger.DebugMessages.Should().ContainSingle(x => x.Contains(arg));
+            context.Logger.DebugMessages.Should().ContainSingle(x => x.Contains(arg.Value));
         }
         context.Logger.Should().HaveDebugs(
             "Setting environment variable 'SENSITIVE_DATA'. Value: -D<sensitive data removed>",
@@ -703,6 +703,9 @@ public class ProcessRunnerTests
 
         public void ResultErrorOutputShouldBe(string expected) =>
             result.ErrorOutput.Should().Be(expected, "Unexpected error output");
+
+        public void AssertExpectedLogContents(params ProcessRunnerArguments.Argument[] expected) =>
+            AssertExpectedLogContents(expected.Select(x => x.Value).ToArray());
 
         public void AssertExpectedLogContents(params string[] expected)
         {

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
@@ -64,7 +64,7 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-jar"), new("engine.jar")]),
+            CmdLineArgs = new ProcessRunnerArguments.Argument[] { "-jar", "engine.jar" },
             StandardInput = SampleInput,
         });
         context.Runtime.Logger.Should().HaveInfos(
@@ -140,7 +140,7 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Env", true), new("-jar"), new("engine.jar")]),
+            CmdLineArgs = new ProcessRunnerArguments.Argument[] { new("-DJavaParam=Env", true), new("-jar"), new("engine.jar") },
             StandardInput = SampleInput,
         });
     }
@@ -161,7 +161,7 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Config", true), "-jar", "engine.jar"]),
+            CmdLineArgs = new ProcessRunnerArguments.Argument[] { new("-DJavaParam=Config", true), "-jar", "engine.jar" },
             StandardInput = SampleInput,
         });
     }
@@ -182,7 +182,7 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-jar"), new("engine.jar")]),
+            CmdLineArgs = new ProcessRunnerArguments.Argument[] { "-jar", "engine.jar" },
             StandardInput = SampleInput,
             WorkingDirectory = @"C:\MyWorkingDir",
         });
@@ -207,7 +207,7 @@ public class SonarEngineWrapperTest
         {
             ExeName = context.ResolvedJavaExe,
 
-            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Env", true), new("-DJavaParam=Config", true), new("-jar", false), new("engine.jar", false)]),
+            CmdLineArgs = new ProcessRunnerArguments.Argument[] { new("-DJavaParam=Env", true), new("-DJavaParam=Config", true), "-jar", "engine.jar" },
             StandardInput = SampleInput,
         });
     }
@@ -232,13 +232,15 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([
+            CmdLineArgs = new ProcessRunnerArguments.Argument[]
+            {
                 new("-DJavaParam=Env -DJavaOtherParam=Value -DSomeOtherParam=AnotherValue", true),
                 new("-DJavaParam=Config", true),
                 new("-DSomeParam=SomeValue", true),
                 new("-DOtherParam=OtherValue", true),
                 new("-jar", false),
-                new("engine.jar", false)]),
+                new("engine.jar", false)
+            },
             StandardInput = SampleInput,
         });
     }

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
@@ -161,7 +161,7 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Config", true), new("-jar"), new("engine.jar")]),
+            CmdLineArgs = new ProcessRunnerArguments.ArgumentList(["-DJavaParam=Config", "-jar", "engine.jar"]),
             StandardInput = SampleInput,
         });
     }
@@ -207,7 +207,7 @@ public class SonarEngineWrapperTest
         {
             ExeName = context.ResolvedJavaExe,
 
-            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Env", true), new("-DJavaParam=Config", true), new("-jar"), new("engine.jar")]),
+            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Env", true), new("-DJavaParam=Config", false), new("-jar", false), new("engine.jar", false)]),
             StandardInput = SampleInput,
         });
     }
@@ -234,11 +234,11 @@ public class SonarEngineWrapperTest
             ExeName = context.ResolvedJavaExe,
             CmdLineArgs = new ProcessRunnerArguments.ArgumentList([
                 new("-DJavaParam=Env -DJavaOtherParam=Value -DSomeOtherParam=AnotherValue", true),
-                new("-DJavaParam=Config", true),
-                new("-DSomeParam=SomeValue", true),
-                new("-DOtherParam=OtherValue", true),
-                new("-jar"),
-                new("engine.jar")]),
+                new("-DJavaParam=Config", false),
+                new("-DSomeParam=SomeValue", false),
+                new("-DOtherParam=OtherValue", false),
+                new("-jar", false),
+                new("engine.jar", false)]),
             StandardInput = SampleInput,
         });
     }

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
@@ -161,7 +161,7 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = new ProcessRunnerArguments.ArgumentList(["-DJavaParam=Config", "-jar", "engine.jar"]),
+            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Config", true), "-jar", "engine.jar"]),
             StandardInput = SampleInput,
         });
     }
@@ -207,7 +207,7 @@ public class SonarEngineWrapperTest
         {
             ExeName = context.ResolvedJavaExe,
 
-            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Env", true), new("-DJavaParam=Config", false), new("-jar", false), new("engine.jar", false)]),
+            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Env", true), new("-DJavaParam=Config", true), new("-jar", false), new("engine.jar", false)]),
             StandardInput = SampleInput,
         });
     }
@@ -234,9 +234,9 @@ public class SonarEngineWrapperTest
             ExeName = context.ResolvedJavaExe,
             CmdLineArgs = new ProcessRunnerArguments.ArgumentList([
                 new("-DJavaParam=Env -DJavaOtherParam=Value -DSomeOtherParam=AnotherValue", true),
-                new("-DJavaParam=Config", false),
-                new("-DSomeParam=SomeValue", false),
-                new("-DOtherParam=OtherValue", false),
+                new("-DJavaParam=Config", true),
+                new("-DSomeParam=SomeValue", true),
+                new("-DOtherParam=OtherValue", true),
                 new("-jar", false),
                 new("engine.jar", false)]),
             StandardInput = SampleInput,

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarEngineWrapperTest.cs
@@ -64,7 +64,7 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = (string[])["-jar", "engine.jar"],
+            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-jar"), new("engine.jar")]),
             StandardInput = SampleInput,
         });
         context.Runtime.Logger.Should().HaveInfos(
@@ -140,7 +140,7 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = (string[])["-DJavaParam=Env", "-jar", "engine.jar"],
+            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Env", true), new("-jar"), new("engine.jar")]),
             StandardInput = SampleInput,
         });
     }
@@ -161,7 +161,7 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = (string[])["-DJavaParam=Config", "-jar", "engine.jar"],
+            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Config", true), new("-jar"), new("engine.jar")]),
             StandardInput = SampleInput,
         });
     }
@@ -182,7 +182,7 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = (string[])["-jar", "engine.jar"],
+            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-jar"), new("engine.jar")]),
             StandardInput = SampleInput,
             WorkingDirectory = @"C:\MyWorkingDir",
         });
@@ -206,7 +206,8 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = (string[])["-DJavaParam=Env", "-DJavaParam=Config", "-jar", "engine.jar"],
+
+            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([new("-DJavaParam=Env", true), new("-DJavaParam=Config", true), new("-jar"), new("engine.jar")]),
             StandardInput = SampleInput,
         });
     }
@@ -231,7 +232,13 @@ public class SonarEngineWrapperTest
         context.Runner.SuppliedArguments.Should().BeEquivalentTo(new
         {
             ExeName = context.ResolvedJavaExe,
-            CmdLineArgs = (string[])["-DJavaParam=Env -DJavaOtherParam=Value -DSomeOtherParam=AnotherValue", "-DJavaParam=Config", "-DSomeParam=SomeValue", "-DOtherParam=OtherValue", "-jar", "engine.jar"],
+            CmdLineArgs = new ProcessRunnerArguments.ArgumentList([
+                new("-DJavaParam=Env -DJavaOtherParam=Value -DSomeOtherParam=AnotherValue", true),
+                new("-DJavaParam=Config", true),
+                new("-DSomeParam=SomeValue", true),
+                new("-DOtherParam=OtherValue", true),
+                new("-jar"),
+                new("engine.jar")]),
             StandardInput = SampleInput,
         });
     }

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
@@ -149,16 +149,19 @@ public class SonarScannerWrapperTests
 
         // Non-sensitive values from the file should not be passed on the command line
         result.CheckArgDoesNotExist("file.not.sensitive.key");
-        result.SuppliedArguments.CmdLineArgs.Select(x => x.Value).Should().BeEquivalentTo(
-            "-Dxxx=yyy",
-            "-Dsonar.password=cmdline.password",                          // sensitive value from cmd line: overrides file value
-            "-Dsonar.clientcert.password=file.clientCertificatePassword", // sensitive value from file
-            "-Dsonar.login=file.username",
-            "-Dsonar.token=file.token",
-            "-Dproject.settings=c:\\foo.props",
-            $"--from=ScannerMSBuild/{Utilities.ScannerVersion}",
-            "--debug",
-            "-Dsonar.scanAllFiles=true");
+        result.SuppliedArguments.CmdLineArgs.Should().BeEquivalentTo(
+            new ProcessRunnerArguments.Argument[]
+            {
+                "-Dxxx=yyy",
+                "-Dsonar.password=cmdline.password",                          // sensitive value from cmd line: overrides file value
+                "-Dsonar.clientcert.password=file.clientCertificatePassword", // sensitive value from file
+                "-Dsonar.login=file.username",
+                "-Dsonar.token=file.token",
+                "-Dproject.settings=c:\\foo.props",
+                $"--from=ScannerMSBuild/{Utilities.ScannerVersion}",
+                "--debug",
+                "-Dsonar.scanAllFiles=true"
+            });
 
         var clientCertPwdIndex = result.CheckArgExists("-Dsonar.clientcert.password=file.clientCertificatePassword"); // sensitive value from file
         var userPwdIndex = result.CheckArgExists("-Dsonar.password=cmdline.password"); // sensitive value from cmd line: overrides file value

--- a/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/SonarScannerWrapperTests.cs
@@ -149,7 +149,7 @@ public class SonarScannerWrapperTests
 
         // Non-sensitive values from the file should not be passed on the command line
         result.CheckArgDoesNotExist("file.not.sensitive.key");
-        result.SuppliedArguments.CmdLineArgs.Should().BeEquivalentTo(
+        result.SuppliedArguments.CmdLineArgs.Select(x => x.Value).Should().BeEquivalentTo(
             "-Dxxx=yyy",
             "-Dsonar.password=cmdline.password",                          // sensitive value from cmd line: overrides file value
             "-Dsonar.clientcert.password=file.clientCertificatePassword", // sensitive value from file
@@ -650,7 +650,7 @@ public class SonarScannerWrapperTests
 
         public void CheckArgDoesNotExist(string argToCheck)
         {
-            var allArgs = testRunner.Runner.SuppliedArguments.CmdLineArgs;
+            var allArgs = testRunner.Runner.SuppliedArguments.CmdLineArgs.Select(x => x.Value);
             allArgs.Should().NotContainMatch(
                 $"*{argToCheck}*",
                 "Not expecting to find the argument. Arg: '{0}', all args: '{1}'",

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/MSBuildExecution/BuildRunner.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/MSBuildExecution/BuildRunner.cs
@@ -53,7 +53,7 @@ public static class BuildRunner
         // Run the build
         var args = new ProcessRunnerArguments(exePath, false)
         {
-            CmdLineArgs = msbuildArgs
+            CmdLineArgs = msbuildArgs.Select(x => new ProcessRunnerArguments.Argument(x)).ToArray()
         };
         var runner = new ProcessRunner(new ConsoleLogger(true));
         var success = runner.Execute(args);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ProxyTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ProxyTest.java
@@ -86,7 +86,6 @@ class ProxyTest {
     var context = AnalysisContext.forServer("ProjectUnderTest")
       .setEnvironmentVariable("SONAR_SCANNER_OPTS", "-Dhttp.nonProxyHosts= -Dhttp.proxyHost=localhost -Dhttp.proxyPort=" + httpProxyPort)
       .setQualityProfile(QualityProfile.CS_S1134);
-    context.begin.setProperty("sonar.scanner.useSonarScannerCLI", "true");  // TODO: remove this in SCAN4NET-860
 
     var logs = context.runFailedAnalysis().end().getLogs();
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
@@ -126,7 +126,7 @@ class SslTest {
 
       if (serverSupportsProvisioning()) {
         assertThat(logs)
-          .contains("Successfully loaded KeyStore of the type [Windows-ROOT]");
+          .contains("Args: -Djavax.net.ssl.trustStoreType=Windows-ROOT");
       }
       else {
         assertThat(logs)
@@ -241,7 +241,7 @@ class SslTest {
       validateAnalysis(context, server);
     }
   }
-  
+
   @Test
   void unmatchedDomainNameInCertificate() {
     try (var server = initSslTestAndServerWithTrustStore("p@ssw0rd42", Path.of(""), "not-localhost", "keystore.p12")) {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
@@ -425,17 +425,16 @@ class SslTest {
     var result = context.runAnalysis();
     var logs = result.end().getLogs();
 
-    var trustStorePath = server.getKeystorePath().replace('\\', '/');
-    var trustStorePassword = server.getKeystorePassword();
-    if (OSPlatform.isWindows()) {
-      trustStorePath = "\"" + trustStorePath + "\"";
-      trustStorePassword = "\"" + trustStorePassword + "\"";
-    }
-
     if (serverSupportsProvisioning()) {
-      assertScannerEngineSuccessfulKeystore(logs, trustStorePath, trustStorePassword);
+      assertScannerEngineSuccessfulKeystore(logs, server.getKeystorePath(), server.getKeystorePassword());
     }
     else {
+      var trustStorePath = server.getKeystorePath().replace('\\', '/');
+      var trustStorePassword = server.getKeystorePassword();
+      if (OSPlatform.isWindows()) {
+        trustStorePath = "\"" + trustStorePath + "\"";
+        trustStorePassword = "\"" + trustStorePassword + "\"";
+      }
       assertThat(logs)
         .contains("SONAR_SCANNER_OPTS")
         .contains("-Djavax.net.ssl.trustStore=" + trustStorePath)
@@ -458,9 +457,9 @@ class SslTest {
       .collect(Collectors.joining("[/\\\\]"));
     assertThat(logs)
       .contains("Args: ")
-      .containsPattern("-Djavax.net.ssl.trustStore=" + trustStorePathRegex)
+      .containsPattern("-Djavax.net.ssl.trustStore=" + "\"?" + trustStorePathRegex)
       .contains("Loading OS trusted SSL certificates")
-      .containsPattern("Loaded truststore from '" + trustStorePathRegex + "'")
+      .containsPattern("Loaded truststore from '" + "\"?" + trustStorePathRegex)
       .doesNotContain("-Djavax.net.ssl.trustStorePassword=" + trustStorePassword);
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
@@ -31,6 +31,9 @@ import com.sonar.it.scanner.msbuild.utils.SslUtils;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -450,11 +453,14 @@ class SslTest {
   }
 
   private void assertScannerEngineSuccessfulKeystore(String logs, String trustStorePath, String trustStorePassword) {
+    String trustStorePathRegex = Stream.of(trustStorePath.split("[/\\\\]"))
+      .map(Pattern::quote)
+      .collect(Collectors.joining("[/\\\\]"));
     assertThat(logs)
       .contains("Args: ")
-      .contains("-Djavax.net.ssl.trustStore=" + trustStorePath)
+      .containsPattern("-Djavax.net.ssl.trustStore=" + trustStorePathRegex)
       .contains("Loading OS trusted SSL certificates")
-      .contains("Loaded truststore from '" + trustStorePath + "'")
+      .containsPattern("Loaded truststore from '" + trustStorePathRegex + "'")
       .doesNotContain("-Djavax.net.ssl.trustStorePassword=" + trustStorePassword);
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
@@ -109,6 +109,8 @@ class SslTest {
       context.begin.setDebugLogs();
       var logs = context.runAnalysis().end().getLogs();
 
+      // '-Djavax.net.ssl.trustStorePassword' & '-Djavax.net.ssl.trustStore' are part of the same argument.
+      // They do not appear in logs as the argument contains sensitive data.
       assertThat(logs)
         .doesNotContain("-Djavax.net.ssl.trustStorePassword=\"" + keystorePassword + "\"")
         .doesNotContain(keystorePassword);
@@ -126,7 +128,6 @@ class SslTest {
         .setDebugLogs();
 
       var logs = context.runAnalysis().end().getLogs();
-
       if (serverSupportsProvisioning()) {
         assertThat(logs)
           .contains("Args: -Djavax.net.ssl.trustStoreType=Windows-ROOT");
@@ -458,18 +459,7 @@ class SslTest {
 
     return result;
   }
-
-  private void assertScannerEngineSuccessfulKeystore(String logs, String trustStorePath, String trustStorePassword) {
-    String trustStorePathRegex = Stream.of(trustStorePath.split("[/\\\\]"))
-      .map(Pattern::quote)
-      .collect(Collectors.joining("[/\\\\]"));
-    assertThat(logs)
-      .contains("Args: ")
-      .containsPattern("-Djavax.net.ssl.trustStore=" + "\"?" + trustStorePathRegex)
-      .contains("Loading OS trusted SSL certificates")
-      .containsPattern("Loaded truststore from '" + "\"?" + trustStorePathRegex)
-      .doesNotContain("-Djavax.net.ssl.trustStorePassword=" + trustStorePassword);
-  }
+  
 
   private String createKeyStore(String password, String host) {
     return createKeyStore(password, Path.of(""), host, "keystore.pfx");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SslTest.java
@@ -174,8 +174,7 @@ class SslTest {
       context.begin
         .setProperty("sonar.scanner.truststorePath", server.getKeystorePath())
         .setProperty("sonar.scanner.truststorePassword", server.getKeystorePassword())
-        .setProperty("sonar.host.url", server.getUrl())
-        .setProperty("sonar.scanner.useSonarScannerCLI", "true"); // TODO: remove this in SCAN4NET-859
+        .setProperty("sonar.host.url", server.getUrl());
       context.end
         .setProperty("sonar.scanner.truststorePassword", server.getKeystorePassword());
       validateAnalysis(context, server);
@@ -234,8 +233,7 @@ class SslTest {
       context.begin
         .setProperty("sonar.scanner.truststorePath", server.getKeystorePath())
         .setProperty("sonar.scanner.truststorePassword", server.getKeystorePassword())
-        .setProperty("sonar.host.url", server.getUrl())
-        .setProperty("sonar.scanner.useSonarScannerCLI", "true"); // TODO: remove this in SCAN4NET-859
+        .setProperty("sonar.host.url", server.getUrl());
       context.end
         .setProperty("sonar.scanner.truststorePassword", server.getKeystorePassword());
       validateAnalysis(context, server);
@@ -336,7 +334,6 @@ class SslTest {
         .setEnvironmentVariable("SONAR_USER_HOME", sonarHome)
         .setProperty("sonar.host.url", server.getUrl())
         .setProperty("sonar.scanner.truststorePassword", server.getKeystorePassword())
-        .setProperty("sonar.scanner.useSonarScannerCLI", "true") // TODO: remove this in SCAN4NET-859
         .setDebugLogs();
       context.end
         .setProperty("sonar.scanner.truststorePassword", server.getKeystorePassword());
@@ -368,8 +365,7 @@ class SslTest {
       context.begin
         .setProperty("sonar.scanner.truststorePath", server.getKeystorePath())
         .setDebugLogs()
-        .setProperty("sonar.host.url", server.getUrl())
-        .setProperty("sonar.scanner.useSonarScannerCLI", "true"); // TODO: remove this in SCAN4NET-859
+        .setProperty("sonar.host.url", server.getUrl());
 
       var result = validateAnalysis(context, server);
       if (defaultPassword.equals("sonar")) {
@@ -434,7 +430,7 @@ class SslTest {
     }
 
     if (serverSupportsProvisioning()) {
-      assertScannerEngineSuccessfulKeystore(logs, server.getKeystorePath(), trustStorePassword);
+      assertScannerEngineSuccessfulKeystore(logs, trustStorePath, trustStorePassword);
     }
     else {
       assertThat(logs)

--- a/src/SonarScanner.MSBuild.Common/ProcessRunner.cs
+++ b/src/SonarScanner.MSBuild.Common/ProcessRunner.cs
@@ -86,7 +86,10 @@ public sealed class ProcessRunner : IProcessRunner
 
         // Warning: do not log the raw command line args as they
         // may contain sensitive data
-        logger.LogDebug(Resources.MSG_ExecutingFile,
+
+        // AsLogText() returns the CmdLineArgs, but we invoke the process with 'EscapedArguments'
+        logger.LogDebug(
+            Resources.MSG_ExecutingFile,
             runnerArgs.ExeName,
             runnerArgs.AsLogText(),
             runnerArgs.WorkingDirectory,

--- a/src/SonarScanner.MSBuild.Common/ProcessRunnerArguments.cs
+++ b/src/SonarScanner.MSBuild.Common/ProcessRunnerArguments.cs
@@ -52,7 +52,7 @@ public class ProcessRunnerArguments
     /// <summary>
     /// Non-sensitive command line arguments (i.e. ones that can safely be logged). Optional.
     /// </summary>
-    public ArgumentList CmdLineArgs { get; set; }
+    public IReadOnlyList<Argument> CmdLineArgs { get; set; }
 
     public string WorkingDirectory { get; set; }
 
@@ -217,7 +217,7 @@ public class ProcessRunnerArguments
         return sb.ToString();
     }
 
-    public record Argument(string Value, bool Escaped = false)
+    public readonly record struct Argument(string Value, bool Escaped = false)
     {
         /// <summary>
         /// The CreateProcess Win32 API call only takes 1 string for all arguments.
@@ -273,18 +273,5 @@ public class ProcessRunnerArguments
 
         public static implicit operator Argument(string value) =>
             new(value);
-    }
-
-    public class ArgumentList : List<Argument>
-    {
-        public ArgumentList() { }
-
-        public ArgumentList(IEnumerable<Argument> collection) : base(collection) { }
-
-        public static implicit operator ArgumentList(List<string> args) =>
-            new(args.Select(x => new Argument(x)));
-
-        public static implicit operator ArgumentList(string[] args) =>
-            new(args.Select(x => new Argument(x)));
     }
 }

--- a/src/SonarScanner.MSBuild.Common/ProcessRunnerArguments.cs
+++ b/src/SonarScanner.MSBuild.Common/ProcessRunnerArguments.cs
@@ -234,7 +234,7 @@ public class ProcessRunnerArguments
             {
                 return Value;
             }
-            var sb = new StringBuilder();
+            var sb = new StringBuilder(capacity: Value.Length + 2);
             sb.Append("\"");
 
             for (var i = 0; i < Value.Length; i++)

--- a/src/SonarScanner.MSBuild.Shim/SonarEngineWrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarEngineWrapper.cs
@@ -99,7 +99,7 @@ public class SonarEngineWrapper
             // set via the environment variable.
             foreach (var property in config.ScannerOptsSettings)
             {
-                yield return new ProcessRunnerArguments.Argument(property.AsSonarScannerArg(), false);
+                yield return property.AsSonarScannerArg();
             }
         }
     }

--- a/src/SonarScanner.MSBuild.Shim/SonarEngineWrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarEngineWrapper.cs
@@ -41,7 +41,7 @@ public class SonarEngineWrapper
 
         var engine = config.EngineJarPath;
         var javaExe = FindJavaExe(config.JavaExePath);
-        var javaParams = JavaParams(config).Select(x => new ProcessRunnerArguments.Argument(x, true));
+        var javaParams = JavaParams(config);
 
         var args = new ProcessRunnerArguments(javaExe, isBatchScript: false)
         {
@@ -84,11 +84,11 @@ public class SonarEngineWrapper
         return result.Succeeded;
     }
 
-    private static IEnumerable<string> JavaParams(AnalysisConfig config)
+    private static IEnumerable<ProcessRunnerArguments.Argument> JavaParams(AnalysisConfig config)
     {
         if (Environment.GetEnvironmentVariable(EnvironmentVariables.SonarScannerOptsVariableName)?.Trim() is { Length: > 0 } scannerOpts)
         {
-            yield return scannerOpts;
+            yield return new ProcessRunnerArguments.Argument(scannerOpts, true);
         }
 
         if (config.ScannerOptsSettings.Any())
@@ -99,7 +99,7 @@ public class SonarEngineWrapper
             // set via the environment variable.
             foreach (var property in config.ScannerOptsSettings)
             {
-                yield return property.AsSonarScannerArg();
+                yield return new ProcessRunnerArguments.Argument(property.AsSonarScannerArg(), false);
             }
         }
     }

--- a/src/SonarScanner.MSBuild.Shim/SonarEngineWrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarEngineWrapper.cs
@@ -99,7 +99,7 @@ public class SonarEngineWrapper
             // set via the environment variable.
             foreach (var property in config.ScannerOptsSettings)
             {
-                yield return property.AsSonarScannerArg();
+                yield return new ProcessRunnerArguments.Argument(property.AsSonarScannerArg(), true);
             }
         }
     }

--- a/src/SonarScanner.MSBuild.Shim/SonarEngineWrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarEngineWrapper.cs
@@ -41,7 +41,7 @@ public class SonarEngineWrapper
 
         var engine = config.EngineJarPath;
         var javaExe = FindJavaExe(config.JavaExePath);
-        var javaParams = JavaParams(config);
+        var javaParams = JavaParams(config).Select(x => new ProcessRunnerArguments.Argument(x, true));
 
         var args = new ProcessRunnerArguments(javaExe, isBatchScript: false)
         {

--- a/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
@@ -68,7 +68,7 @@ public class SonarScannerWrapper
 
         var scannerArgs = new ProcessRunnerArguments(exeFileName, runtime.OperatingSystem.IsWindows())
         {
-            CmdLineArgs = allCmdLineArgs,
+            CmdLineArgs = allCmdLineArgs.ToList(),
             WorkingDirectory = config.SonarScannerWorkingDirectory,
             EnvironmentVariables = envVarsDictionary
         };

--- a/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs
@@ -68,7 +68,7 @@ public class SonarScannerWrapper
 
         var scannerArgs = new ProcessRunnerArguments(exeFileName, runtime.OperatingSystem.IsWindows())
         {
-            CmdLineArgs = allCmdLineArgs.ToList(),
+            CmdLineArgs = allCmdLineArgs.Select(x => new ProcessRunnerArguments.Argument(x)).ToArray(),
             WorkingDirectory = config.SonarScannerWorkingDirectory,
             EnvironmentVariables = envVarsDictionary
         };

--- a/src/SonarScanner.MSBuild.Shim/TFSProcessor.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/TFSProcessor.Wrapper.cs
@@ -49,7 +49,7 @@ public class TfsProcessorWrapper
 
         var converterArgs = new ProcessRunnerArguments(exeFileName, !runtime.OperatingSystem.IsWindows())
         {
-            CmdLineArgs = userCmdLineArguments.ToList(),
+            CmdLineArgs = userCmdLineArguments.Select(x => new ProcessRunnerArguments.Argument(x)).ToArray(),
             WorkingDirectory = config.SonarScannerWorkingDirectory,
         };
 

--- a/src/SonarScanner.MSBuild.Shim/TFSProcessor.Wrapper.cs
+++ b/src/SonarScanner.MSBuild.Shim/TFSProcessor.Wrapper.cs
@@ -49,7 +49,7 @@ public class TfsProcessorWrapper
 
         var converterArgs = new ProcessRunnerArguments(exeFileName, !runtime.OperatingSystem.IsWindows())
         {
-            CmdLineArgs = userCmdLineArguments,
+            CmdLineArgs = userCmdLineArguments.ToList(),
             WorkingDirectory = config.SonarScannerWorkingDirectory,
         };
 


### PR DESCRIPTION
[SCAN4NET-860](https://sonarsource.atlassian.net/browse/SCAN4NET-860)


TODO:
Follow up PR - Copy [SonarScannerWrapper](https://github.com/SonarSource/sonar-scanner-msbuild/blob/66618b506d3d951e7ca4ca00d9f86dba35b12e48/src/SonarScanner.MSBuild.Shim/SonarScanner.Wrapper.cs#L178) in mapping from 
cli `sonar.scanner.truststorePassword` -> `-Djavax.net.ssl.trustStorePassword`
Should fix remaining tests:
selfSignedCertificateInGivenTrustStore
selfSignedCertificateInGivenTrustStore_PathAndPasswordWithSpace
defaultTruststoreExist_ProvidedPassword
truststorePasswordNotProvided_UseDefaultPassword



[SCAN4NET-860]: https://sonarsource.atlassian.net/browse/SCAN4NET-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ