### PR TITLE
CLP-95 Update notifications Slack channels

### DIFF
--- a/.github/workflows/SlackNotification.yml
+++ b/.github/workflows/SlackNotification.yml
@@ -21,4 +21,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         uses: SonarSource/gh-action_slack-notify@v1
         with:
-          slackChannel: squad-dotnet-s4net
+          slackChannel: squad-corelang-notifs

--- a/.github/workflows/ToggleLockBranch.yml
+++ b/.github/workflows/ToggleLockBranch.yml
@@ -25,4 +25,4 @@ jobs:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
           additional-message: ${{ github.event.inputs.additional-message }}
-          slack-channel: squad-dotnet-s4net
+          slack-channel: squad-corelang-releases

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
-          slack-channel: squad-dotnet-s4net
+          slack-channel: squad-corelang-releases
           branch-pattern: ${{ inputs.branch }}
           lock-branch: true
   release:
@@ -61,7 +61,7 @@ jobs:
       project-name: "SonarScanner for .NET"
       plugin-name: "scanner-msbuild" # irrelevant for Scanner MSBuild but required
       jira-project-key: "SCAN4NET"
-      slack-channel: "squad-dotnet-s4net"
+      slack-channel: "squad-corelang-releases"
       release-artifacts-private: |
         sonarsource-public-builds/org/sonarsource/scanner/msbuild/sonar-scanner/{version}/sonar-scanner-{version}-net-framework.zip
         sonarsource-public-builds/org/sonarsource/scanner/msbuild/sonar-scanner/{version}/sonar-scanner-{version}-net.zip
@@ -97,7 +97,7 @@ jobs:
         with:
           github-token: ${{ fromJSON(steps.secrets.outputs.vault).lock_token }}
           slack-token: ${{ fromJSON(steps.secrets.outputs.vault).slack_api_token }}
-          slack-channel: squad-dotnet-s4net
+          slack-channel: squad-corelang-releases
           branch-pattern: ${{ inputs.branch }}
           lock-branch: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,6 @@ jobs:
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
       publishToBinaries: true
-      slackChannel: squad-dotnet-s4net
+      slackChannel: squad-corelang-releases
       version: ${{ inputs.version }}
       dryRun: ${{ inputs.dryRun }}


### PR DESCRIPTION
Part of [CLP-59](https://sonarsource.atlassian.net/browse/CLP-59).

[CLP-59]: https://sonarsource.atlassian.net/browse/CLP-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **Slack channel migrations:**
  - Update `slack-channel` from `squad-dotnet-s4net` to `squad-corelang-releases` in various CI workflows.
  - Update `slackChannel` to `squad-corelang-notifs` in `SlackNotification.yml`.

<sub>This will update automatically on new commits.</sub>