### PR TITLE
SCAN4NET-1587 Simplify WarningWaveTest rule assertion to analyzer-level

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/WarningWaveTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/WarningWaveTest.java
@@ -27,7 +27,6 @@ import org.sonarqube.ws.Issues.Issue;
 import java.util.List;
 
 import static com.sonar.it.scanner.msbuild.utils.SonarAssertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 
 @ExtendWith({ServerTests.class, ContextExtension.class})
 class WarningWaveTest {
@@ -42,7 +41,8 @@ class WarningWaveTest {
 
     List<Issue> issues = TestUtils.projectIssues(context.orchestrator, context.projectKey);
     assertThat(issues)
-      .extracting(Issue::getRule, Issue::getComponent)
-      .contains(tuple("external_roslyn:CS8981", context.projectKey + ":Program.cs"));
+      .filteredOn(x -> x.getRule().startsWith("external_roslyn"))
+      .extracting(Issue::getComponent)
+      .contains(context.projectKey + ":Program.cs");
   }
 }


### PR DESCRIPTION
## What
Replace the `external_roslyn:CS8981` rule assertion in `WarningWaveTest` with a check that an external Roslyn issue is imported on `Program.cs` (drops the exact rule key, keeps the file).

## Why
The IT pinned an exact external rule key, coupling it to the bundled analyzer version. The test verifies that external Roslyn issues are imported. One PR per test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)