### PR TITLE
SCAN4NET-1625 Add nightly schedule trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  schedule:
+    - cron: '17 2 * * 1-5'
   push:
     branches: [master, 'branch-*', 'feature/*']
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   schedule:
-    - cron: '17 2 * * 1-5'
+    - cron: '17 2 * * 1-5' # Mon-Fri 2:17 AM UTC
   push:
     branches: [master, 'branch-*', 'feature/*']
   pull_request:


### PR DESCRIPTION
## What
Adds a `schedule` cron trigger (`17 2 * * 1-5`) mirroring azure-pipelines.yml's nightly build, offset a few minutes past the hour to avoid GitHub Actions' known top-of-hour scheduler load spike.

## Why
Kept in its own PR so it can be merged independently, whenever the pipeline has enough QA/IT coverage to make a nightly run worthwhile — no need to gate it on the rest of the migration.

Part of the Azure DevOps → GitHub Actions CI migration (stacked on #3215).