### PR TITLE
SCAN4NET-1586 Simplify CppTest rule assertions to analyzer-level

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CppTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CppTest.java
@@ -77,7 +77,7 @@ class CppTest {
       assertThat(result.getLogs()).doesNotContain("Invalid character encountered in file");
 
       List<Issue> issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
-      assertThat(issues).extracting(Issue::getRule).containsAll(List.of("cpp:S106"));
+      assertThat(issues).filteredOn(x -> x.getRule().startsWith("cpp")).isNotEmpty();
       assertThat(TestUtils.getMeasureAsInteger(context.projectKey, "ncloc", ORCHESTRATOR)).isEqualTo(15);
       assertThat(TestUtils.getMeasureAsInteger(context.projectKey + ":ConsoleApp/ConsoleApp.cpp", "ncloc", ORCHESTRATOR)).isEqualTo(8);
     }
@@ -106,7 +106,7 @@ class CppTest {
       assertThat(result.getLogs()).doesNotContain("Invalid character encountered in file");
 
       List<Issue> issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
-      assertThat(issues).extracting(Issue::getRule).containsAll(List.of("cpp:S106"));
+      assertThat(issues).filteredOn(x -> x.getRule().startsWith("cpp")).isNotEmpty();
       assertThat(TestUtils.getMeasureAsInteger(context.projectKey, "ncloc", ORCHESTRATOR)).isEqualTo(22);
       assertThat(TestUtils.getMeasureAsInteger(context.projectKey + ":Project1/Project1.cpp", "ncloc", ORCHESTRATOR)).isEqualTo(8);
     }


### PR DESCRIPTION
## What
Replace `cpp:S106` assertions in `CppTest` with a "the C++ analyzer raised an issue" check. Measure assertions are unchanged.

## Why
The ITs pinned an exact rule key, coupling them to the bundled analyzer version. These tests verify the scanner invokes the analyzer and imports its issues. One PR per test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Refactored integration tests:**
  - Replaced specific rule key assertions with generic `startsWith` checks for `cpp`, `vbnet`, `csharpsquid`, `javascript`, `typescript`, `php`, `docker`, `terraform`, `azureresourcemanager`, `cloudformation`, `ipython`, `java`, `secrets`, `groovydre`, and `powershelldre`.
  - Simplified multi-language file path assertions in `MultiLanguageTest.java` to verify existence rather than exact rule-component tuples.

<sub>This will update automatically on new commits.</sub>