### PR TITLE
CLP-144 Clean up Renovate config in sonar-scanner-msbuild

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,13 +14,6 @@
   },
   "packageRules": [
     {
-      "description": "Group Coverlet dependencies into a single PR",
-      "matchPackageNames": [
-        "coverlet.**"
-      ],
-      "groupName": "Coverlet"
-    },
-    {
       "description": "Do not update Build dependency. It provides backward compatibility with MsBuild 14+",
       "matchPackageNames": [
         "Microsoft.Build**"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,9 +9,6 @@
     "github-actions",
     "pre-commit"
   ],
-  "pre-commit": {
-    "enabled": true
-  },
   "nuget": {
     "description": "ignorePaths in the root does not work due to higher-precedence built-in counter-intuitive nuget-specifc defaults",
     "ignorePaths": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,11 +3,8 @@
   "extends": [
     "local>SonarSource/core-languages-tooling-public:renovate-config"
   ],
-  "enabledManagers": [
-    "nuget",
-    "maven",
-    "github-actions",
-    "pre-commit"
+  "ignorePaths": [
+    "its/projects/**"
   ],
   "nuget": {
     "description": "ignorePaths in the root does not work due to higher-precedence built-in counter-intuitive nuget-specifc defaults",


### PR DESCRIPTION
Part of CLP-11.

This PR cleans up the local Renovate config after the latest updates in the squad parent preset.

Expected current effective delta:
- track `scripts/Dockerfile` updates
