### PR TITLE
SCAN4NET-1170 Disable Dependabot in favor of Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,2 @@
+version: 2
+updates: []


### PR DESCRIPTION
Renovate is configured to handle dependency updates. Dependabot is creating noise with PRs for `its/projects` npm packages which are test fixtures and should not be updated automatically.

We previously deleted `dependabot.yml` in #1968 (merged June 19, 2024), but Dependabot resumed creating PRs ~21 months later (first reappearance: March 5, 2026) — likely due to org-level security settings enabling it by default. Adding an explicit `dependabot.yml` with an empty `updates` list disables version update PRs at the repo level.

## Disabling Dependabot security update PRs

Dependabot security updates (PRs triggered by CVEs) are separate from version updates and cannot be disabled via `dependabot.yml`. They can be disabled via:
- **GitHub UI**: Settings → Advanced Security → Dependabot security updates → Disable
- **Terraform**: [`github_repository_dependabot_security_updates`](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_dependabot_security_updates) resource (separate from `vulnerability_alerts`) — could be added to `re-service-config`

Note: the 15 currently open Dependabot PRs are all version updates (not security-triggered), so this PR already addresses the actual problem.

## References
- Previous removal: https://github.com/SonarSource/sonar-scanner-msbuild/pull/1968
- Configuring Dependabot version updates: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-version-updates
- Dependabot feedback (disable discussion): https://github.com/dependabot/feedback/issues/216
- Terraform `vulnerability_alerts` does not cover security updates: https://github.com/integrations/terraform-provider-github/issues/588

## Summary
- Add `.github/dependabot.yml` with empty `updates` list to disable Dependabot version update PRs

## Test plan
- [ ] Verify no new Dependabot PRs are created after merge
- [ ] Close existing open Dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)