### PR TITLE
SCAN4NET-1617 Compute version in CI workflow

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -20,7 +20,7 @@ runs:
       run: |
         [xml]$xml = Get-Content Version.targets
         $ShortVersion = $xml.Project.PropertyGroup.ShortVersion.Trim()
-        $PatchVersion = if ($ShortVersion.IndexOf('.') -eq $ShortVersion.LastIndexOf('.')) { "$ShortVersion.0" } else { $ShortVersion }
+        $PatchVersion = if ($ShortVersion.Split('.').Count -eq 2) { "$ShortVersion.0" } else { $ShortVersion }
         $FullVersion  = "$PatchVersion.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
         Write-Host "SHORT_VERSION=$ShortVersion"
         Write-Host "PATCH_VERSION=$PatchVersion"

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,6 +1,46 @@
 name: Prepare
 description: Install tools, cache NuGet, fetch secrets, compute version, and restore.
 
+outputs:
+  SHORT_VERSION:
+    description: Short version (e.g. 1.2)
+    value: ${{ steps.set-version.outputs.SHORT_VERSION }}
+  PATCH_VERSION:
+    description: Patch version (e.g. 1.2.0)
+    value: ${{ steps.set-version.outputs.PATCH_VERSION }}
+  FULL_VERSION:
+    description: Full version including build number (e.g. 1.2.0.123)
+    value: ${{ steps.set-version.outputs.FULL_VERSION }}
+  BUILD_NUMBER:
+    description: CI build number
+    value: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+
 runs:
   using: composite
   steps:
+
+    - name: Get build number
+      uses: SonarSource/ci-github-actions/get-build-number@master
+      id: get-build-number
+
+    - name: Set version
+      id: set-version
+      #TODO: Rename params in set-version-ci.ps1 when we delete azure-pipelines.yml
+      shell: powershell
+      env:
+        BUILD_BUILDID:          ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+        BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
+        BUILD_SOURCEVERSION:    ${{ github.sha }}
+      run: |
+        [xml]$xml = Get-Content Version.targets
+        $ShortVersion = $xml.Project.PropertyGroup.ShortVersion.Trim()
+        $PatchVersion = if ($ShortVersion.IndexOf('.') -eq $ShortVersion.LastIndexOf('.')) { "$ShortVersion.0" } else { $ShortVersion }
+        $FullVersion  = "$PatchVersion.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
+        Write-Host "SHORT_VERSION=$ShortVersion"
+        Write-Host "PATCH_VERSION=$PatchVersion"
+        Write-Host "FULL_VERSION=$FullVersion"
+        "SHORT_VERSION=$ShortVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "PATCH_VERSION=$PatchVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "FULL_VERSION=$FullVersion"   | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        $env:SHORT_VERSION = $ShortVersion
+        ./scripts/set-version-ci.ps1

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,20 +1,6 @@
 name: Prepare
 description: Install tools, cache NuGet, fetch secrets, compute version, and restore.
 
-outputs:
-  SHORT_VERSION:
-    description: Short version (e.g. 1.2)
-    value: ${{ steps.set-version.outputs.SHORT_VERSION }}
-  PATCH_VERSION:
-    description: Patch version (e.g. 1.2.0)
-    value: ${{ steps.set-version.outputs.PATCH_VERSION }}
-  FULL_VERSION:
-    description: Full version including build number (e.g. 1.2.0.123)
-    value: ${{ steps.set-version.outputs.FULL_VERSION }}
-  BUILD_NUMBER:
-    description: CI build number
-    value: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
-
 runs:
   using: composite
   steps:
@@ -25,7 +11,7 @@ runs:
 
     - name: Set version
       id: set-version
-      #TODO: Rename params in set-version-ci.ps1 when we delete azure-pipelines.yml
+      #TODO: Wait for https://sonarsource.atlassian.net/browse/NET-4093 (rewrite set-version-ci.ps1), then adopt the same approach here.
       shell: powershell
       env:
         BUILD_BUILDID:          ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
@@ -39,8 +25,5 @@ runs:
         Write-Host "SHORT_VERSION=$ShortVersion"
         Write-Host "PATCH_VERSION=$PatchVersion"
         Write-Host "FULL_VERSION=$FullVersion"
-        "SHORT_VERSION=$ShortVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "PATCH_VERSION=$PatchVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "FULL_VERSION=$FullVersion"   | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         $env:SHORT_VERSION = $ShortVersion
         ./scripts/set-version-ci.ps1

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
 
     - name: Get build number
-      uses: SonarSource/ci-github-actions/get-build-number@master
+      uses: SonarSource/ci-github-actions/get-build-number@v1
       id: get-build-number
 
     - name: Set version


### PR DESCRIPTION
## Summary
- Third step of the incremental Azure Pipelines → GitHub Actions migration (stacked on the Tim/CiPrepareTools PR).
- Adds `Get build number` and `Set version` steps to `.github/actions/prepare`, exposing `SHORT_VERSION`/`PATCH_VERSION`/`FULL_VERSION`/`BUILD_NUMBER` as action outputs.
- Reuses the existing `scripts/set-version-ci.ps1` (unchanged) via the same Azure-Pipelines-style env var names, mapped from GitHub context. Ported from the already-migrated `sonar-dotnet-autoscan` `prepare` action.
- Secrets fetch and NuGet cache/restore land in follow-up PRs, kept out here to keep this reviewable in isolation.

## Test plan
- [ ] Confirm the `Build` check computes a version without error
- [ ] Confirm `SHORT_VERSION`/`PATCH_VERSION`/`FULL_VERSION`/`BUILD_NUMBER` outputs look correct

Part of NET-2037