### PR TITLE
SCAN4NET-1627 Zip .NET packages

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -6,6 +6,11 @@ inputs:
     description: Directory NuGet packages are restored into and cached from.
     required: true
 
+outputs:
+  FULL_VERSION:
+    description: Full version including build number (e.g. 10.28.0.123)
+    value: ${{ steps.set-version.outputs.FULL_VERSION }}
+
 runs:
   using: composite
   steps:
@@ -29,6 +34,7 @@ runs:
         Write-Host "SHORT_VERSION=$ShortVersion"
         Write-Host "PATCH_VERSION=$PatchVersion"
         Write-Host "FULL_VERSION=$FullVersion"
+        "FULL_VERSION=$FullVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         $env:SHORT_VERSION = $ShortVersion
         ./scripts/set-version-ci.ps1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
 
       - name: Build
-        run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release
+        run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release /m
 
       - name: Upload binaries as pipeline artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## What
Exposes `SHORT_VERSION`/`PATCH_VERSION`/`FULL_VERSION` as outputs of the `prepare` action, and adds the "Zip .NET packages" step producing `sonar-scanner-<version>-net(-framework).zip` from the build output.

## Why
Mirrors azure-pipelines.yml's "Zip .NET Packages" step. The version outputs were dropped earlier in the migration since nothing consumed them yet — this is their first consumer.

Stacked on #3225
Part of NET-2037

----
## Summary by Gitar

- **CI Configuration:**
    - Enabled multi-process builds for `dotnet build` by adding the `/m` flag in `ci.yml`.
    - Updated `prepare` action to correctly export `FULL_VERSION` to `$GITHUB_OUTPUT` for workflow consumption.

<sub>This will update automatically on new commits.</sub>