### PR TITLE
SCAN4NET-1619 Cache and restore NuGet packages in CI workflow

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -58,3 +58,22 @@ runs:
         secrets: |
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
+
+    - name: Setup cache month variable
+      shell: powershell
+      run: |
+        "CACHE_MONTH=$(Get-Date -Format 'MM')" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+    - name: Cache NuGet packages
+      uses: SonarSource/gh-action_cache@v1
+      with:
+        path: ${{ github.workspace }}\.nuget\packages
+        key: nuget-${{ env.CACHE_MONTH }}-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: nuget-${{ env.CACHE_MONTH }}-
+
+    - name: Restore
+      shell: powershell
+      env:
+        ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
+        ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+      run: dotnet restore SonarScanner.MSBuild.sln --locked-mode --configfile "NuGet.Config"


### PR DESCRIPTION
## Summary
- Fifth step of the incremental Azure Pipelines → GitHub Actions migration (stacked on the Tim/CiFetchSecrets PR).
- Adds a NuGet package cache (`SonarSource/gh-action_cache`) and a `Restore` step to `.github/actions/prepare`, using the `SonarScanner.MSBuild.sln` solution and the existing `NuGet.Config`, authenticated with the Artifactory credentials fetched in the previous PR. Ported from the already-migrated `sonar-dotnet-autoscan` `prepare` action.
- This completes the `prepare` action's stated scope: "Install tools, cache NuGet, fetch secrets, compute version, and restore."

## Test plan
- [ ] Confirm the `Build` check restores NuGet packages successfully

Part of NET-2037