### PR TITLE
SCAN4NET-1628 Generate SBOM

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -14,13 +14,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Install tools
-      uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
-      with:
-        cache: true
-        tool_versions: |
-          gh 2.96.0
-
     - name: Get build number
       uses: SonarSource/ci-github-actions/get-build-number@v1
       id: get-build-number

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -14,6 +14,13 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Install tools
+      uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+      with:
+        cache: true
+        tool_versions: |
+          gh 2.96.0
+
     - name: Get build number
       uses: SonarSource/ci-github-actions/get-build-number@v1
       id: get-build-number

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
 
+      - name: Generate SBOM
+        run: dotnet CycloneDX SonarScanner.MSBuild.sln -t --json -o Packaging\Binaries
+
       - name: Build
         run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release /m
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare
+        id: prepare
         uses: ./.github/actions/prepare
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare
-        id: prepare
         uses: ./.github/actions/prepare
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}


### PR DESCRIPTION
## What
Adds a "Generate SBOM" step using the CycloneDX dotnet tool, producing a CycloneDX JSON SBOM into `Packaging\Binaries`.

## Why
Mirrors azure-pipelines.yml's "Generate SBOM" task. Placed right after Prepare/before Build to match Azure's order (SBOM only needs restored packages, not build output).

Part of the Azure DevOps → GitHub Actions CI migration (stacked on the PR adding the zip step).

Part of NET-2037

----
## Summary by Gitar

- **Added CI infrastructure:**
    - Created a reusable `.github/actions/prepare` composite action to handle NuGet restoration, secret fetching, and version calculation.
    - Added `mise-action` to install `gh` CLI version `2.96.0` in the `prepare` composite action.
- **Workflow configuration:**
    - Integrated `Generate SBOM` step using `CycloneDX` into the main `ci.yml` build pipeline.
    - Standardized build environment using a custom `warp-custom-dotnet-bubble-ci` runner.
    - Added a `Zip .NET packages` step using `tar` and `upload-artifact` to package build outputs.

<sub>This will update automatically on new commits.</sub>