### PR TITLE
SCAN4NET-1623 Build the solution and upload raw binaries artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,14 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
+
+      - name: Build
+        run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release
+
+      - name: Upload Binaries artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: Binaries
+          path: Packaging/Binaries
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
 
       - name: Build
-        run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release
+        run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release /m
 
       - name: Upload Binaries artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
 
       - name: Build
-        run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release /m
+        run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release
 
-      - name: Upload Binaries artifact
+      - name: Upload binaries as pipeline artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Binaries


### PR DESCRIPTION
## What
Adds the `dotnet build` step and uploads `Packaging/Binaries` (populated automatically by each project's `Directory.Build.targets` copy target) as the `Binaries` artifact.

## Why
Proves the build produces the expected output on the new `warp-custom-dotnet-bubble-ci` runner before later PRs add zipping, NuGet/Choco packaging, signing, and SBOM generation on top of the same output directory.

Part of the Azure DevOps → GitHub Actions CI migration (stacked on #3218).