### PR TITLE
SCAN4NET-1618 Fetch Artifactory secrets and restore NuGet packages in CI workflow

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -3,7 +3,7 @@ description: Install tools, cache NuGet, fetch secrets, compute version, and res
 
 inputs:
   nuget-packages-path:
-    description: Directory NuGet packages are restored into and cached from. Must match the NUGET_PACKAGES env var in the caller so cache and restore agree.
+    description: Directory NuGet packages are restored into and cached from.
     required: true
 
 runs:

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -26,3 +26,11 @@ runs:
         Write-Host "FULL_VERSION=$FullVersion"
         $env:SHORT_VERSION = $ShortVersion
         ./scripts/set-version-ci.ps1
+
+    - name: Fetch Vault Secrets
+      id: secrets
+      uses: SonarSource/vault-action-wrapper@v3
+      with:
+        secrets: |
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,6 +1,11 @@
 name: Prepare
 description: Install tools, cache NuGet, fetch secrets, compute version, and restore.
 
+inputs:
+  nuget-packages-path:
+    description: Directory NuGet packages are restored into and cached from. Must match the NUGET_PACKAGES env var in the caller so cache and restore agree.
+    required: true
+
 runs:
   using: composite
   steps:
@@ -34,3 +39,24 @@ runs:
         secrets: |
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
+
+    - name: Setup cache month variable
+      id: cache-month
+      shell: powershell
+      run: |
+        "CACHE_MONTH=$(Get-Date -Format 'MM')" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+    - name: Cache NuGet packages
+      uses: SonarSource/gh-action_cache@v1
+      with:
+        path: ${{ inputs.nuget-packages-path }}
+        key: nuget-${{ steps.cache-month.outputs.CACHE_MONTH }}-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: nuget-${{ steps.cache-month.outputs.CACHE_MONTH }}-
+
+    - name: Restore
+      shell: powershell
+      env:
+        NUGET_PACKAGES:       ${{ inputs.nuget-packages-path }}
+        ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
+        ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+      run: dotnet restore SonarScanner.MSBuild.sln --locked-mode --configfile "NuGet.Config"

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -40,6 +40,10 @@ runs:
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
 
+    # The cache bucket is the current month. It's part of the cache key so the cache
+    # rotates monthly, preventing it from growing unbounded with stale packages.
+    # Get-Date can't be called inside a ${{ }} expression, so it's computed here.
+    # see: https://docs.github.com/en/actions/reference/workflows-and-actions/expressions
     - name: Setup cache month variable
       id: cache-month
       shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -26,3 +28,5 @@ jobs:
 
       - name: Prepare
         uses: ./.github/actions/prepare
+        with:
+          nuget-packages-path: ${{ env.NUGET_PACKAGES }}


### PR DESCRIPTION
## Summary
- Fourth step of the incremental Azure Pipelines → GitHub Actions migration (stacked on the Tim/CiVersioning PR).
- Adds to `.github/actions/prepare`: a `Fetch Vault Secrets` step (`SonarSource/vault-action-wrapper`) for the private-reader Artifactory credentials, a monthly-rotating NuGet package cache (`SonarSource/gh-action_cache`), and a `Restore` step (`dotnet restore SonarScanner.MSBuild.sln --locked-mode`) authenticated with those credentials. Ported from the already-migrated `sonar-dotnet-autoscan`/`sonar-dotnet-enterprise` `prepare` actions.
- Originally split into two PRs (secrets fetch, then cache+restore); merged into one since the secrets-only step was too small to review in isolation.
- This completes the `prepare` action's stated scope: "Install tools, cache NuGet, fetch secrets, compute version, and restore."

## Test plan
- [ ] Confirm the `Build` check fetches secrets and restores NuGet packages successfully

Part of NET-2037