### PR TITLE
SCAN4NET-1558 Fix NuGet signing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,9 +31,7 @@ variables:
     value: $[variables.ARTIFACTORY_PRIVATE_READER_USERNAME]
   # pipelines-yaml-templates/promote-stage.yml line 56
   - name: IS_RELEASE_BRANCH
-  #FIXME: Restore before approval
-    #value: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/branch-')) }}
-    value: true
+    value: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/branch-')) }}
   - name: BUILD_CONFIGURATION
     value: "Release"
   - name: BUILD_PLATFORM

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,9 @@ variables:
     value: $[variables.ARTIFACTORY_PRIVATE_READER_USERNAME]
   # pipelines-yaml-templates/promote-stage.yml line 56
   - name: IS_RELEASE_BRANCH
-    value: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/branch-')) }}
+  #FIXME: Restore before approval
+    #value: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/branch-')) }}
+    value: true
   - name: BUILD_CONFIGURATION
     value: "Release"
   - name: BUILD_PLATFORM
@@ -176,7 +178,7 @@ stages:
             displayName: "Sign NuGet packages"
             condition: and(succeeded(), eq(variables.IS_RELEASE_BRANCH, 'true'))
             env:
-              PACKAGES_PATH: '$(Build.SourcesDirectory)\build\dotnet-sonarscanner*.nupkg'
+              PACKAGES_PATH: '$(Build.SourcesDirectory)\Packaging\Binaries\dotnet-sonarscanner*.nupkg'
               SM_CLIENT_CERT_FILE: $(SM_CLIENT_CERT.secureFilePath)
               SM_CLIENT_CERT_PASSWORD: $(SM_CLIENT_CERT_PASSWORD)
               SM_API_KEY: $(SM_API_KEY)


### PR DESCRIPTION
Part of SCAN4NET-1540

Tested here 
https://dev.azure.com/sonarsource/DotNetTeam%20Project/_build/results?buildId=139727&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=00170b8f-1061-5420-820e-1eb883d5ca57
using
```
  - name: IS_RELEASE_BRANCH
  #FIXME: Restore before approval
    #value: ${{ or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/branch-')) }}
    value: true

```