### PR TITLE
SCAN4NET-1610 Revert #3188 "Simplify ScannerEngineTest rule assertion to analyzer-level"

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerEngineTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerEngineTest.java
@@ -47,6 +47,7 @@ import org.xml.sax.SAXException;
 
 import static com.sonar.it.scanner.msbuild.sonarqube.ServerTests.ORCHESTRATOR;
 import static com.sonar.it.scanner.msbuild.utils.SonarAssertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith({ServerTests.class, ContextExtension.class})
@@ -65,9 +66,14 @@ class ScannerEngineTest {
 
     assertTrue(result.isSuccess());
     var issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
-    assertThat(issues).filteredOn(x -> x.getRule().startsWith("csharpsquid"))
-      .extracting(x -> x.getComponent())
-      .contains(context.projectKey + ":UTF8Filenames/UTF8Filename_äöüß_ソナー_😊.cs");
+    assertThat(issues)
+      .extracting(x -> tuple(x.getComponent(), x.getRule(), x.getMessage()))
+      .containsExactlyInAnyOrder(
+        tuple(
+          context.projectKey + ":UTF8Filenames/UTF8Filename_äöüß_ソナー_😊.cs",
+          "csharpsquid:S101",
+          "Rename class 'UTF8Filename_äöüß_ソナー' to match pascal case naming rules, consider using 'Utf8Filenameäöüßソナー'.")
+      );
     var analyses = TestUtils.newWsClient(ORCHESTRATOR).projectAnalyses().search(new SearchRequest().setProject(context.projectKey)).getAnalysesList();
     assertThat(analyses)
       .extracting(ProjectAnalyses.Analysis::getBuildString)

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerEngineTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ScannerEngineTest.java
@@ -67,6 +67,7 @@ class ScannerEngineTest {
     assertTrue(result.isSuccess());
     var issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
     assertThat(issues)
+      .filteredOn(x -> x.getRule().equals("csharpsquid:S101"))
       .extracting(x -> tuple(x.getComponent(), x.getRule(), x.getMessage()))
       .containsExactlyInAnyOrder(
         tuple(


### PR DESCRIPTION
This reverts commit 024e5d9.

----
## Summary by Gitar

- **Test assertions:**
  - Added a rule filter for `csharpsquid:S101` in `ScannerEngineTest` to replace previous broad filtering.
  - Updated assertions to verify specific rule components, IDs, and messages using `tuple` for strict matching.

<sub>This will update automatically on new commits.</sub>