### PR TITLE
SCAN4NET-1614 Add prepare action with tool install, wire into CI workflow

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,0 +1,12 @@
+name: Prepare
+description: Install tools, cache NuGet, fetch secrets, compute version, and restore.
+
+runs:
+  using: composite
+  steps:
+    - name: Install tools
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      with:
+        cache: true
+        tool_versions: |
+          gh 2.92

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,6 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
+
+      - name: Prepare
+        uses: ./.github/actions/prepare


### PR DESCRIPTION
## Summary
- Second step of the incremental Azure Pipelines → GitHub Actions migration (stacked on #3213).
- Adds `.github/actions/prepare`, a composite action starting with just `gh` CLI install via `jdx/mise-action`.
- Wires it into `ci.yml`. Versioning and NuGet restore land in follow-up PRs, kept out here to keep this reviewable in isolation.

## Test plan
- [ ] Confirm the `CI / Build` check installs `gh` successfully

Part of NET-2037