### PR TITLE
SCAN4NET-1613 Add bare GitHub Actions CI workflow skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and Test
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master, 'branch-*']
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: warp-custom-dotnet-bubble-ci
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          fetch-depth: 0


### PR DESCRIPTION
## Summary
- First step of the incremental Azure Pipelines → GitHub Actions migration.
- Adds `.github/workflows/ci.yml`: trigger/concurrency/permissions scaffolding and a single checkout step on `warp-custom-dotnet-bubble-ci`. No build logic yet.
- `azure-pipelines.yml` stays untouched and remains the only required check; this workflow is purely informational for now.

## Test plan
- [ ] Confirm the `CI / Build` check appears on this PR and goes green (checkout succeeds on the runner)
- [ ] Confirm existing Azure Pipelines checks still gate the PR unchanged

Part of NET-2037