### PR TITLE
SCAN4NET-935 Bump version to 11.0

### DIFF
--- a/AssemblyInfo.Shared.cs
+++ b/AssemblyInfo.Shared.cs
@@ -22,9 +22,9 @@ using System.Reflection;
 using System.Resources;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyVersion("10.4.0")]
-[assembly: AssemblyFileVersion("10.4.0.0")]
-[assembly: AssemblyInformationalVersion("Version:10.4.0.0 Branch:not-set Sha1:not-set")]
+[assembly: AssemblyVersion("11.0.0")]
+[assembly: AssemblyFileVersion("11.0.0.0")]
+[assembly: AssemblyInformationalVersion("Version:11.0.0.0 Branch:not-set Sha1:not-set")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("SonarSource")]
 [assembly: AssemblyCopyright("Copyright © SonarSource 2015-2025")]

--- a/nuspec/netcoreglobaltool/dotnet-sonarscanner.nuspec
+++ b/nuspec/netcoreglobaltool/dotnet-sonarscanner.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>dotnet-sonarscanner</id>
-    <version>10.4.0</version>
+    <version>11.0.0</version>
     <title>SonarScanner for .NET</title>
     <authors>SonarSource</authors>
     <projectUrl>https://redirect.sonarsource.com/doc/msbuild-sq-runner.html</projectUrl>

--- a/scripts/version/Version.props
+++ b/scripts/version/Version.props
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MainVersion>10.4.0</MainVersion>
+    <MainVersion>11.0.0</MainVersion>
     <BuildNumber>0</BuildNumber>
     <PrereleaseSuffix>
     </PrereleaseSuffix>


### PR DESCRIPTION
Bump to a new major release because the in the next release we will remove the embedded scanner-cli and download it on demand. This will be a breaking change.
See also https://sonarsource.slack.com/archives/C03HVJQ53M2/p1758100159139809?thread_ts=1758098032.300949&cid=C03HVJQ53M2