### PR TITLE
SCAN4NET-1621 Remove sonar-secrets-pre-commit references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,0 @@
-default_install_hook_types: [pre-push]
-repos:
--   repo: https://github.com/SonarSource/sonar-secrets-pre-commit
-    rev: v2.38.0.10279
-    hooks:
-    -   id: sonar-secrets
-        stages: [pre-push]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,3 @@ In our CI/CD pipeline, we use the following:
 - SONARCLOUD_PROJECT_TOKEN=[user-token]
 
 These can be set either on the operating system or your preferred IDE test run configuration.
-
-## `sonar-secrets-pre-commit` hook
-
-If you are Sonar internal use `sonar-secrets-pre-commit` to prevent pushing secrets to the repository. The hook is configured in [.pre-commit-hooks.yaml](.pre-commit-hooks.yaml). Follow the instructions in the [`sonar-secrets-pre-commit` README](https://github.com/SonarSource/sonar-secrets-pre-commit?tab=readme-ov-file) to activate it.
-Despite its name, the secrets check is configured as a pre-push hook.


### PR DESCRIPTION
## Summary
- Delete `.pre-commit-config.yaml`, whose only hook was `SonarSource/sonar-secrets-pre-commit` (now archived)
- Drop the now-unused `pre-commit` Renovate manager entry from `.github/renovate.json`
- Remove the corresponding `sonar-secrets-pre-commit` hook section from `CONTRIBUTING.md`

## Test plan
- [x] Confirmed no remaining references to `sonar-secrets-pre-commit` in the repo