### PR TITLE
SCAN4NET-1632 Split version computation into its own job

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,40 +5,24 @@ inputs:
   nuget-packages-path:
     description: Directory NuGet packages are restored into and cached from.
     required: true
-
-outputs:
-  FULL_VERSION:
-    description: Full version including build number (e.g. 10.28.0.123)
-    value: ${{ steps.set-version.outputs.FULL_VERSION }}
-  PATCH_VERSION:
-    description: Patch version (e.g. 10.28.0)
-    value: ${{ steps.set-version.outputs.PATCH_VERSION }}
+  build-number:
+    description: Build number computed by the version job. Used to set Version.targets before building.
+    required: true
 
 runs:
   using: composite
   steps:
-    - name: Get build number
-      uses: SonarSource/ci-github-actions/get-build-number@v1
-      id: get-build-number
-
     - name: Set version
-      id: set-version
       #TODO: Wait for https://sonarsource.atlassian.net/browse/NET-4093 (rewrite set-version-ci.ps1), then adopt the same approach here.
       shell: powershell
       env:
-        BUILD_BUILDID:          ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+        BUILD_BUILDID:          ${{ inputs.build-number }}
         BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
         BUILD_SOURCEVERSION:    ${{ github.sha }}
       run: |
         [xml]$xml = Get-Content Version.targets
         $ShortVersion = $xml.Project.PropertyGroup.ShortVersion.Trim()
-        $PatchVersion = if ($ShortVersion.Split('.').Count -eq 2) { "$ShortVersion.0" } else { $ShortVersion }
-        $FullVersion  = "$PatchVersion.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
         Write-Host "SHORT_VERSION=$ShortVersion"
-        Write-Host "PATCH_VERSION=$PatchVersion"
-        Write-Host "FULL_VERSION=$FullVersion"
-        "PATCH_VERSION=$PatchVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "FULL_VERSION=$FullVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         $env:SHORT_VERSION = $ShortVersion
         ./scripts/set-version-ci.ps1
 

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -6,7 +6,10 @@ inputs:
     description: Directory NuGet packages are restored into and cached from.
     required: true
   build-number:
-    description: Build number computed by the version job. Used to set Version.targets before building.
+    description: Build number used to set Version.targets before building.
+    required: true
+  short-version:
+    description: Short version (e.g. 5.15) used to set Version.targets before building.
     required: true
 
 runs:
@@ -16,15 +19,11 @@ runs:
       #TODO: Wait for https://sonarsource.atlassian.net/browse/NET-4093 (rewrite set-version-ci.ps1), then adopt the same approach here.
       shell: powershell
       env:
+        SHORT_VERSION:          ${{ inputs.short-version }}
         BUILD_BUILDID:          ${{ inputs.build-number }}
         BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
         BUILD_SOURCEVERSION:    ${{ github.sha }}
-      run: |
-        [xml]$xml = Get-Content Version.targets
-        $ShortVersion = $xml.Project.PropertyGroup.ShortVersion.Trim()
-        Write-Host "SHORT_VERSION=$ShortVersion"
-        $env:SHORT_VERSION = $ShortVersion
-        ./scripts/set-version-ci.ps1
+      run: ./scripts/set-version-ci.ps1
 
     - name: Fetch Vault Secrets
       id: secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         id: set-version
         shell: bash
         run: |
-          SHORT_VERSION=$(xmllint --xpath 'string(//ShortVersion)' Version.targets)
+          SHORT_VERSION=$(python3 -c "import xml.etree.ElementTree as ET; print(ET.parse('Version.targets').getroot().find('.//ShortVersion').text.strip())")
           if [ "$(echo "$SHORT_VERSION" | tr -cd '.' | wc -c)" -eq 1 ]; then
             PATCH_VERSION="$SHORT_VERSION.0"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,17 @@ jobs:
 
       - name: Set version
         id: set-version
-        shell: pwsh
+        shell: bash
         run: |
-          [xml]$xml = Get-Content Version.targets
-          $ShortVersion = $xml.Project.PropertyGroup.ShortVersion.Trim()
-          $PatchVersion = if ($ShortVersion.Split('.').Count -eq 2) { "$ShortVersion.0" } else { $ShortVersion }
-          $FullVersion  = "$PatchVersion.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
-          "PATCH_VERSION=$PatchVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "FULL_VERSION=$FullVersion"   | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          SHORT_VERSION=$(sed -n 's/.*<ShortVersion>\(.*\)<\/ShortVersion>.*/\1/p' Version.targets | xargs)
+          if [ "$(echo "$SHORT_VERSION" | tr -cd '.' | wc -c)" -eq 1 ]; then
+            PATCH_VERSION="$SHORT_VERSION.0"
+          else
+            PATCH_VERSION="$SHORT_VERSION"
+          fi
+          FULL_VERSION="$PATCH_VERSION.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
+          echo "PATCH_VERSION=$PATCH_VERSION" >> "$GITHUB_OUTPUT"
+          echo "FULL_VERSION=$FULL_VERSION"   >> "$GITHUB_OUTPUT"
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         id: set-version
         shell: bash
         run: |
-          SHORT_VERSION=$(sed -n 's/.*<ShortVersion>\(.*\)<\/ShortVersion>.*/\1/p' Version.targets | xargs)
+          SHORT_VERSION=$(xmllint --xpath 'string(//ShortVersion)' Version.targets)
           if [ "$(echo "$SHORT_VERSION" | tr -cd '.' | wc -c)" -eq 1 ]; then
             PATCH_VERSION="$SHORT_VERSION.0"
           else
@@ -55,6 +55,8 @@ jobs:
       contents: read
     env:
       NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
+      BUILD_NUMBER: ${{ needs.version.outputs.BUILD_NUMBER }}
+      SHORT_VERSION: ${{ needs.version.outputs.SHORT_VERSION }}
       FULL_VERSION: ${{ needs.version.outputs.FULL_VERSION }}
       PATCH_VERSION: ${{ needs.version.outputs.PATCH_VERSION }}
     steps:
@@ -69,8 +71,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
-          build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
-          short-version: ${{ needs.version.outputs.SHORT_VERSION }}
+          build-number: ${{ env.BUILD_NUMBER }}
+          short-version: ${{ env.SHORT_VERSION }}
 
       - name: Generate SBOM
         run: dotnet CycloneDX SonarScanner.MSBuild.sln -t --json -o Packaging\Binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       id-token: write
     outputs:
       BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+      SHORT_VERSION: ${{ steps.set-version.outputs.SHORT_VERSION }}
       FULL_VERSION: ${{ steps.set-version.outputs.FULL_VERSION }}
       PATCH_VERSION: ${{ steps.set-version.outputs.PATCH_VERSION }}
     steps:
@@ -41,6 +42,7 @@ jobs:
             PATCH_VERSION="$SHORT_VERSION"
           fi
           FULL_VERSION="$PATCH_VERSION.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
+          echo "SHORT_VERSION=$SHORT_VERSION" >> "$GITHUB_OUTPUT"
           echo "PATCH_VERSION=$PATCH_VERSION" >> "$GITHUB_OUTPUT"
           echo "FULL_VERSION=$FULL_VERSION"   >> "$GITHUB_OUTPUT"
 
@@ -68,6 +70,7 @@ jobs:
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
           build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
+          short-version: ${{ needs.version.outputs.SHORT_VERSION }}
 
       - name: Generate SBOM
         run: dotnet CycloneDX SonarScanner.MSBuild.sln -t --json -o Packaging\Binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,47 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
+  version:
+    name: Compute version
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+    outputs:
+      BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+      FULL_VERSION: ${{ steps.set-version.outputs.FULL_VERSION }}
+      PATCH_VERSION: ${{ steps.set-version.outputs.PATCH_VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Get build number
+        uses: SonarSource/ci-github-actions/get-build-number@v1
+        id: get-build-number
+
+      - name: Set version
+        id: set-version
+        shell: pwsh
+        run: |
+          [xml]$xml = Get-Content Version.targets
+          $ShortVersion = $xml.Project.PropertyGroup.ShortVersion.Trim()
+          $PatchVersion = if ($ShortVersion.Split('.').Count -eq 2) { "$ShortVersion.0" } else { $ShortVersion }
+          $FullVersion  = "$PatchVersion.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
+          "PATCH_VERSION=$PatchVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "FULL_VERSION=$FullVersion"   | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
   build:
     name: Build
+    needs: version
     runs-on: warp-custom-dotnet-bubble-ci
     permissions:
       id-token: write
       contents: read
     env:
       NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
+      FULL_VERSION: ${{ needs.version.outputs.FULL_VERSION }}
+      PATCH_VERSION: ${{ needs.version.outputs.PATCH_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -31,6 +64,7 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
+          build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
 
       - name: Generate SBOM
         run: dotnet CycloneDX SonarScanner.MSBuild.sln -t --json -o Packaging\Binaries
@@ -48,8 +82,6 @@ jobs:
             Packaging/Binaries/Net-Framework/Sonar*.exe
 
       - name: Zip .NET packages
-        env:
-          FULL_VERSION: ${{ steps.prepare.outputs.FULL_VERSION }}
         run: |
           function Zip-Assemblies([string]$Source, [string]$Destination) {
               # Don't use Compress-Archive because https://github.com/SonarSource/sonar-scanner-msbuild/issues/2086
@@ -60,14 +92,9 @@ jobs:
           Zip-Assemblies "Packaging/Binaries/Net-Framework" "Packaging/Binaries/sonar-scanner-$env:FULL_VERSION-net-framework.zip"
 
       - name: Package dotnet global tool
-        env:
-          PATCH_VERSION: ${{ steps.prepare.outputs.PATCH_VERSION }}
         run: nuget pack Packaging\NuGet\dotnet-sonarscanner.nuspec -Version $env:PATCH_VERSION -OutputDirectory Packaging\Binaries\NuGet
 
       - name: Generate Choco packages
-        env:
-          FULL_VERSION: ${{ steps.prepare.outputs.FULL_VERSION }}
-          PATCH_VERSION: ${{ steps.prepare.outputs.PATCH_VERSION }}
         run: . .\scripts\create-choco-packages.ps1
 
       - name: Upload binaries as pipeline artifact


### PR DESCRIPTION
## What
Adds a "version" job (`sonar-xs`) that computes `BUILD_NUMBER`/`SHORT_VERSION`/`FULL_VERSION`/`PATCH_VERSION` before the `build` job starts. The `build` job depends on it and exposes these as job-level env vars, so individual steps no longer need per-step `env:` blocks referencing `steps.prepare.outputs.*`. The `prepare` action now takes `build-number` as an input instead of calling `get-build-number` itself.

## Why
`FULL_VERSION`/`PATCH_VERSION` were becoming repetitive per-step `env:` declarations. Job-level `env:` can't reference `steps.*.outputs` from the same job (not resolved yet when the job starts), but it can reference `needs.<job>.outputs`, since that job has already finished. Version computation also doesn't need Windows, so it runs on a cheap Linux runner instead of the expensive self-hosted one.

Part of the Azure DevOps → GitHub Actions CI migration (stacked on the NuGet/Choco packaging PR).
Part of NET-2037