### PR TITLE
SCAN4NET-1556 Move Assembly Signing to Packaging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,13 +152,31 @@ stages:
               arguments: '/m /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /p:configuration=$(BUILD_CONFIGURATION) /p:platform="$(BUILD_PLATFORM)"'
 
           - task: PowerShell@2
-            displayName: 'Sign and package scanner files'
+            displayName: 'Sign .NET Assemblies'
             env:
               SM_CLIENT_CRT_FILE: $(SM_CLIENT_CRT.secureFilePath)
               SM_CLIENT_CERT_FILE: $(SM_CLIENT_CERT.secureFilePath)
               SM_CLIENT_CERT_PASSWORD: $(SM_CLIENT_CERT_PASSWORD)
               SM_API_KEY: $(SM_API_KEY)
               SM_CERT: $(SM_CERT)
+            condition: and(succeeded(), eq(variables.IS_RELEASE_BRANCH, 'true'))
+            inputs:
+              targetType: 'inline'
+              script: |
+                function Sign-Assemblies([string]$FolderPath) {
+                    Write-Host "Signing $FolderPath"
+                    Get-ChildItem -Path $FolderPath -Recurse -Include @("Sonar*.dll", "Sonar*.exe") |
+                        Foreach-Object {
+                            Write-Host "Signing $($_.FullName)"
+                            & signtool sign /du https://www.sonarsource.com/ /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 /csp "DigiCert Signing Manager KSP" /kc "$env:SM_KP" /f "$env:SM_CLIENT_CRT_FILE" $_.FullName
+                        }
+                }
+
+                Sign-Assemblies "Packaging/Binaries/Net"
+                Sign-Assemblies "Packaging/Binaries/Net-Framework"
+
+          - task: PowerShell@2
+            displayName: 'Zip .NET Packages'
             inputs:
               targetType: 'inline'
               script: |

--- a/scripts/package-artifacts.ps1
+++ b/scripts/package-artifacts.ps1
@@ -31,10 +31,6 @@
     Copy-Item -Path "$PSScriptRoot\..\LICENSE.txt" -Destination $DestinationLicenses
     Copy-Item -Path "$PSScriptRoot\..\Licenses\THIRD_PARTY_LICENSES\*" -Destination $DestinationThirdPartyLicenses
 
-    if ($SignAssemblies) {
-        Sign-Assemblies -Pattern "$Destination\Sonar*" -TargetName ".NET Framework assemblies"
-    }
-
     # Don't use Compress-Archive because https://github.com/SonarSource/sonar-scanner-msbuild/issues/2086
     # This is propably fixed in Powershell 7
     tar -c -a -C "$Destination" --options "zip:compression-level=9" -f "$DestinationZip" *
@@ -75,24 +71,8 @@ function Package-NetScanner {
     Copy-Item -Path "$PSScriptRoot\..\Licenses\THIRD_PARTY_LICENSES\Newtonsoft.Json-LICENSE.txt" -Destination $DestinationThirdPartyLicenses
     Copy-Item -Path "$PSScriptRoot\..\Licenses\THIRD_PARTY_LICENSES\SharpZipLib-LICENSE.txt" -Destination $DestinationThirdPartyLicenses
 
-    if ($SignAssemblies) {
-        Sign-Assemblies -Pattern "$Destination\Sonar*" -TargetName ".NET assemblies"
-    }
-
     # Don't use Compress-Archive because https://github.com/SonarSource/sonar-scanner-msbuild/issues/2086
     # This is propably fixed in Powershell 7
     tar -c -a -C "$Destination" --options "zip:compression-level=9" -f "$DestinationZip" *
 }
 
-function Sign-Assemblies {
-    param (
-        [string]$Pattern,
-        [string]$TargetName
-    )
-    Write-Host "Signing $TargetName"
-    Get-ChildItem -Path $Pattern -Include @("*.dll","*.exe") |
-        Foreach-Object {
-            & signtool sign /du https://www.sonarsource.com/ /tr http://timestamp.digicert.com /td SHA256 /fd SHA256 /csp "DigiCert Signing Manager KSP" /kc "$env:SM_KP" /f "$env:SM_CLIENT_CRT_FILE" $_.FullName
-        }
-    Write-Host "[Completed] Signing $TargetName"
-}


### PR DESCRIPTION
Part of SCAN4NET-300

Once this is merged, the `build` assemblies (still published to repox) are temporarily not signed. SCAN4NET-1547 will delete `build` later.

Tested here
https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=139710&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=1bb4b58e-f076-55c3-0dfc-a70a7c67f4bb
using
```
  - name: IS_RELEASE_BRANCH
    #FIXME: Revert before merging
    #value: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/branch-')) }}
    value: true
```