### PR TITLE
SCAN4NET-1555 Unify ZIP artifact names

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,6 +206,8 @@ stages:
               ARTIFACTORY_PRIVATE_READER_USERNAME: $(ARTIFACTORY_PRIVATE_READER_USERNAME)
               ARTIFACTORY_PRIVATE_READER_PASSWORD: $(ARTIFACTORY_PRIVATE_READER_ACCESS_TOKEN)
               BUILD_ID: $(Build.BuildId)
+              PROJECT_VERSION: $(FULL_VERSION)  # Stored in JFrog, used for release action
+              FULL_VERSION: $(FULL_VERSION)
               PATCH_VERSION: $(PATCH_VERSION)
               ARTIFACTORY_DEPLOY_PASSWORD: $(ARTIFACTORY_QA_DEPLOYER_ACCESS_TOKEN)
               PGP_SIGN_KEY_PATH: $(signKey.secureFilePath)
@@ -221,12 +223,6 @@ stages:
               javaHomeOption: 'JDKVersion'
               jdkVersionOption: '1.21'
               mavenOptions: $(MAVEN_OPTS)
-
-          - powershell: |
-              $artifactsFolder = "$env:BUILD_SOURCESDIRECTORY\\build"
-              Rename-Item -Path "$artifactsFolder\\sonarscanner-net-framework.zip" -NewName sonar-scanner-$(FULL_VERSION)-net-framework.zip
-              Rename-Item -Path "$artifactsFolder\\sonarscanner-net.zip" -NewName sonar-scanner-$(FULL_VERSION)-net.zip
-            displayName: "Rename artifacts for GitHub Release"
 
           - task: PublishPipelineArtifact@1
             displayName: 'Publish Packaging artifact'

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
             <configuration>
               <artifacts>
                 <artifact>
-                  <file>build/sonarscanner-net-framework.zip</file>
+                  <file>build/sonar-scanner-${env.FULL_VERSION}-net-framework.zip</file>
                   <type>zip</type>
                   <classifier>net-framework</classifier>
                 </artifact>
@@ -80,7 +80,7 @@
                   <classifier>net-framework</classifier>
                 </artifact>
                 <artifact>
-                  <file>build/sonarscanner-net.zip</file>
+                  <file>build/sonar-scanner-${env.FULL_VERSION}-net.zip</file>
                   <type>zip</type>
                   <classifier>net</classifier>
                 </artifact>

--- a/scripts/generate-packages.ps1
+++ b/scripts/generate-packages.ps1
@@ -36,8 +36,8 @@ function Update-Choco-Package([string] $scannerZipFileName, [string] $runtimeSuf
 }
 
 $artifactsFolder = "$sourcesDirectory/build"
-$netFrameworkScannerZipPath = Get-Item "$artifactsFolder/sonarscanner-net-framework.zip"
-$netScannerZipPath = Get-Item "$artifactsFolder/sonarscanner-net.zip"
+$netFrameworkScannerZipPath = Get-Item "$artifactsFolder/sonar-scanner-$env:FULL_VERSION-net-framework.zip"
+$netScannerZipPath = Get-Item "$artifactsFolder/sonar-scanner-$env:FULL_VERSION-net.zip"
 
 Update-Choco-Package $netFrameworkScannerZipPath 'net-framework'
 Update-Choco-Package $netScannerZipPath 'net'

--- a/scripts/package-artifacts.ps1
+++ b/scripts/package-artifacts.ps1
@@ -4,6 +4,7 @@
     )
 
     $Destination = "$FullBuildOutputDir\sonarscanner-net-framework"
+    $DestinationZip = "$FullBuildOutputDir\sonar-scanner-$env:FULL_VERSION-net-framework.zip"
     $DestinationTargets = "$Destination\Targets"
     $DestinationLicenses = "$Destination\licenses"
     $DestinationThirdPartyLicenses = "$DestinationLicenses\THIRD_PARTY_LICENSES"
@@ -36,7 +37,7 @@
 
     # Don't use Compress-Archive because https://github.com/SonarSource/sonar-scanner-msbuild/issues/2086
     # This is propably fixed in Powershell 7
-    tar -c -a -C "$Destination" --options "zip:compression-level=9" -f "$Destination.zip" *
+    tar -c -a -C "$Destination" --options "zip:compression-level=9" -f "$DestinationZip" *
 }
 
 function Package-NetScanner {
@@ -46,6 +47,7 @@ function Package-NetScanner {
 
     $SourceRoot = "$PSScriptRoot\..\src\SonarScanner.MSBuild\bin\Release\netcoreapp3.1"
     $Destination = "$FullBuildOutputDir\sonarscanner-net"
+    $DestinationZip = "$FullBuildOutputDir\sonar-scanner-$env:FULL_VERSION-net.zip"
     $DestinationTargets = "$Destination\Targets"
     $DestinationLicenses = "$Destination\licenses"
     $DestinationThirdPartyLicenses = "$DestinationLicenses\THIRD_PARTY_LICENSES"
@@ -79,7 +81,7 @@ function Package-NetScanner {
 
     # Don't use Compress-Archive because https://github.com/SonarSource/sonar-scanner-msbuild/issues/2086
     # This is propably fixed in Powershell 7
-    tar -c -a -C "$Destination" --options "zip:compression-level=9" -f "$Destination.zip" *
+    tar -c -a -C "$Destination" --options "zip:compression-level=9" -f "$DestinationZip" *
 }
 
 function Sign-Assemblies {


### PR DESCRIPTION
Same change applies to `-net` and `-net-framework` flavors.

Before:
`sonarscanner-net.zip` was created and used, published to repox, and then renamed to `sonar-scanner-11.3.0.42424-net.zip` and published as build artifact for GH release

After:
`sonar-scanner-11.3.0.42424-net.zip` is created and used consistently everywhere

