### PR TITLE
SCAN4NET-1616 SCAN4NET-1617 Add prepare action which computes version

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -4,9 +4,3 @@ description: Install tools, cache NuGet, fetch secrets, compute version, and res
 runs:
   using: composite
   steps:
-    - name: Install tools
-      uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
-      with:
-        cache: true
-        tool_versions: |
-          gh 2.96.0

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,0 +1,12 @@
+name: Prepare
+description: Install tools, cache NuGet, fetch secrets, compute version, and restore.
+
+runs:
+  using: composite
+  steps:
+    - name: Install tools
+      uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      with:
+        cache: true
+        tool_versions: |
+          gh 2.96.0

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -4,3 +4,25 @@ description: Install tools, cache NuGet, fetch secrets, compute version, and res
 runs:
   using: composite
   steps:
+    - name: Get build number
+      uses: SonarSource/ci-github-actions/get-build-number@v1
+      id: get-build-number
+
+    - name: Set version
+      id: set-version
+      #TODO: Wait for https://sonarsource.atlassian.net/browse/NET-4093 (rewrite set-version-ci.ps1), then adopt the same approach here.
+      shell: powershell
+      env:
+        BUILD_BUILDID:          ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+        BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
+        BUILD_SOURCEVERSION:    ${{ github.sha }}
+      run: |
+        [xml]$xml = Get-Content Version.targets
+        $ShortVersion = $xml.Project.PropertyGroup.ShortVersion.Trim()
+        $PatchVersion = if ($ShortVersion.Split('.').Count -eq 2) { "$ShortVersion.0" } else { $ShortVersion }
+        $FullVersion  = "$PatchVersion.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
+        Write-Host "SHORT_VERSION=$ShortVersion"
+        Write-Host "PATCH_VERSION=$PatchVersion"
+        Write-Host "FULL_VERSION=$FullVersion"
+        $env:SHORT_VERSION = $ShortVersion
+        ./scripts/set-version-ci.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and Test
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,6 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
+
+      - name: Prepare
+        uses: ./.github/actions/prepare


### PR DESCRIPTION
## Summary
- Second step of the incremental Azure Pipelines → GitHub Actions migration (stacked on the Tim/CiSkeleton PR).
- Adds `.github/actions/prepare`, a composite action starting with just `gh` CLI install via `jdx/mise-action`.
- Wires it into `ci.yml`. Versioning and NuGet restore land in follow-up PRs, kept out here to keep this reviewable in isolation.

## Test plan
- [ ] Confirm the `Build` check installs `gh` successfully

Part of NET-2037

----
## Summary by Gitar

- **CI Configuration:**
  - Added `action.yml` for the `prepare` composite action to compute build versions.
  - Integrated versioning logic in `prepare/action.yml` using `Version.targets` and build IDs.
  - Updated `ci.yml` to call the new `prepare` action step.

<sub>This will update automatically on new commits.</sub>