### PR TITLE
SCAN4NET-1592 Remove inherited Renovate rules from scanner config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,13 @@
   },
   "packageRules": [
     {
+      "description": "Do update SonarSource/sonar-secrets-pre-commit.",
+      "matchDepNames": [
+        "SonarSource/sonar-secrets-pre-commit"
+      ],
+      "enabled": true
+    },
+    {
       "description": "Group MSTest dependencies into a single PR",
       "matchPackageNames": [
         "MSTest.**",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,21 +20,6 @@
   },
   "packageRules": [
     {
-      "description": "Do update SonarSource/sonar-secrets-pre-commit.",
-      "matchDepNames": [
-        "SonarSource/sonar-secrets-pre-commit"
-      ],
-      "enabled": true
-    },
-    {
-      "description": "Group MSTest dependencies into a single PR",
-      "matchPackageNames": [
-        "MSTest.**",
-        "Microsoft.NET.Test.Sdk"
-      ],
-      "groupName": "MSTest"
-    },
-    {
       "description": "Group Coverlet dependencies into a single PR",
       "matchPackageNames": [
         "coverlet.**"
@@ -42,26 +27,11 @@
       "groupName": "Coverlet"
     },
     {
-      "description": "Group protobuf packages together - Grpc.Tools bundles protoc which must be compatible with the Google.Protobuf runtime",
-      "matchPackageNames": [
-        "Google.Protobuf",
-        "Grpc.Tools"
-      ],
-      "groupName": "protobuf"
-    },
-    {
       "description": "Do not update Build dependency. It provides backward compatibility with MsBuild 14+",
       "matchPackageNames": [
         "Microsoft.Build**"
       ],
       "enabled": false
-    },
-    {
-      "description": "Do not update FluentAssertions above v7 due to license change",
-      "matchPackageNames": [
-        "FluentAssertions"
-      ],
-      "allowedVersions": "<8.0.0"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,20 +20,6 @@
   },
   "packageRules": [
     {
-      "description": "Do not update SonarSource GH actions, we want the branch-version. Only external actions must have commit ID.",
-      "matchDepNames": [
-        "SonarSource/**"
-      ],
-      "enabled": false
-    },
-    {
-      "description": "Do update SonarSource/sonar-secrets-pre-commit.",
-      "matchDepNames": [
-        "SonarSource/sonar-secrets-pre-commit"
-      ],
-      "enabled": true
-    },
-    {
       "description": "Group MSTest dependencies into a single PR",
       "matchPackageNames": [
         "MSTest.**",


### PR DESCRIPTION
## Summary
- remove local Renovate rules that are now inherited from the shared Core Languages & Parsers preset
- keep only the scanner-specific Renovate rules in this repository

## Why
This repository already extends the shared Core Languages & Parsers Renovate preset.

The shared preset is being expanded in SonarSource/core-languages-tooling-public#28 to cover:
- SonarSource GitHub Actions policy
- MSTest grouping
- protobuf grouping
- `FluentAssertions < 8`

Once that PR is merged, the matching local rules in this repository become redundant.

## What stays local
This PR keeps the repository-specific rules that are not part of the shared preset:
- Coverlet grouping
- Microsoft.Build update disabling
- pre-commit configuration
- repository-specific `nuget.ignorePaths`

## Important
This PR depends on SonarSource/core-languages-tooling-public#28 and should be merged only after that preset change is on `master`.