### PR TITLE
SCAN4NET-1633 Run packaging tests

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,40 +5,24 @@ inputs:
   nuget-packages-path:
     description: Directory NuGet packages are restored into and cached from.
     required: true
-
-outputs:
-  FULL_VERSION:
-    description: Full version including build number (e.g. 10.28.0.123)
-    value: ${{ steps.set-version.outputs.FULL_VERSION }}
-  PATCH_VERSION:
-    description: Patch version (e.g. 10.28.0)
-    value: ${{ steps.set-version.outputs.PATCH_VERSION }}
+  build-number:
+    description: Build number computed by the version job. Used to set Version.targets before building.
+    required: true
 
 runs:
   using: composite
   steps:
-    - name: Get build number
-      uses: SonarSource/ci-github-actions/get-build-number@v1
-      id: get-build-number
-
     - name: Set version
-      id: set-version
       #TODO: Wait for https://sonarsource.atlassian.net/browse/NET-4093 (rewrite set-version-ci.ps1), then adopt the same approach here.
       shell: powershell
       env:
-        BUILD_BUILDID:          ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+        BUILD_BUILDID:          ${{ inputs.build-number }}
         BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
         BUILD_SOURCEVERSION:    ${{ github.sha }}
       run: |
         [xml]$xml = Get-Content Version.targets
         $ShortVersion = $xml.Project.PropertyGroup.ShortVersion.Trim()
-        $PatchVersion = if ($ShortVersion.Split('.').Count -eq 2) { "$ShortVersion.0" } else { $ShortVersion }
-        $FullVersion  = "$PatchVersion.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
         Write-Host "SHORT_VERSION=$ShortVersion"
-        Write-Host "PATCH_VERSION=$PatchVersion"
-        Write-Host "FULL_VERSION=$FullVersion"
-        "PATCH_VERSION=$PatchVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "FULL_VERSION=$FullVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         $env:SHORT_VERSION = $ShortVersion
         ./scripts/set-version-ci.ps1
 

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -6,7 +6,10 @@ inputs:
     description: Directory NuGet packages are restored into and cached from.
     required: true
   build-number:
-    description: Build number computed by the version job. Used to set Version.targets before building.
+    description: Build number used to set Version.targets before building.
+    required: true
+  short-version:
+    description: Short version (e.g. 5.15) used to set Version.targets before building.
     required: true
 
 runs:
@@ -16,15 +19,11 @@ runs:
       #TODO: Wait for https://sonarsource.atlassian.net/browse/NET-4093 (rewrite set-version-ci.ps1), then adopt the same approach here.
       shell: powershell
       env:
+        SHORT_VERSION:          ${{ inputs.short-version }}
         BUILD_BUILDID:          ${{ inputs.build-number }}
         BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
         BUILD_SOURCEVERSION:    ${{ github.sha }}
-      run: |
-        [xml]$xml = Get-Content Version.targets
-        $ShortVersion = $xml.Project.PropertyGroup.ShortVersion.Trim()
-        Write-Host "SHORT_VERSION=$ShortVersion"
-        $env:SHORT_VERSION = $ShortVersion
-        ./scripts/set-version-ci.ps1
+      run: ./scripts/set-version-ci.ps1
 
     - name: Fetch Vault Secrets
       id: secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         id: set-version
         shell: bash
         run: |
-          SHORT_VERSION=$(xmllint --xpath 'string(//ShortVersion)' Version.targets)
+          SHORT_VERSION=$(python3 -c "import xml.etree.ElementTree as ET; print(ET.parse('Version.targets').getroot().find('.//ShortVersion').text.strip())")
           if [ "$(echo "$SHORT_VERSION" | tr -cd '.' | wc -c)" -eq 1 ]; then
             PATCH_VERSION="$SHORT_VERSION.0"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,17 @@ jobs:
 
       - name: Set version
         id: set-version
-        shell: pwsh
+        shell: bash
         run: |
-          [xml]$xml = Get-Content Version.targets
-          $ShortVersion = $xml.Project.PropertyGroup.ShortVersion.Trim()
-          $PatchVersion = if ($ShortVersion.Split('.').Count -eq 2) { "$ShortVersion.0" } else { $ShortVersion }
-          $FullVersion  = "$PatchVersion.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
-          "PATCH_VERSION=$PatchVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-          "FULL_VERSION=$FullVersion"   | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          SHORT_VERSION=$(sed -n 's/.*<ShortVersion>\(.*\)<\/ShortVersion>.*/\1/p' Version.targets | xargs)
+          if [ "$(echo "$SHORT_VERSION" | tr -cd '.' | wc -c)" -eq 1 ]; then
+            PATCH_VERSION="$SHORT_VERSION.0"
+          else
+            PATCH_VERSION="$SHORT_VERSION"
+          fi
+          FULL_VERSION="$PATCH_VERSION.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
+          echo "PATCH_VERSION=$PATCH_VERSION" >> "$GITHUB_OUTPUT"
+          echo "FULL_VERSION=$FULL_VERSION"   >> "$GITHUB_OUTPUT"
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       id-token: write
     outputs:
       BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+      SHORT_VERSION: ${{ steps.set-version.outputs.SHORT_VERSION }}
       FULL_VERSION: ${{ steps.set-version.outputs.FULL_VERSION }}
       PATCH_VERSION: ${{ steps.set-version.outputs.PATCH_VERSION }}
     steps:
@@ -41,6 +42,7 @@ jobs:
             PATCH_VERSION="$SHORT_VERSION"
           fi
           FULL_VERSION="$PATCH_VERSION.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
+          echo "SHORT_VERSION=$SHORT_VERSION" >> "$GITHUB_OUTPUT"
           echo "PATCH_VERSION=$PATCH_VERSION" >> "$GITHUB_OUTPUT"
           echo "FULL_VERSION=$FULL_VERSION"   >> "$GITHUB_OUTPUT"
 
@@ -67,6 +69,7 @@ jobs:
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
           build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
+          short-version: ${{ needs.version.outputs.SHORT_VERSION }}
 
       - name: Generate SBOM
         run: dotnet CycloneDX SonarScanner.MSBuild.sln -t --json -o Packaging\Binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         id: set-version
         shell: bash
         run: |
-          SHORT_VERSION=$(sed -n 's/.*<ShortVersion>\(.*\)<\/ShortVersion>.*/\1/p' Version.targets | xargs)
+          SHORT_VERSION=$(xmllint --xpath 'string(//ShortVersion)' Version.targets)
           if [ "$(echo "$SHORT_VERSION" | tr -cd '.' | wc -c)" -eq 1 ]; then
             PATCH_VERSION="$SHORT_VERSION.0"
           else
@@ -55,6 +55,8 @@ jobs:
       contents: read
     env:
       NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
+      BUILD_NUMBER: ${{ needs.version.outputs.BUILD_NUMBER }}
+      SHORT_VERSION: ${{ needs.version.outputs.SHORT_VERSION }}
       FULL_VERSION: ${{ needs.version.outputs.FULL_VERSION }}
       PATCH_VERSION: ${{ needs.version.outputs.PATCH_VERSION }}
     steps:
@@ -68,8 +70,8 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
-          build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
-          short-version: ${{ needs.version.outputs.SHORT_VERSION }}
+          build-number: ${{ env.BUILD_NUMBER }}
+          short-version: ${{ env.SHORT_VERSION }}
 
       - name: Generate SBOM
         run: dotnet CycloneDX SonarScanner.MSBuild.sln -t --json -o Packaging\Binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,11 @@ jobs:
       - name: Generate Choco packages
         run: . .\scripts\create-choco-packages.ps1
 
+      - name: Run packaging tests
+        env:
+          IS_RELEASE_BRANCH: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-') }}
+        run: dotnet test Tests\SonarScanner.MSBuild.PackagingTest\SonarScanner.MSBuild.PackagingTest.csproj --configuration Release --no-build --no-restore
+
       - name: Upload binaries as pipeline artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,47 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
+  version:
+    name: Compute version
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+    outputs:
+      BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
+      FULL_VERSION: ${{ steps.set-version.outputs.FULL_VERSION }}
+      PATCH_VERSION: ${{ steps.set-version.outputs.PATCH_VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Get build number
+        uses: SonarSource/ci-github-actions/get-build-number@v1
+        id: get-build-number
+
+      - name: Set version
+        id: set-version
+        shell: pwsh
+        run: |
+          [xml]$xml = Get-Content Version.targets
+          $ShortVersion = $xml.Project.PropertyGroup.ShortVersion.Trim()
+          $PatchVersion = if ($ShortVersion.Split('.').Count -eq 2) { "$ShortVersion.0" } else { $ShortVersion }
+          $FullVersion  = "$PatchVersion.${{ steps.get-build-number.outputs.BUILD_NUMBER }}"
+          "PATCH_VERSION=$PatchVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "FULL_VERSION=$FullVersion"   | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
   build:
     name: Build
+    needs: version
     runs-on: warp-custom-dotnet-bubble-ci
     permissions:
       id-token: write
       contents: read
     env:
       NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
+      FULL_VERSION: ${{ needs.version.outputs.FULL_VERSION }}
+      PATCH_VERSION: ${{ needs.version.outputs.PATCH_VERSION }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -30,6 +63,7 @@ jobs:
         uses: ./.github/actions/prepare
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
+          build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
 
       - name: Generate SBOM
         run: dotnet CycloneDX SonarScanner.MSBuild.sln -t --json -o Packaging\Binaries
@@ -47,8 +81,6 @@ jobs:
             Packaging/Binaries/Net-Framework/Sonar*.exe
 
       - name: Zip .NET packages
-        env:
-          FULL_VERSION: ${{ steps.prepare.outputs.FULL_VERSION }}
         run: |
           function Zip-Assemblies([string]$Source, [string]$Destination) {
               # Don't use Compress-Archive because https://github.com/SonarSource/sonar-scanner-msbuild/issues/2086
@@ -59,14 +91,9 @@ jobs:
           Zip-Assemblies "Packaging/Binaries/Net-Framework" "Packaging/Binaries/sonar-scanner-$env:FULL_VERSION-net-framework.zip"
 
       - name: Package dotnet global tool
-        env:
-          PATCH_VERSION: ${{ steps.prepare.outputs.PATCH_VERSION }}
         run: nuget pack Packaging\NuGet\dotnet-sonarscanner.nuspec -Version $env:PATCH_VERSION -OutputDirectory Packaging\Binaries\NuGet
 
       - name: Generate Choco packages
-        env:
-          FULL_VERSION: ${{ steps.prepare.outputs.FULL_VERSION }}
-          PATCH_VERSION: ${{ steps.prepare.outputs.PATCH_VERSION }}
         run: . .\scripts\create-choco-packages.ps1
 
       - name: Upload binaries as pipeline artifact

--- a/Tests/SonarScanner.MSBuild.PackagingTest/NuGetTest.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/NuGetTest.cs
@@ -61,7 +61,6 @@ public class NuGetTest
     [TestMethod]
     public void ValidateSignatures()
     {
-        TestOrchestration.RunOnlyOnReleaseBranch();
         using var archive = Verifier.UnzipFile("NuGet", "dotnet-sonarscanner.*.nupkg");
         var dlls = archive.Entries.Where(Verifier.IsSonarBinary).ToArray();
         dlls.Should().HaveCount(7);

--- a/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/TestOrchestration.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/TestOrchestration.cs
@@ -36,12 +36,4 @@ public static class TestOrchestration
             Assert.Inconclusive("This test must run on the CI environment, after the signing.");
         }
     }
-
-    public static void RunOnlyOnReleaseBranch()
-    {
-        if (!IsReleaseBranch)
-        {
-            Assert.Inconclusive("This test runs only on a release branch with signing.");
-        }
-    }
 }

--- a/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/TestOrchestration.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/TestOrchestration.cs
@@ -25,11 +25,13 @@ public static class TestOrchestration
     public static bool IsReleaseBranch => bool.TryParse(Environment.GetEnvironmentVariable("IS_RELEASE_BRANCH"), out var value) && value;
     public static string FullVersion => typeof(TestOrchestration).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
 
-    private static bool IsAzureDevOpsContext => Environment.GetEnvironmentVariable("BUILD_REASON") is not null;
+    private static bool IsCIContext =>
+        Environment.GetEnvironmentVariable("BUILD_REASON") is not null      // Azure DevOps
+        || Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is not null; // GitHub Actions
 
     public static void InitializeTestClass()
     {
-        if (!IsAzureDevOpsContext)
+        if (!IsCIContext)
         {
             Assert.Inconclusive("This test must run on the CI environment, after the signing.");
         }

--- a/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
@@ -53,7 +53,11 @@ public static class Verifier
         certificates.Size.Should().NotBe(0, $"file {entry.FullName} should contain signature");
         var cms = new SignedCms();
         cms.Decode(peReader.GetEntireImage().GetContent().AsSpan(certificates.RelativeVirtualAddress + HeaderSize, certificates.Size - HeaderSize));
-        cms.Certificates.Should().ContainSingle(x => x.Subject == "CN=SonarSource SA, O=SonarSource SA, L=Vernier, S=Genève, C=CH");    // There's also DigiCert certificate present
+        // Release branches sign with the real SonarSource SA certificate; other branches get Azure Trusted Signing's test certificate instead.
+        var expectedSubject = TestOrchestration.IsReleaseBranch
+            ? "CN=SonarSource SA, O=SonarSource SA, L=Vernier, S=Genève, C=CH"
+            : "CN=\"SonarSource US, Inc.(TEST ONLY)\", O=\"SonarSource US, Inc.\", L=Austin, S=Texas, C=US";
+        cms.Certificates.Should().ContainSingle(x => x.Subject == expectedSubject);    // There's also a Microsoft/DigiCert CA certificate present
     }
 
     private static MemoryStream ReadStream(ZipArchiveEntry entry)

--- a/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
@@ -53,7 +53,6 @@ public static class Verifier
         certificates.Size.Should().NotBe(0, $"file {entry.FullName} should contain signature");
         var cms = new SignedCms();
         cms.Decode(peReader.GetEntireImage().GetContent().AsSpan(certificates.RelativeVirtualAddress + HeaderSize, certificates.Size - HeaderSize));
-        // Release branches sign with the real SonarSource SA certificate; other branches get Azure Trusted Signing's test certificate instead.
         var expectedSubject = TestOrchestration.IsReleaseBranch
             ? "CN=SonarSource SA, O=SonarSource SA, L=Vernier, S=Genève, C=CH"
             : "CN=\"SonarSource US, Inc.(TEST ONLY)\", O=\"SonarSource US, Inc.\", L=Austin, S=Texas, C=US";

--- a/Tests/SonarScanner.MSBuild.PackagingTest/ZipTest.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/ZipTest.cs
@@ -292,7 +292,6 @@ public class ZipTest
     [DataRow("sonar-scanner-*-net-framework.zip", 8)]   // 6x dll + 2x exe
     public void ValidateSignatures(string pattern, int expectedFileCount)
     {
-        TestOrchestration.RunOnlyOnReleaseBranch();
         using var archive = Verifier.UnzipFile(null, pattern);
         var dlls = archive.Entries.Where(Verifier.IsSonarBinary).ToArray();
         dlls.Should().HaveCount(expectedFileCount);


### PR DESCRIPTION
## What
Adds "Run packaging tests" step running `SonarScanner.MSBuild.PackagingTest`, with `IS_RELEASE_BRANCH` set the same way azure-pipelines.yml computes it.

## Why
Mirrors azure-pipelines.yml's "Run Packaging tests" step.

Note: on master/branch-* this will currently fail the NuGet-signature assertion, since NuGet package signing (a separate step from the DLL signing already added) hasn't been ported yet - tracked separately.

Part of the Azure DevOps → GitHub Actions CI migration (stacked on the version-job PR).
Part of NET-2037

----
## Summary by Gitar

- **CI Configuration:**
  - Added `Run packaging tests` step to `.github/workflows/ci.yml` with `IS_RELEASE_BRANCH` logic.
  - Updated `TestOrchestration` to recognize `GITHUB_ACTIONS` as a valid CI context.
- **Test Logic:**
  - Modified `Verifier` to support validating both production and test certificates based on `IsReleaseBranch`.
  - Removed `RunOnlyOnReleaseBranch` and unused NuGet/Zip test assertions to enable broader test execution.

<sub>This will update automatically on new commits.</sub>