### PR TITLE
SCAN4NET-1536 Build to Packaging folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ target/
 # Claude Code
 .claude
 CLAUDE.md
+
+
+Packaging/Binaries/

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -2,6 +2,14 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)\..\Common.targets" />
 
+  <PropertyGroup>
+    <!-- Binary files folder used by ITs, NuGet and java deployment. -->
+    <BinariesFolder Condition="'$(TargetFramework)'=='$(ScannerNetVersion)'">$(MSBuildThisFileDirectory)..\Packaging\Binaries\net\</BinariesFolder>
+    <BinariesFolder Condition="'$(TargetFramework)'=='$(ScannerNetFxVersion)'">$(MSBuildThisFileDirectory)..\Packaging\Binaries\net-framework\</BinariesFolder>
+    <!-- SonarScanner.MsBuild.Tasks targets .NET Standard & .NET Framework -->
+    <BinariesFolder Condition="'$(TargetFramework)'=='$(ScannerNetStandardVersion)'">$(MSBuildThisFileDirectory)..\Packaging\Binaries\net\</BinariesFolder>
+  </PropertyGroup>
+
   <ItemGroup>
     <Using Include="SonarScanner.MSBuild.Common" />
     <Using Include="System.Xml.Serialization" />

--- a/src/SonarScanner.MSBuild.TFS.Classic/SonarScanner.MSBuild.TFS.Classic.csproj
+++ b/src/SonarScanner.MSBuild.TFS.Classic/SonarScanner.MSBuild.TFS.Classic.csproj
@@ -63,4 +63,14 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+
+  <Target Name="CopyBinaries" AfterTargets="Build">
+    <ItemGroup>
+      <!-- We do not ship Microsoft.TeamFoundation.*.dll, see note above -->
+      <BinariesToCopy Include="$(OutputPath)SonarScanner.MSBuild.TFSProcessor.exe" />
+      <BinariesToCopy Include="$(OutputPath)SonarScanner.MSBuild.TFSProcessor.exe.config" />
+    </ItemGroup>
+    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolder)" />
+  </Target>
+
 </Project>

--- a/src/SonarScanner.MSBuild.Tasks/SonarScanner.MSBuild.Tasks.csproj
+++ b/src/SonarScanner.MSBuild.Tasks/SonarScanner.MSBuild.Tasks.csproj
@@ -48,7 +48,7 @@
     <ItemGroup>
       <!-- We don't ship Microsoft.Build*.dll files, they should be on the Task runtime -->
       <BinariesToCopy Include="$(OutputPath)SonarScanner.MSBuild.Tasks.dll" />
-      <TargetsToCopy Include="$(OutputPath)Targets\*.Targets" />
+      <TargetsToCopy Include="$(OutputPath)Targets\*.targets" />
     </ItemGroup>
     <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolder)" />
     <Copy SourceFiles="@(TargetsToCopy)" DestinationFolder="$(BinariesFolder)Targets\" />

--- a/src/SonarScanner.MSBuild.Tasks/SonarScanner.MSBuild.Tasks.csproj
+++ b/src/SonarScanner.MSBuild.Tasks/SonarScanner.MSBuild.Tasks.csproj
@@ -3,9 +3,11 @@
     <TargetFrameworks>$(ScannerNetStandardVersion);$(ScannerNetFxVersion)</TargetFrameworks>
     <AssemblyName>SonarScanner.MSBuild.Tasks</AssemblyName>
   </PropertyGroup>
+
   <ItemGroup>
     <None Include="Docs\IntegrationTargetDependencies.dgml" />
   </ItemGroup>
+
   <ItemGroup>
     <None Include="Targets\SonarQube.Integration.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -14,15 +16,18 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
   <ItemGroup>
     <!-- Runtime dependencies used by tasks need to be copied by SonarScanner.MSBuild.BootstrapperClass.CopyDlls() -->
     <PackageReference Include="Microsoft.Build" Version="15.9.20" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.9.20" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SonarScanner.MSBuild.Common\SonarScanner.MSBuild.Common.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -30,10 +35,23 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+
+  <!-- This Build triggers three times - one for each TFM, and once with empty TFM as a solution-level build.  -->
+  <Target Name="CopyBinaries" AfterTargets="Build" Condition="'$(BinariesFolder)' != ''">
+    <ItemGroup>
+      <!-- We don't ship Microsoft.Build*.dll files, they should be on the Task runtime -->
+      <BinariesToCopy Include="$(OutputPath)SonarScanner.MSBuild.Tasks.dll" />
+      <TargetsToCopy Include="$(OutputPath)Targets\*.Targets" />
+    </ItemGroup>
+    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolder)" />
+    <Copy SourceFiles="@(TargetsToCopy)" DestinationFolder="$(BinariesFolder)Targets\" />
+  </Target>
+
 </Project>

--- a/src/SonarScanner.MSBuild/SonarScanner.MSBuild.csproj
+++ b/src/SonarScanner.MSBuild/SonarScanner.MSBuild.csproj
@@ -59,7 +59,7 @@
       <ThirdPartyLicenseFiles Include="$(MSBuildThisFileDirectory)\..\..\Licenses\THIRD_PARTY_LICENSES\SharpZipLib-LICENSE.txt" Condition="'$(TargetFramework)'=='$(ScannerNetVersion)'"  />
     </ItemGroup>
     <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolder)" />
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)\..\..\License.txt" DestinationFiles="$(BinariesFolder)Licenses\LICENSE.txt" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)\..\..\LICENSE.txt" DestinationFiles="$(BinariesFolder)Licenses\LICENSE.txt" />
     <Copy SourceFiles="@(ThirdPartyLicenseFiles)" DestinationFolder="$(BinariesFolder)Licenses\THIRD_PARTY_LICENSES" />
   </Target>
 

--- a/src/SonarScanner.MSBuild/SonarScanner.MSBuild.csproj
+++ b/src/SonarScanner.MSBuild/SonarScanner.MSBuild.csproj
@@ -6,24 +6,29 @@
     <RollForward>LatestMajor</RollForward>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
     <WarningLevel>5</WarningLevel>
   </PropertyGroup>
+
   <ItemGroup>
     <None Include="SonarQube.Analysis.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\SonarScanner.MSBuild.Common\SonarScanner.MSBuild.Common.csproj" />
     <ProjectReference Include="..\SonarScanner.MSBuild.PostProcessor\SonarScanner.MSBuild.PostProcessor.csproj" />
     <ProjectReference Include="..\SonarScanner.MSBuild.PreProcessor\SonarScanner.MSBuild.PreProcessor.csproj" />
     <ProjectReference Include="..\SonarScanner.MSBuild.Shim\SonarScanner.MSBuild.Shim.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Update="Resources.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -31,11 +36,31 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Update="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+
+  <!-- This Build triggers three times - one for each TFM, and once with empty TFM as a solution-level build.  -->
+  <Target Name="CopyBinaries" AfterTargets="Build" Condition="'$(BinariesFolder)' != ''">
+    <ItemGroup>
+      <BinariesToCopy Include="$(OutputPath)*.dll" />
+      <BinariesToCopy Include="$(OutputPath)SonarQube.Analysis.xml" />
+      <BinariesToCopy Include="$(OutputPath)SonarScanner.MSBuild.exe" Condition="'$(TargetFramework)'=='$(ScannerNetFxVersion)'" />
+      <BinariesToCopy Include="$(OutputPath)SonarScanner.MSBuild.exe.config" Condition="'$(TargetFramework)'=='$(ScannerNetFxVersion)'" />
+      <BinariesToCopy Include="$(OutputPath)SonarScanner.MSBuild.runtimeconfig.json" Condition="'$(TargetFramework)'=='$(ScannerNetVersion)'" />
+      <ThirdPartyLicenseFiles Include="$(MSBuildThisFileDirectory)\..\..\Licenses\THIRD_PARTY_LICENSES\*.*" Condition="'$(TargetFramework)'=='$(ScannerNetFxVersion)'"  />
+      <ThirdPartyLicenseFiles Include="$(MSBuildThisFileDirectory)\..\..\Licenses\THIRD_PARTY_LICENSES\Google.Protobuf-LICENSE.txt" Condition="'$(TargetFramework)'=='$(ScannerNetVersion)'"  />
+      <ThirdPartyLicenseFiles Include="$(MSBuildThisFileDirectory)\..\..\Licenses\THIRD_PARTY_LICENSES\Microsoft.CodeCoverage.IO-LICENSE.txt" Condition="'$(TargetFramework)'=='$(ScannerNetVersion)'"  />
+      <ThirdPartyLicenseFiles Include="$(MSBuildThisFileDirectory)\..\..\Licenses\THIRD_PARTY_LICENSES\Newtonsoft.Json-LICENSE.txt" Condition="'$(TargetFramework)'=='$(ScannerNetVersion)'"  />
+      <ThirdPartyLicenseFiles Include="$(MSBuildThisFileDirectory)\..\..\Licenses\THIRD_PARTY_LICENSES\SharpZipLib-LICENSE.txt" Condition="'$(TargetFramework)'=='$(ScannerNetVersion)'"  />
+    </ItemGroup>
+    <Copy SourceFiles="@(BinariesToCopy)" DestinationFolder="$(BinariesFolder)" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)\..\..\License.txt" DestinationFiles="$(BinariesFolder)Licenses\LICENSE.txt" />
+    <Copy SourceFiles="@(ThirdPartyLicenseFiles)" DestinationFolder="$(BinariesFolder)Licenses\THIRD_PARTY_LICENSES" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
This PR intentionally:
* Adds `Microsoft.CodeCoverage.IO.dll` to `net` build, even when not technically necessary. I've added comment to SCAN4NET-719 to isolate it better in the future (might do it in this sprint later as well)
* Ignores all the language resources shipped for `Microsoft.CodeCoverage.IO.dll` to `netframework` build. It's not really useful to have "Nepovedlo se otevřít soubor pokrytí {0}." as an error

As part of the review, please download released zip for both TFMs and compare the file list.