### PR TITLE
SCAN4NET-1624 Skip CI for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,11 @@ on:
       - '**.md'
       - 'docs/**'
       - '.github/CODEOWNERS'
-      - 'LICENSE.txt'
-  pull_request:
+pull_request:
     paths-ignore:
       - '**.md'
       - 'docs/**'
       - '.github/CODEOWNERS'
-      - 'LICENSE.txt'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,17 @@ name: Build, Test, and Publish
 on:
   push:
     branches: [master, 'branch-*', 'feature/*']
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/CODEOWNERS'
+      - 'LICENSE.txt'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/CODEOWNERS'
+      - 'LICENSE.txt'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - '**.md'
       - 'docs/**'
       - '.github/CODEOWNERS'
-pull_request:
+  pull_request:
     paths-ignore:
       - '**.md'
       - 'docs/**'


### PR DESCRIPTION
## What
Adds `paths-ignore` (`**.md`, `docs/**`, `.github/CODEOWNERS`, `LICENSE.txt`) to both the `push` and `pull_request` triggers.

## Why
Avoids spinning up the build runner for changes that can't affect the build. Safe to do now since this workflow isn't a required check yet — per the pipeline optimization guide, revisit alongside the `alls-green` pattern once it becomes one.

Part of the Azure DevOps → GitHub Actions CI migration (stacked on #3215).