### PR TITLE
SCAN4NET-1550 Update pom.xml with current version

### DIFF
--- a/Tests/SonarScanner.MSBuild.Common.Test/packages.lock.json
+++ b/Tests/SonarScanner.MSBuild.Common.Test/packages.lock.json
@@ -1941,7 +1941,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }
@@ -3696,7 +3696,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }

--- a/Tests/SonarScanner.MSBuild.PostProcessor.Test/packages.lock.json
+++ b/Tests/SonarScanner.MSBuild.PostProcessor.Test/packages.lock.json
@@ -1940,16 +1940,16 @@
       "sonarscanner.msbuild.postprocessor": {
         "type": "Project",
         "dependencies": {
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )",
-          "SonarScanner.MSBuild.TFS": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )",
+          "SonarScanner.MSBuild.TFS": "[11.3.0, )"
         }
       },
       "sonarscanner.msbuild.shim": {
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -1957,8 +1957,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeCoverage.IO": "[17.7.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       },
       "testutilities": {
@@ -1970,7 +1970,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }
@@ -3729,16 +3729,16 @@
       "sonarscanner.msbuild.postprocessor": {
         "type": "Project",
         "dependencies": {
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )",
-          "SonarScanner.MSBuild.TFS": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )",
+          "SonarScanner.MSBuild.TFS": "[11.3.0, )"
         }
       },
       "sonarscanner.msbuild.shim": {
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -3746,8 +3746,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeCoverage.IO": "[17.7.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       },
       "testutilities": {
@@ -3759,7 +3759,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/packages.lock.json
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/packages.lock.json
@@ -1980,7 +1980,7 @@
           "Google.Protobuf": "[3.34.1, )",
           "Newtonsoft.Json": "[13.0.4, )",
           "SharpZipLib": "[1.4.2, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.Net.Http": "[4.3.4, )"
         }
       },
@@ -1993,7 +1993,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }
@@ -4126,7 +4126,7 @@
           "Google.Protobuf": "[3.34.1, )",
           "Newtonsoft.Json": "[13.0.4, )",
           "SharpZipLib": "[1.4.2, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.Net.Http": "[4.3.4, )"
         }
       },
@@ -4139,7 +4139,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }

--- a/Tests/SonarScanner.MSBuild.Shim.Test/packages.lock.json
+++ b/Tests/SonarScanner.MSBuild.Shim.Test/packages.lock.json
@@ -1936,7 +1936,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -1949,7 +1949,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }
@@ -3704,7 +3704,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -3717,7 +3717,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }

--- a/Tests/SonarScanner.MSBuild.TFS.Test/packages.lock.json
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/packages.lock.json
@@ -1941,7 +1941,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -1949,16 +1949,16 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeCoverage.IO": "[17.7.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       },
       "SonarScanner.MSBuild.TFSProcessor": {
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.TFS": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.TFS": "[11.3.0, )"
         }
       },
       "testutilities": {
@@ -1970,7 +1970,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }
@@ -3730,7 +3730,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -3738,8 +3738,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeCoverage.IO": "[17.7.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       },
       "testutilities": {
@@ -3751,7 +3751,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/packages.lock.json
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/packages.lock.json
@@ -2042,7 +2042,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -2051,7 +2051,7 @@
         "dependencies": {
           "Microsoft.Build": "[15.9.20, )",
           "Microsoft.Build.Utilities.Core": "[15.9.20, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.Runtime.InteropServices.RuntimeInformation": "[4.3.0, )"
         }
       },
@@ -2064,7 +2064,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }
@@ -4195,7 +4195,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -4204,7 +4204,7 @@
         "dependencies": {
           "Microsoft.Build": "[15.9.20, )",
           "Microsoft.Build.Utilities.Core": "[15.9.20, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.Runtime.InteropServices.RuntimeInformation": "[4.3.0, )"
         }
       },
@@ -4217,7 +4217,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTest/packages.lock.json
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTest/packages.lock.json
@@ -2159,7 +2159,7 @@
         "dependencies": {
           "Microsoft.Build": "[15.9.20, )",
           "Microsoft.Build.Utilities.Core": "[15.9.20, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.Runtime.InteropServices.RuntimeInformation": "[4.3.0, )"
         }
       },
@@ -2172,7 +2172,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }
@@ -4400,7 +4400,7 @@
         "dependencies": {
           "Microsoft.Build": "[15.9.20, )",
           "Microsoft.Build.Utilities.Core": "[15.9.20, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.Runtime.InteropServices.RuntimeInformation": "[4.3.0, )"
         }
       },
@@ -4413,7 +4413,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }

--- a/Tests/SonarScanner.MSBuild.Test/packages.lock.json
+++ b/Tests/SonarScanner.MSBuild.Test/packages.lock.json
@@ -1968,10 +1968,10 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.PostProcessor": "[1.0.0, )",
-          "SonarScanner.MSBuild.PreProcessor": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.PostProcessor": "[11.3.0, )",
+          "SonarScanner.MSBuild.PreProcessor": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       },
       "sonarscanner.msbuild.common": {
@@ -1984,9 +1984,9 @@
       "sonarscanner.msbuild.postprocessor": {
         "type": "Project",
         "dependencies": {
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )",
-          "SonarScanner.MSBuild.TFS": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )",
+          "SonarScanner.MSBuild.TFS": "[11.3.0, )"
         }
       },
       "sonarscanner.msbuild.preprocessor": {
@@ -1995,7 +1995,7 @@
           "Google.Protobuf": "[3.34.1, )",
           "Newtonsoft.Json": "[13.0.4, )",
           "SharpZipLib": "[1.4.2, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.Net.Http": "[4.3.4, )"
         }
       },
@@ -2003,7 +2003,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -2011,8 +2011,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeCoverage.IO": "[17.7.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       },
       "testutilities": {
@@ -2024,7 +2024,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }
@@ -4120,10 +4120,10 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.PostProcessor": "[1.0.0, )",
-          "SonarScanner.MSBuild.PreProcessor": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.PostProcessor": "[11.3.0, )",
+          "SonarScanner.MSBuild.PreProcessor": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       },
       "sonarscanner.msbuild.common": {
@@ -4136,9 +4136,9 @@
       "sonarscanner.msbuild.postprocessor": {
         "type": "Project",
         "dependencies": {
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )",
-          "SonarScanner.MSBuild.TFS": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )",
+          "SonarScanner.MSBuild.TFS": "[11.3.0, )"
         }
       },
       "sonarscanner.msbuild.preprocessor": {
@@ -4147,7 +4147,7 @@
           "Google.Protobuf": "[3.34.1, )",
           "Newtonsoft.Json": "[13.0.4, )",
           "SharpZipLib": "[1.4.2, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.Net.Http": "[4.3.4, )"
         }
       },
@@ -4155,7 +4155,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -4163,8 +4163,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeCoverage.IO": "[17.7.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       },
       "testutilities": {
@@ -4176,7 +4176,7 @@
           "MSTest.TestFramework": "[4.2.1, )",
           "Microsoft.NET.Test.Sdk": "[18.4.0, )",
           "NSubstitute": "[5.3.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "WireMock.Net": "[2.3.0, )",
           "altcover": "[9.0.102, )"
         }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,12 +61,6 @@ stages:
         steps:
           - checkout: self
 
-          - task: Cache@2
-            displayName: Cache Maven local repo
-            inputs:
-              key: maven | pom.xml
-              path: $(MAVEN_CACHE_FOLDER)
-
           - task: DownloadSecureFile@1
             name: snk
             inputs:
@@ -197,29 +191,8 @@ stages:
             inputs:
               secureFile: 'maven-settings.xml'
 
-          - powershell: |
-              . .\scripts\generate-packages.ps1
+          - powershell: . .\scripts\generate-packages.ps1
             displayName: 'Generate packages'
-
-          - task: Maven@4
-            displayName: Promote new version in pom
-            env:
-              ARTIFACTORY_PRIVATE_READER_USERNAME: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
-              ARTIFACTORY_PRIVATE_READER_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
-              ARTIFACTORY_DEPLOY_PASSWORD: $(ARTIFACTORY_QA_DEPLOYER_ACCESS_TOKEN)
-            inputs:
-              mavenPomFile: 'pom.xml'
-              goals: 'org.codehaus.mojo:versions-maven-plugin:2.2:set'
-              options: >-
-                $(commonMavenArguments)
-                -DnewVersion=$(FULL_VERSION)
-                --settings $(mavenSettings.secureFilePath)
-                -Denable-repo=private
-                -DgenerateBackupPoms=false -e
-              javaHomeOption: 'JDKVersion'
-              mavenVersionOption: 'Default'
-              jdkVersionOption: '1.21'
-              mavenOptions: $(MAVEN_OPTS)
 
           - task: DownloadSecureFile@1
             displayName: 'Download the sign key'
@@ -259,11 +232,6 @@ stages:
             inputs:
               targetPath: 'Packaging'
               artifact: 'Packaging'
-
-          - task: CmdLine@2
-            displayName: Revert changes made to pom.xml to not break cache feature
-            inputs:
-              script: 'git checkout .'
 
   - stage: qa_windows
     displayName: 'QA - Windows:'

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.sonarsource.scanner.msbuild</groupId>
     <artifactId>sonar-scanner</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>11.3-SNAPSHOT</version>
   </parent>
 
   <groupId>org.sonarsource.scanner.msbuild</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.sonarsource.scanner.msbuild</groupId>
   <artifactId>sonar-scanner</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>11.3-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>SonarScanner.MSBuild</name>
   <url>http://redirect.sonarsource.com/doc/msbuild-sq-runner.html</url>

--- a/scripts/set-version.ps1
+++ b/scripts/set-version.ps1
@@ -66,7 +66,7 @@ try {
 
         Write-Host "Pushing branch and creating PR"
         git push -u origin "version-bump/$ShortVersion"
-        gh pr create --title "Bump version to $ShortVersion" --body "" --web --base master --head "version-bump/$ShortVersion"
+        gh pr create --title "Bump version to $ShortVersion" --web --base master --head "version-bump/$ShortVersion"
     }
 
     exit 0

--- a/src/SonarScanner.MSBuild.PostProcessor/packages.lock.json
+++ b/src/SonarScanner.MSBuild.PostProcessor/packages.lock.json
@@ -67,7 +67,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -75,8 +75,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeCoverage.IO": "[17.7.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       }
     },
@@ -297,7 +297,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -305,8 +305,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeCoverage.IO": "[17.7.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       }
     }

--- a/src/SonarScanner.MSBuild.TFS.Classic/packages.lock.json
+++ b/src/SonarScanner.MSBuild.TFS.Classic/packages.lock.json
@@ -68,7 +68,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -76,8 +76,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeCoverage.IO": "[17.7.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       }
     }

--- a/src/SonarScanner.MSBuild.TFS/packages.lock.json
+++ b/src/SonarScanner.MSBuild.TFS/packages.lock.json
@@ -68,7 +68,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       }
@@ -291,7 +291,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       }

--- a/src/SonarScanner.MSBuild/packages.lock.json
+++ b/src/SonarScanner.MSBuild/packages.lock.json
@@ -649,9 +649,9 @@
       "sonarscanner.msbuild.postprocessor": {
         "type": "Project",
         "dependencies": {
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )",
-          "SonarScanner.MSBuild.TFS": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )",
+          "SonarScanner.MSBuild.TFS": "[11.3.0, )"
         }
       },
       "sonarscanner.msbuild.preprocessor": {
@@ -660,7 +660,7 @@
           "Google.Protobuf": "[3.34.1, )",
           "Newtonsoft.Json": "[13.0.4, )",
           "SharpZipLib": "[1.4.2, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.Net.Http": "[4.3.4, )"
         }
       },
@@ -668,7 +668,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -676,8 +676,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeCoverage.IO": "[17.7.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       }
     },
@@ -832,9 +832,9 @@
       "sonarscanner.msbuild.postprocessor": {
         "type": "Project",
         "dependencies": {
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )",
-          "SonarScanner.MSBuild.TFS": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )",
+          "SonarScanner.MSBuild.TFS": "[11.3.0, )"
         }
       },
       "sonarscanner.msbuild.preprocessor": {
@@ -843,7 +843,7 @@
           "Google.Protobuf": "[3.34.1, )",
           "Newtonsoft.Json": "[13.0.4, )",
           "SharpZipLib": "[1.4.2, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.Net.Http": "[4.3.4, )"
         }
       },
@@ -851,7 +851,7 @@
         "type": "Project",
         "dependencies": {
           "Newtonsoft.Json": "[13.0.4, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
           "System.ValueTuple": "[4.6.2, )"
         }
       },
@@ -859,8 +859,8 @@
         "type": "Project",
         "dependencies": {
           "Microsoft.CodeCoverage.IO": "[17.7.0, )",
-          "SonarScanner.MSBuild.Common": "[1.0.0, )",
-          "SonarScanner.MSBuild.Shim": "[1.0.0, )"
+          "SonarScanner.MSBuild.Common": "[11.3.0, )",
+          "SonarScanner.MSBuild.Shim": "[11.3.0, )"
         }
       }
     }


### PR DESCRIPTION
Part of SCAN4NET-1543

Execute set-version.ps1
Cleanup maven steps that are not needed anymore (it used to download ton of maven dependencies with cache miss just to rewrite 1 line in two pom.xml files)