### PR TITLE
SCAN4NET-1611 Revert #3184 "Simplify CppTest rule assertions to analyzer-level

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CppTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CppTest.java
@@ -77,7 +77,7 @@ class CppTest {
       assertThat(result.getLogs()).doesNotContain("Invalid character encountered in file");
 
       List<Issue> issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
-      assertThat(issues).filteredOn(x -> x.getRule().startsWith("cpp")).isNotEmpty();
+      assertThat(issues).extracting(Issue::getRule).containsAll(List.of("cpp:S106"));
       assertThat(TestUtils.getMeasureAsInteger(context.projectKey, "ncloc", ORCHESTRATOR)).isEqualTo(15);
       assertThat(TestUtils.getMeasureAsInteger(context.projectKey + ":ConsoleApp/ConsoleApp.cpp", "ncloc", ORCHESTRATOR)).isEqualTo(8);
     }
@@ -106,7 +106,7 @@ class CppTest {
       assertThat(result.getLogs()).doesNotContain("Invalid character encountered in file");
 
       List<Issue> issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
-      assertThat(issues).filteredOn(x -> x.getRule().startsWith("cpp")).isNotEmpty();
+      assertThat(issues).extracting(Issue::getRule).containsAll(List.of("cpp:S106"));
       assertThat(TestUtils.getMeasureAsInteger(context.projectKey, "ncloc", ORCHESTRATOR)).isEqualTo(22);
       assertThat(TestUtils.getMeasureAsInteger(context.projectKey + ":Project1/Project1.cpp", "ncloc", ORCHESTRATOR)).isEqualTo(8);
     }


### PR DESCRIPTION
This reverts commit 99405b44032eabdd06f364b71d5c5ab656d027aa.