### PR TITLE
SCAN4NET-1630 Package NuGet global tool and Chocolatey packages

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -10,6 +10,9 @@ outputs:
   FULL_VERSION:
     description: Full version including build number (e.g. 10.28.0.123)
     value: ${{ steps.set-version.outputs.FULL_VERSION }}
+  PATCH_VERSION:
+    description: Patch version (e.g. 10.28.0)
+    value: ${{ steps.set-version.outputs.PATCH_VERSION }}
 
 runs:
   using: composite
@@ -34,6 +37,7 @@ runs:
         Write-Host "SHORT_VERSION=$ShortVersion"
         Write-Host "PATCH_VERSION=$PatchVersion"
         Write-Host "FULL_VERSION=$FullVersion"
+        "PATCH_VERSION=$PatchVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         "FULL_VERSION=$FullVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         $env:SHORT_VERSION = $ShortVersion
         ./scripts/set-version-ci.ps1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,31 @@ jobs:
             Packaging/Binaries/Net-Framework/Sonar*.dll
             Packaging/Binaries/Net-Framework/Sonar*.exe
 
+      - name: Zip .NET packages
+        shell: powershell
+        env:
+          FULL_VERSION: ${{ steps.prepare.outputs.FULL_VERSION }}
+        run: |
+          function Zip-Assemblies([string]$Source, [string]$Destination) {
+              # Don't use Compress-Archive because https://github.com/SonarSource/sonar-scanner-msbuild/issues/2086
+              tar -c -a -C "$Source" --options "zip:compression-level=9" -f "$Destination" *
+          }
+
+          Zip-Assemblies "Packaging/Binaries/Net" "Packaging/Binaries/sonar-scanner-$env:FULL_VERSION-net.zip"
+          Zip-Assemblies "Packaging/Binaries/Net-Framework" "Packaging/Binaries/sonar-scanner-$env:FULL_VERSION-net-framework.zip"
+
+      - name: Package dotnet global tool
+        env:
+          PATCH_VERSION: ${{ steps.prepare.outputs.PATCH_VERSION }}
+        run: nuget pack Packaging\NuGet\dotnet-sonarscanner.nuspec -Version $env:PATCH_VERSION -OutputDirectory Packaging\Binaries\NuGet
+
+      - name: Generate Choco packages
+        shell: powershell
+        env:
+          FULL_VERSION: ${{ steps.prepare.outputs.FULL_VERSION }}
+          PATCH_VERSION: ${{ steps.prepare.outputs.PATCH_VERSION }}
+        run: . .\scripts\create-choco-packages.ps1
+
       - name: Upload binaries as pipeline artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Prepare
+        id: prepare
         uses: ./.github/actions/prepare
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,6 @@ jobs:
             Packaging/Binaries/Net-Framework/Sonar*.exe
 
       - name: Zip .NET packages
-        shell: powershell
         env:
           FULL_VERSION: ${{ steps.prepare.outputs.FULL_VERSION }}
         run: |
@@ -65,7 +64,6 @@ jobs:
         run: nuget pack Packaging\NuGet\dotnet-sonarscanner.nuspec -Version $env:PATCH_VERSION -OutputDirectory Packaging\Binaries\NuGet
 
       - name: Generate Choco packages
-        shell: powershell
         env:
           FULL_VERSION: ${{ steps.prepare.outputs.FULL_VERSION }}
           PATCH_VERSION: ${{ steps.prepare.outputs.PATCH_VERSION }}


### PR DESCRIPTION
## What
Exposes `PATCH_VERSION` as a `prepare` action output. Adds "Package dotnet global tool" (`nuget pack`) and "Generate Choco packages" steps after zipping.

## Why
Mirrors azure-pipelines.yml's "Package dotnet global tool" and "Generate Choco Packages" steps.

Part of the Azure DevOps → GitHub Actions CI migration (stacked on the signing PR).
Part of NET-2037