### PR TITLE
SKUNK-2498 Add DRE Languages to the Scanner for .NET

### DIFF
--- a/Tests/SonarScanner.MSBuild.Shim.Test/AdditionalFilesServiceTest.cs
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/AdditionalFilesServiceTest.cs
@@ -234,6 +234,8 @@ public class AdditionalFilesServiceTest
     [DataRow("sonar.azureresourcemanager.file.suffixes")]
     [DataRow("sonar.terraform.file.suffixes")]
     [DataRow("sonar.go.file.suffixes")]
+    [DataRow("sonar.groovy.file.suffixes")]
+    [DataRow("sonar.powershell.file.suffixes")]
     public void AdditionalFiles_ExtensionsFound_SingleProperty(string propertyName)
     {
         runtime.Directory
@@ -495,6 +497,7 @@ public class AdditionalFilesServiceTest
 
     [TestMethod]
     [DataRow("sonar.docker.file.patterns")]
+    [DataRow("sonar.groovy.file.patterns")]
     [DataRow("sonar.java.jvmframeworkconfig.file.patterns")]
     [DataRow("sonar.text.inclusions")]
     public void AdditionalFiles_WildcardPattern_RelativePattern(string property)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -503,8 +503,11 @@ stages:
               MSBUILD_PATH: $(MSBUILD_18_PATH)
               TEST_INCLUDE: "**/sonarqube/*"
               CFAMILY_VERSION: "NONE"         # Commercial plugin
+              DRE_VERSION: "NONE"             # Commercial plugin
               GO_VERSION: "NONE"              # Commercial plugin
+              GO_ENTERPRISE_VERSION: "NONE"   # Commercial plugin & DRE Dependency
               IAC_ENTERPRISE_VERSION: "NONE"  # Commercial plugin
+              RUBY_VERSION: "NONE"            # Not-Commercial, but only required when the DRE plugin is installed
               PLSQL_VERSION: "NONE"           # Commercial plugin
               JDKVERSION: "1.21"
             Cloud:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -444,7 +444,7 @@ stages:
               CFAMILY_VERSION: "6.77.0.95488"         # Bundled version with SQ 2026.1
               CSS_VERSION: "NONE"                     # No official release in SQ 2026.1, the plug-in should not be loaded. Rules are in the JS plugin
               DOTNET_VERSION: "10.21.0.135332"        # Minimum version supporting new telemetry convention (bundled was 10.18.0)
-              DRE_VERSION: "1.0.0.5029"               # Bundled version with SQ 2026.1
+              DRE_VERSION: "NONE"                     # The DRE plugin is not required for the tests for this version
               GO_VERSION: "1.31.0.4938"               # Bundled version with SQ 2026.1
               GO_GROUP_ID: "org.sonarsource.go"
               IAC_VERSION: "NONE"                     # Enterprise plugin is a superset; installing both causes conflicts for githubactions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -362,6 +362,7 @@ stages:
               CFAMILY_VERSION: "6.20.5.49286"   # Bundled version with SQ 8.9
               CSS_VERSION: "1.4.2.2002"         # Bundled version with SQ 8.9
               DOTNET_VERSION: "8.22.0.31243"    # Bundled version with SQ 8.9
+              DRE_VERSION: "NONE"               # No release before 2026.1
               GO_VERSION: "1.8.3.2219"          # Bundled version with SQ 8.9
               GO_GROUP_ID: "org.sonarsource.slang"
               IAC_VERSION: "NONE"               # No release brefore SQ 9.9, the plug-in should not be loaded
@@ -381,6 +382,7 @@ stages:
               CFAMILY_VERSION: "6.41.0.60884"    # Bundled version with SQ 9.9
               CSS_VERSION: "NONE"                # No official release in SQ 9.9, the plug-in should not be loaded. Rules are in the JS plugin
               DOTNET_VERSION: "8.51.0.59060"     # Bundled version with SQ 9.9
+              DRE_VERSION: "NONE"                # No release before 2026.1
               GO_VERSION: "1.11.0.3905"          # Bundled version with SQ 9.9
               GO_GROUP_ID: "org.sonarsource.slang"
               IAC_VERSION: "1.11.0.2847"         # Bundled version with SQ 9.9
@@ -400,6 +402,7 @@ stages:
               CFAMILY_VERSION: "6.62.0.78645"         # Bundled version with SQ 2025.1
               CSS_VERSION: "NONE"                     # No official release in SQ 2025.1, the plug-in should not be loaded. Rules are in the JS plugin
               DOTNET_VERSION: "10.4.0.108396"         # Bundled version with SQ 2025.1
+              DRE_VERSION: "NONE"                     # No release before 2026.1
               GO_VERSION: "1.18.0.240"                # Bundled version with SQ 2025.1
               GO_GROUP_ID: "org.sonarsource.slang"
               IAC_VERSION: "1.41.0.14206"             # Bundled version with SQ 2025.1
@@ -420,6 +423,7 @@ stages:
               CFAMILY_VERSION: "6.70.1.93088"         # Bundled version with SQ 2025.4
               CSS_VERSION: "NONE"                     # No official release in SQ 2025.4, the plug-in should not be loaded. Rules are in the JS plugin
               DOTNET_VERSION: "10.21.0.135332"        # Minimum version supporting new telemetry convention (bundled was 10.15.0)
+              DRE_VERSION: "NONE"                     # No release before 2026.1
               GO_VERSION: "1.26.0.3421"               # Bundled version with SQ 2025.4
               GO_GROUP_ID: "org.sonarsource.go"
               IAC_VERSION: "1.48.1.18410"             # Bundled version with SQ 2025.4
@@ -440,6 +444,7 @@ stages:
               CFAMILY_VERSION: "6.77.0.95488"         # Bundled version with SQ 2026.1
               CSS_VERSION: "NONE"                     # No official release in SQ 2026.1, the plug-in should not be loaded. Rules are in the JS plugin
               DOTNET_VERSION: "10.21.0.135332"        # Minimum version supporting new telemetry convention (bundled was 10.18.0)
+              DRE_VERSION: "1.0.0.5029"               # Bundled version with SQ 2026.1
               GO_VERSION: "1.31.0.4938"               # Bundled version with SQ 2026.1
               GO_GROUP_ID: "org.sonarsource.go"
               IAC_VERSION: "NONE"                     # Enterprise plugin is a superset; installing both causes conflicts for githubactions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -364,6 +364,7 @@ stages:
               DOTNET_VERSION: "8.22.0.31243"    # Bundled version with SQ 8.9
               DRE_VERSION: "NONE"               # No release before 2026.1
               GO_VERSION: "1.8.3.2219"          # Bundled version with SQ 8.9
+              GO_ENTERPRISE_VERSION: "NONE"     # DRE Dependency
               GO_GROUP_ID: "org.sonarsource.slang"
               IAC_VERSION: "NONE"               # No release brefore SQ 9.9, the plug-in should not be loaded
               IAC_ENTERPRISE_VERSION: "NONE"    # Not present until LTA-2025
@@ -372,6 +373,7 @@ stages:
               PHP_VERSION: "3.17.0.7439"        # Bundled version with SQ 8.9
               PLSQL_VERSION: "3.6.1.3873"       # Bundled version with SQ 8.9
               PYTHON_VERSION: "3.4.1.8066"      # Bundled version with SQ 8.9
+              RUBY_VERSION: "NONE"              # DRE Dependency
               TEXT_VERSION: "NONE"              # Not release brefore SQ 9.9, the plug-in should not be loaded
               XML_VERSION: "2.2.0.2973"         # Bundled version with SQ 8.9
             LTA-99:
@@ -384,6 +386,7 @@ stages:
               DOTNET_VERSION: "8.51.0.59060"     # Bundled version with SQ 9.9
               DRE_VERSION: "NONE"                # No release before 2026.1
               GO_VERSION: "1.11.0.3905"          # Bundled version with SQ 9.9
+              GO_ENTERPRISE_VERSION: "NONE"      # DRE Dependency
               GO_GROUP_ID: "org.sonarsource.slang"
               IAC_VERSION: "1.11.0.2847"         # Bundled version with SQ 9.9
               IAC_ENTERPRISE_VERSION: "NONE"     # Not present until LTA-2025
@@ -392,6 +395,7 @@ stages:
               PHP_VERSION: "3.27.1.9352"         # Bundled version with SQ 9.9
               PLSQL_VERSION: "3.8.0.4948"        # Bundled version with SQ 9.9
               PYTHON_VERSION: "3.24.0.10784"     # Bundled version with SQ 9.9
+              RUBY_VERSION: "NONE"               # DRE Dependency
               TEXT_VERSION: "NONE"               # Not required in our ITs for SQ 9.9
               XML_VERSION: "2.7.0.3820"          # Bundled version with SQ 9.9
             LTA-2025-1:
@@ -404,6 +408,7 @@ stages:
               DOTNET_VERSION: "10.4.0.108396"         # Bundled version with SQ 2025.1
               DRE_VERSION: "NONE"                     # No release before 2026.1
               GO_VERSION: "1.18.0.240"                # Bundled version with SQ 2025.1
+              GO_ENTERPRISE_VERSION: "NONE"           # DRE Dependency
               GO_GROUP_ID: "org.sonarsource.slang"
               IAC_VERSION: "1.41.0.14206"             # Bundled version with SQ 2025.1
               IAC_ENTERPRISE_VERSION: "1.41.0.14206"  # Bundled version with SQ 2025.1
@@ -412,6 +417,7 @@ stages:
               PHP_VERSION: "3.42.0.12795"             # Bundled version with SQ 2025.1
               PLSQL_VERSION: "3.15.0.7123"            # Bundled version with SQ 2025.1
               PYTHON_VERSION: "4.26.0.19456"          # Bundled version with SQ 2025.1
+              RUBY_VERSION: "NONE"                    # DRE Dependency
               TEXT_VERSION: "2.20.0.5038"             # Bundled version with SQ 2025.1
               XML_VERSION: "2.12.0.5749"              # Bundled version with SQ 2025.1
             LTA-2025-4:
@@ -424,6 +430,7 @@ stages:
               CSS_VERSION: "NONE"                     # No official release in SQ 2025.4, the plug-in should not be loaded. Rules are in the JS plugin
               DOTNET_VERSION: "10.21.0.135332"        # Minimum version supporting new telemetry convention (bundled was 10.15.0)
               DRE_VERSION: "NONE"                     # No release before 2026.1
+              GO_ENTERPRISE_VERSION: "NONE"           # DRE Dependency
               GO_VERSION: "1.26.0.3421"               # Bundled version with SQ 2025.4
               GO_GROUP_ID: "org.sonarsource.go"
               IAC_VERSION: "1.48.1.18410"             # Bundled version with SQ 2025.4
@@ -433,6 +440,7 @@ stages:
               PHP_VERSION: "3.46.1.15272"             # Bundled version with SQ 2025.4
               PLSQL_VERSION: "3.17.1.7623"            # Bundled version with SQ 2025.4
               PYTHON_VERSION: "5.7.1.26730"           # Bundled version with SQ 2025.4
+              RUBY_VERSION: "NONE"                    # DRE Dependency
               TEXT_VERSION: "2.26.1.9976"             # Bundled version with SQ 2025.4
               XML_VERSION: "2.13.1.6351"              # Bundled version with SQ 2025.4
             LTA-2026-1:
@@ -446,6 +454,7 @@ stages:
               DOTNET_VERSION: "10.21.0.135332"        # Minimum version supporting new telemetry convention (bundled was 10.18.0)
               DRE_VERSION: "NONE"                     # The DRE plugin is not required for the tests for this version
               GO_VERSION: "1.31.0.4938"               # Bundled version with SQ 2026.1
+              GO_ENTERPRISE_VERSION: "NONE"           # DRE Dependency
               GO_GROUP_ID: "org.sonarsource.go"
               IAC_VERSION: "NONE"                     # Enterprise plugin is a superset; installing both causes conflicts for githubactions
               IAC_ENTERPRISE_VERSION: "2.6.1.19203"   # Minimum version supporting githubactions rules (bundled was 2.5.0)
@@ -454,6 +463,7 @@ stages:
               PHP_VERSION: "3.54.0.15452"             # Bundled version with SQ 2026.1
               PLSQL_VERSION: "3.18.1.230"             # Bundled version with SQ 2026.1
               PYTHON_VERSION: "5.14.2.29072"          # Bundled version with SQ 2026.1
+              RUBY_VERSION: "NONE"                    # DRE Dependency
               TEXT_VERSION: "2.38.0.10279"            # Bundled version with SQ 2026.1
               XML_VERSION: "2.15.0.7513"              # Bundled version with SQ 2026.1
             LATEST_RELEASE:

--- a/its/projects/MultiLanguageSupport/Jenkinsfile
+++ b/its/projects/MultiLanguageSupport/Jenkinsfile
@@ -1,0 +1,1 @@
+// TODO trigger groovydre:S1135

--- a/its/projects/MultiLanguageSupport/src/script.ps1
+++ b/its/projects/MultiLanguageSupport/src/script.ps1
@@ -1,2 +1,4 @@
+# TODO trigger powershelldre:S1135
+
 # S6702
 Write-Host "squ_e0015b6f1397c601e9029e0f52d80e24327cf062"

--- a/its/projects/MultiLanguageSupport/todo.groovy
+++ b/its/projects/MultiLanguageSupport/todo.groovy
@@ -1,0 +1,1 @@
+// TODO trigger groovydre:S1135

--- a/its/projects/MultiLanguageSupport/todo.gsh
+++ b/its/projects/MultiLanguageSupport/todo.gsh
@@ -1,0 +1,1 @@
+// TODO trigger groovydre:S1135

--- a/its/projects/MultiLanguageSupport/todo.gvy
+++ b/its/projects/MultiLanguageSupport/todo.gvy
@@ -1,0 +1,1 @@
+// TODO trigger groovydre:S1135

--- a/its/projects/MultiLanguageSupport/todo.gy
+++ b/its/projects/MultiLanguageSupport/todo.gy
@@ -1,0 +1,1 @@
+// TODO trigger groovydre:S1135

--- a/its/projects/MultiLanguageSupport/todo.psd1
+++ b/its/projects/MultiLanguageSupport/todo.psd1
@@ -1,0 +1,1 @@
+# TODO trigger powershelldre:S1135

--- a/its/projects/MultiLanguageSupport/todo.psm1
+++ b/its/projects/MultiLanguageSupport/todo.psm1
@@ -1,0 +1,1 @@
+# TODO trigger powershelldre:S1135

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
@@ -207,16 +207,13 @@ class MultiLanguageTest {
             tuple("typescript:S6481", context.projectKey + ":frontend/PageTwo.tsx")));
         }
       }
-      if (version.isGreaterThan(2025, 6)) {
+      if (version.isGreaterThan(2026, 1)) {
         expectedIssues.addAll(List.of(
           tuple("groovydre:S1135", context.projectKey + ":Jenkinsfile"),
           tuple("groovydre:S1135", context.projectKey + ":todo.groovy"),
           tuple("groovydre:S1135", context.projectKey + ":todo.gvy"),
           tuple("groovydre:S1135", context.projectKey + ":todo.gy"),
-          tuple("groovydre:S1135", context.projectKey + ":todo.gsh")));
-      }
-      if (version.isGreaterThan(2026, 1)) {
-        expectedIssues.addAll(List.of(
+          tuple("groovydre:S1135", context.projectKey + ":todo.gsh"),
           tuple("powershelldre:S1135", context.projectKey + ":src/script.ps1"),
           tuple("powershelldre:S1135", context.projectKey + ":todo.psm1"),
           tuple("powershelldre:S1135", context.projectKey + ":todo.psd1")));

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
@@ -207,6 +207,20 @@ class MultiLanguageTest {
             tuple("typescript:S6481", context.projectKey + ":frontend/PageTwo.tsx")));
         }
       }
+      if (version.isGreaterThan(2025, 6)) {
+        expectedIssues.addAll(List.of(
+          tuple("groovydre:S1135", context.projectKey + ":Jenkinsfile"),
+          tuple("groovydre:S1135", context.projectKey + ":todo.groovy"),
+          tuple("groovydre:S1135", context.projectKey + ":todo.gvy"),
+          tuple("groovydre:S1135", context.projectKey + ":todo.gy"),
+          tuple("groovydre:S1135", context.projectKey + ":todo.gsh")));
+      }
+      if (version.isGreaterThan(2026, 1)) {
+        expectedIssues.addAll(List.of(
+          tuple("powershelldre:S1135", context.projectKey + ":src/script.ps1"),
+          tuple("powershelldre:S1135", context.projectKey + ":todo.psm1"),
+          tuple("powershelldre:S1135", context.projectKey + ":todo.psd1")));
+      }
       assertThat(issues)
         .extracting(Issue::getRule, Issue::getComponent)
         .containsExactlyInAnyOrder(expectedIssues.toArray(new Tuple[]{}));

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
@@ -84,6 +84,14 @@ public class ServerTests implements BeforeAllCallback, AfterAllCallback {
     addPlugin(orchestrator, "org.sonarsource.text", "sonar-text-plugin", "sonar.textplugin.version");
     addPlugin(orchestrator, "org.sonarsource.xml", "sonar-xml-plugin", "sonar.xmlplugin.version");
     addPlugin(orchestrator, System.getProperty("go.groupid", "org.sonarsource.go"), "sonar-go-plugin", "sonar.goplugin.version");
+    addPlugin(orchestrator, "com.sonarsource.dre", "sonar-dre-plugin", "sonar.dreplugin.version");
+
+    var sonarDreVersion = System.getProperty("sonar.dreplugin.version", "LATEST_RELEASE");
+    if (!sonarDreVersion.equals("NONE")) {
+      // Required dependencies for the SonarDRE plugin
+      addPlugin(orchestrator, "org.sonarsource.slang", "sonar-ruby-plugin", "sonar.rubyplugin.version");
+      addPlugin(orchestrator, "com.sonarsource.go", "sonar-go-enterprise-plugin", "sonar.goplugin.version");
+    }
 
     // DO NOT add any additional plugin loading logic here. Everything must be in the YML
     if (!version.contains("8.9")) {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
@@ -83,7 +83,6 @@ public class ServerTests implements BeforeAllCallback, AfterAllCallback {
     addPlugin(orchestrator, "org.sonarsource.python", "sonar-python-plugin", "sonar.pythonplugin.version");
     addPlugin(orchestrator, "org.sonarsource.text", "sonar-text-plugin", "sonar.textplugin.version");
     addPlugin(orchestrator, "org.sonarsource.xml", "sonar-xml-plugin", "sonar.xmlplugin.version");
-    addPlugin(orchestrator, System.getProperty("go.groupid", "org.sonarsource.go"), "sonar-go-plugin", "sonar.goplugin.version");
     addPlugin(orchestrator, "com.sonarsource.dre", "sonar-dre-plugin", "sonar.dreplugin.version");
 
     var sonarDreVersion = System.getProperty("sonar.dreplugin.version", "LATEST_RELEASE");
@@ -91,6 +90,9 @@ public class ServerTests implements BeforeAllCallback, AfterAllCallback {
       // Required dependencies for the SonarDRE plugin
       addPlugin(orchestrator, "org.sonarsource.slang", "sonar-ruby-plugin", "sonar.rubyplugin.version");
       addPlugin(orchestrator, "com.sonarsource.go", "sonar-go-enterprise-plugin", "sonar.goplugin.version");
+    } else {
+      // Loading both the OSS and enterprise Go can lead to issues, so we only load the OSS one if the DRE plugin is not loaded.
+      addPlugin(orchestrator, System.getProperty("go.groupid", "org.sonarsource.go"), "sonar-go-plugin", "sonar.goplugin.version");
     }
 
     // DO NOT add any additional plugin loading logic here. Everything must be in the YML

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
@@ -83,16 +83,10 @@ public class ServerTests implements BeforeAllCallback, AfterAllCallback {
     addPlugin(orchestrator, "org.sonarsource.python", "sonar-python-plugin", "sonar.pythonplugin.version");
     addPlugin(orchestrator, "org.sonarsource.text", "sonar-text-plugin", "sonar.textplugin.version");
     addPlugin(orchestrator, "org.sonarsource.xml", "sonar-xml-plugin", "sonar.xmlplugin.version");
+    addPlugin(orchestrator, "org.sonarsource.slang", "sonar-ruby-plugin", "sonar.rubyplugin.version");
+    addPlugin(orchestrator, "com.sonarsource.go", "sonar-go-enterprise-plugin", "sonar.goplugin-enterprise.version");
+    addPlugin(orchestrator, System.getProperty("go.groupid", "org.sonarsource.go"), "sonar-go-plugin", "sonar.goplugin.version");
     addPlugin(orchestrator, "com.sonarsource.dre", "sonar-dre-plugin", "sonar.dreplugin.version");
-
-    if (!System.getProperty("sonar.dreplugin.version", "LATEST_RELEASE").equals("NONE")) {
-      // Required dependencies for the SonarDRE plugin
-      addPlugin(orchestrator, "org.sonarsource.slang", "sonar-ruby-plugin", "sonar.rubyplugin.version");
-      addPlugin(orchestrator, "com.sonarsource.go", "sonar-go-enterprise-plugin", "sonar.goplugin-enterprise.version");
-    } else {
-      // Loading both the OSS and enterprise Go can lead to issues, so we only load the OSS one if the DRE plugin is not loaded.
-      addPlugin(orchestrator, System.getProperty("go.groupid", "org.sonarsource.go"), "sonar-go-plugin", "sonar.goplugin.version");
-    }
 
     // DO NOT add any additional plugin loading logic here. Everything must be in the YML
     if (!version.contains("8.9")) {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
@@ -85,8 +85,7 @@ public class ServerTests implements BeforeAllCallback, AfterAllCallback {
     addPlugin(orchestrator, "org.sonarsource.xml", "sonar-xml-plugin", "sonar.xmlplugin.version");
     addPlugin(orchestrator, "com.sonarsource.dre", "sonar-dre-plugin", "sonar.dreplugin.version");
 
-    var sonarDreVersion = System.getProperty("sonar.dreplugin.version", "LATEST_RELEASE");
-    if (!sonarDreVersion.equals("NONE")) {
+    if (!System.getProperty("sonar.dreplugin.version", "LATEST_RELEASE").equals("NONE")) {
       // Required dependencies for the SonarDRE plugin
       addPlugin(orchestrator, "org.sonarsource.slang", "sonar-ruby-plugin", "sonar.rubyplugin.version");
       addPlugin(orchestrator, "com.sonarsource.go", "sonar-go-enterprise-plugin", "sonar.goplugin.version");

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
@@ -88,7 +88,7 @@ public class ServerTests implements BeforeAllCallback, AfterAllCallback {
     if (!System.getProperty("sonar.dreplugin.version", "LATEST_RELEASE").equals("NONE")) {
       // Required dependencies for the SonarDRE plugin
       addPlugin(orchestrator, "org.sonarsource.slang", "sonar-ruby-plugin", "sonar.rubyplugin.version");
-      addPlugin(orchestrator, "com.sonarsource.go", "sonar-go-enterprise-plugin", "sonar.goplugin.version");
+      addPlugin(orchestrator, "com.sonarsource.go", "sonar-go-enterprise-plugin", "sonar.goplugin-enterprise.version");
     } else {
       // Loading both the OSS and enterprise Go can lead to issues, so we only load the OSS one if the DRE plugin is not loaded.
       addPlugin(orchestrator, System.getProperty("go.groupid", "org.sonarsource.go"), "sonar-go-plugin", "sonar.goplugin.version");

--- a/src/SonarScanner.MSBuild.Shim/AdditionalFilesService.cs
+++ b/src/SonarScanner.MSBuild.Shim/AdditionalFilesService.cs
@@ -63,11 +63,14 @@ public class AdditionalFilesService
         "sonar.azureresourcemanager.file.suffixes",
         "sonar.terraform.file.suffixes",
         "sonar.go.file.suffixes",
+        "sonar.groovy.file.suffixes",
+        "sonar.powershell.file.suffixes",
     ];
 
     private static readonly IReadOnlyList<string> GlobingExpressions =
     [
         "sonar.docker.file.patterns",
+        "sonar.groovy.file.patterns",
         "sonar.java.jvmframeworkconfig.file.patterns",
         "sonar.text.inclusions"
     ];

--- a/templates/its-jobs.yml
+++ b/templates/its-jobs.yml
@@ -25,7 +25,7 @@ jobs:
       CSS_VERSION: "NONE" # No official release since 8.9, the plug-in should not be loaded. Rules are in the JS plugin
       DOTNET_VERSION: "DEV"
       DRE_VERSION: "LATEST_RELEASE"
-      GO_VERSION: "LATEST_RELEASE"
+      GO_VERSION: "NONE" # In favor of go-enterprise, which is required for the DRE plugin
       GO_ENTERPRISE_VERSION: "LATEST_RELEASE"
       GO_GROUP_ID: "org.sonarsource.go"
       IAC_VERSION: "NONE" # Merged into sonar-iac-enterprise in 2025.5

--- a/templates/its-jobs.yml
+++ b/templates/its-jobs.yml
@@ -26,6 +26,7 @@ jobs:
       DOTNET_VERSION: "DEV"
       DRE_VERSION: "LATEST_RELEASE"
       GO_VERSION: "LATEST_RELEASE"
+      GO_ENTERPRISE_VERSION: "LATEST_RELEASE"
       GO_GROUP_ID: "org.sonarsource.go"
       IAC_VERSION: "NONE" # Merged into sonar-iac-enterprise in 2025.5
       IAC_ENTERPRISE_VERSION: "LATEST_RELEASE"
@@ -34,6 +35,7 @@ jobs:
       PHP_VERSION: "LATEST_RELEASE"
       PLSQL_VERSION: "LATEST_RELEASE"
       PYTHON_VERSION: "LATEST_RELEASE"
+      RUBY_VERSION: "LATEST_RELEASE"
       TEXT_VERSION: "LATEST_RELEASE"
       XML_VERSION: "LATEST_RELEASE"
       JDKVERSION: "1.17"
@@ -116,7 +118,9 @@ jobs:
             -Dsonar.iacplugin-enterprise.version=$(IAC_ENTERPRISE_VERSION)
             -Dsonar.javaplugin.version=$(JAVA_VERSION)
             -Dsonar.textplugin.version=$(TEXT_VERSION)
+            -Dsonar.rubyplugin.version=$(RUBY_VERSION)
             -Dsonar.goplugin.version=$(GO_VERSION)
+            -Dsonar.goplugin-enterprise.version=$(GO_ENTERPRISE_VERSION)
             -Dgo.groupid=$(GO_GROUP_ID)
             -Dsonar.runtimeVersion=$(SQ_VERSION)
             -Dsonar.sonarQubeEdition=$(SQ_EDITION)

--- a/templates/its-jobs.yml
+++ b/templates/its-jobs.yml
@@ -24,6 +24,7 @@ jobs:
       SQ_EDITION: "DEVELOPER"
       CSS_VERSION: "NONE" # No official release since 8.9, the plug-in should not be loaded. Rules are in the JS plugin
       DOTNET_VERSION: "DEV"
+      DRE_VERSION: "LATEST_RELEASE"
       GO_VERSION: "LATEST_RELEASE"
       GO_GROUP_ID: "org.sonarsource.go"
       IAC_VERSION: "NONE" # Merged into sonar-iac-enterprise in 2025.5
@@ -103,6 +104,7 @@ jobs:
             -Dtest=$(TEST_INCLUDE)
             -Dsonar.csharpplugin.version=$(DOTNET_VERSION)
             -Dsonar.vbnetplugin.version=$(DOTNET_VERSION)
+            -Dsonar.dreplugin.version=$(DRE_VERSION)
             -Dsonar.cfamilyplugin.version=$(CFAMILY_VERSION)
             -Dsonar.xmlplugin.version=$(XML_VERSION)
             -Dsonar.css.version=$(CSS_VERSION)


### PR DESCRIPTION
## Summary
  Extend scan-all additional-file detection to include Groovy and PowerShell inputs, then cover the new behavior in the multi-language SonarQube ITs and CI matrix.

  ## Changes
  - Add `sonar.groovy.file.suffixes`, `sonar.powershell.file.suffixes`, and `sonar.groovy.file.patterns` to `AdditionalFilesService`, with unit-test coverage for both suffix- and pattern-based discovery.
  - Add Groovy and PowerShell fixture files to `its/projects/MultiLanguageSupport` so the scan-all flow can surface DRE issues on those languages.
  - Extend `MultiLanguageTest.sdkFormat` to assert Groovy DRE issues and PowerShell DRE issues starting with versions after `2026.1`.
  - Load the DRE plugin in `ServerTests` and pass its version through the IT Maven configuration.
  - Update the Azure pipeline IT matrix to set `DRE_VERSION` explicitly, using `NONE` on versions where the plugin is not available and the bundled version on `2026.1`.