### PR TITLE
SCAN4NET-1582 Simplify ScannerTest rule assertions to analyzer-level

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerTest.java
@@ -48,8 +48,7 @@ class ScannerTest {
 
     assertTrue(result.isSuccess());
     List<Issue> issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
-    // 1 * csharpsquid:S1134 (line 34)
-    assertThat(issues).hasSize(1);
+    assertThat(issues).filteredOn(x -> x.getRule().startsWith("csharpsquid")).isNotEmpty();
     assertThat(TestUtils.getMeasureAsInteger(context.projectKey, "ncloc", ORCHESTRATOR)).isEqualTo(25);
     assertThat(TestUtils.getMeasureAsInteger(context.projectKey + ":ProjectUnderTest/Foo.cs", "ncloc", ORCHESTRATOR)).isEqualTo(25);
     assertThat(TestUtils.getMeasureAsInteger(context.projectKey + ":ProjectUnderTest/Foo.cs", "lines", ORCHESTRATOR)).isEqualTo(52);
@@ -114,12 +113,7 @@ class ScannerTest {
     var issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
 
     assertThat(logs).doesNotContain("Failed to parse properties from the environment variable 'SONARQUBE_SCANNER_PARAMS'");
-    assertThat(issues).hasSize(3)
-      .extracting(Issue::getRule)
-      .containsExactlyInAnyOrder(
-        "csharpsquid:S1481", // Program.cs line 7
-        "csharpsquid:S1186", // Program.cs line 10
-        "csharpsquid:S1481"); // Generator.cs line 18
+    assertThat(issues).filteredOn(x -> x.getRule().startsWith("csharpsquid")).isNotEmpty();
 
     assertThat(TestUtils.getMeasureAsInteger(context.projectKey, "lines", ORCHESTRATOR)).isEqualTo(40);
     assertThat(TestUtils.getMeasureAsInteger(context.projectKey, "ncloc", ORCHESTRATOR)).isEqualTo(30);


### PR DESCRIPTION
## What
Replace specific rule-ID and exact-count assertions in `ScannerTest` with looser "the C# analyzer raised at least one issue" checks.

## Why
The ITs pinned exact rule keys (e.g. `csharpsquid:S1481`) and counts, coupling them to the bundled analyzer version. These tests exist to verify the scanner invokes the analyzer and imports its issues, not to track the analyzer's exact rule set. `noActiveRule` (`isEmpty()`) is left unchanged.

First of a series, one PR per test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Test refactoring:**
  - Updated `MultiLanguageTest` and `ScannerTest` to use rule-prefix assertions instead of pinning exact rule IDs and issue counts.
  - Simplified complex tuple-based issue validations in `MultiLanguageTest` to focus on verifying presence of issues by component or language prefix.


<sub>This will update automatically on new commits.</sub>