### PR TITLE
SCANENGINE-360 Fix IT provisioning test regex for renamed scanner engine JAR

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ProvisioningAssertions.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ProvisioningAssertions.java
@@ -48,7 +48,7 @@ public final class ProvisioningAssertions {
     String engineUrlPattern;
     if (isCloud) {
       jreUrlPattern = "https://[^\s]+/jres/[^\s]+\\.(?:zip|tar\\.gz)";
-      engineUrlPattern = "https://[^\s]+/engines/sonarcloud-scanner-engine-.+\\.jar";
+      engineUrlPattern = "https://[^\s]+/engines/[^\s]*scanner[^\s]*\\.jar"; // flexible assertion to avoid breaking on file name changes
     } else {
       jreUrlPattern = "analysis/jres/[^\s]+";
       engineUrlPattern = "analysis/engine";
@@ -72,14 +72,13 @@ public final class ProvisioningAssertions {
         "Response received from " + sqApiUrl + "/analysis/engine...",
         "Cache miss. Could not find '");  // + file path to scanner engine
       TestUtils.matchesSingleLine(beginLogs, "Downloading Scanner Engine from " + engineUrlPattern);
-      TestUtils.matchesSingleLine(beginLogs, "EngineResolver: Download success. Scanner Engine can be found at '" + cacheFolderPattern +
-        "((scanner-developer)|(sonarcloud-scanner-engine)|(sonar-scanner-engine-shaded)).+\\.jar'");
+      TestUtils.matchesSingleLine(beginLogs, "EngineResolver: Download success. Scanner Engine can be found at '" + cacheFolderPattern + "scanner.+\\.jar'"); // flexible assertion to avoid breaking on file name changes
     }
   }
 
   public static void cacheHitAssertions(BuildResult secondBegin, String userHome) {
     var javaPattern = userHome.replace("\\", "\\\\") + "[\\\\/]cache.+_extracted.+java(?:\\.exe)?";
-    var enginePattern = userHome.replace("\\", "\\\\") + "[\\\\/]cache.+((scanner-developer)|(sonarcloud-scanner-engine)|(sonar-scanner-engine-shaded)).+\\.jar";
+    var enginePattern = userHome.replace("\\", "\\\\") + "[\\\\/]cache.+scanner.+\\.jar"; // flexible assertion to avoid breaking on file name changes
     assertThat(secondBegin.isSuccess()).isTrue();
     TestUtils.matchesSingleLine(secondBegin.getLogs(),
       "JreResolver: Cache hit '" + javaPattern + "'");


### PR DESCRIPTION
## Context

`SCANENGINE-347` (merged April 9–14 into `sonar-scanner-engine`) is progressively renaming the scanner engine JAR across all SonarQube editions and SonarCloud. The Community edition DEV build already ships `scanner-engine-community-*.jar`; other editions and SonarCloud will follow.

The old regex in `ProvisioningAssertions.java` hardcoded a list of known JAR name prefixes, which broke as soon as any edition was renamed. The scanner itself treats the filename as opaque — it downloads whatever the server provides, caches it by SHA256, and invokes it via `java -jar` with no filename validation — so the filename is irrelevant to correctness and only matters for these test assertions.

## Changes

- Replaced hardcoded JAR name patterns with `scanner.+\.jar` for the cached-file assertions (resilient across all current and future editions)
- Updated the SonarCloud download-URL pattern (`/engines/sonarcloud-scanner-engine-` → `/engines/scanner.+`) for the same reason
- Added inline comments explaining why the assertions are intentionally flexible

## Test plan

- [ ] `ProvisioningTest.cacheMiss_DownloadsCache` passes (SQS)
- [ ] `ProvisioningTest.cacheHit_ReusesCachedFiles` passes (SQS)
- [ ] `CloudProvisioningTest.cacheMiss_DownloadsCache` passes (SonarCloud)
- [ ] `CloudProvisioningTest.cacheHit_ReusesCachedFiles` passes (SonarCloud)