### PR TITLE
SCAN4NET-1634 Prepare windows-qa job

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-sonarscanner": {
+      "version": "11.2.1",
+      "commands": [
+        "dotnet-sonarscanner"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,30 +145,24 @@ jobs:
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
             development/kv/data/sonarcloud token                                             | SONAR_TOKEN;
 
-      - name: Setup cache date variable
-        id: cache-date
-        run: |
-          "CACHE_DATE=$(Get-Date -Format 'yyyy-MM-dd')" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
       - name: Cache SonarScanner for .NET
         id: s4net-cache
         uses: SonarSource/gh-action_cache@v1
         with:
-          path: ${{ runner.temp }}\S4NET
-          key: s4net-${{ steps.cache-date.outputs.CACHE_DATE }}
+          path: ${{ env.NUGET_PACKAGES }}\dotnet-sonarscanner
+          key: s4net-${{ hashFiles('.config/dotnet-tools.json') }}
 
-      - name: Install SonarScanner for .NET
-        if: steps.s4net-cache.outputs.cache-hit != 'true'
+      - name: Restore SonarScanner for .NET
         env:
           ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
           ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
-        run: dotnet tool update dotnet-sonarscanner --tool-path "${{ runner.temp }}\S4NET" --configfile "NuGet.Config"
+        run: dotnet tool restore --tool-manifest .config/dotnet-tools.json --configfile "NuGet.Config"
 
       - name: SonarQube begin
         env:
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
         run: >
-          & "${{ runner.temp }}\S4NET\dotnet-sonarscanner" begin
+          dotnet tool run dotnet-sonarscanner -- begin
           /o:"sonarsource"
           /k:"sonarscanner-msbuild"
           /v:"${{ needs.version.outputs.SHORT_VERSION }}"
@@ -193,4 +187,4 @@ jobs:
       - name: SonarQube end
         env:
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
-        run: '& "${{ runner.temp }}\S4NET\dotnet-sonarscanner" end /d:sonar.token="$env:SONAR_TOKEN"'
+        run: dotnet tool run dotnet-sonarscanner -- end /d:sonar.token="$env:SONAR_TOKEN"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,91 @@ jobs:
           path: Packaging/Binaries
           retention-days: 1
           if-no-files-found: error
+
+  qa_windows:
+    name: QA Windows - UTs and analysis
+    needs: version
+    runs-on: warp-custom-dotnet-bubble-ci
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          fetch-depth: 0
+
+      - name: Prepare
+        uses: ./.github/actions/prepare
+        with:
+          nuget-packages-path: ${{ env.NUGET_PACKAGES }}
+          build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
+
+      - name: Fetch Vault Secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
+            development/kv/data/sonarcloud token                                             | SONAR_TOKEN;
+
+      - name: Setup cache date variable
+        id: cache-date
+        shell: powershell
+        run: |
+          "CACHE_DATE=$(Get-Date -Format 'yyyy-MM-dd')" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Cache SonarScanner for .NET
+        id: s4net-cache
+        uses: SonarSource/gh-action_cache@v1
+        with:
+          path: ${{ runner.temp }}\S4NET
+          key: s4net-${{ steps.cache-date.outputs.CACHE_DATE }}
+
+      - name: Install SonarScanner for .NET
+        if: steps.s4net-cache.outputs.cache-hit != 'true'
+        shell: powershell
+        env:
+          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
+          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+        run: dotnet tool update dotnet-sonarscanner --tool-path "${{ runner.temp }}\S4NET" --configfile "NuGet.Config"
+
+      - name: SonarQube begin
+        shell: powershell
+        env:
+          SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
+        run: >
+          & "${{ runner.temp }}\S4NET\dotnet-sonarscanner" begin
+          /o:"sonarsource"
+          /k:"sonarscanner-msbuild"
+          /n:"SonarScanner for .NET"
+          /v:"${{ needs.version.outputs.SHORT_VERSION }}"
+          /d:sonar.token="$env:SONAR_TOKEN"
+          /d:sonar.cs.opencover.reportsPaths="${{ github.workspace }}\Coverage\*.xml"
+          /d:sonar.cs.vstest.reportsPaths="${{ github.workspace }}\TestResults\*.trx"
+          /d:sonar.sca.exclusions="its/projects/**"
+
+      - name: Build and analyze
+        run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release /p:RunAnalyzers=true /p:RunAnalyzersDuringBuild=true
+
+      - name: Run UTs and compute coverage
+        shell: powershell
+        env:
+          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
+          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+        run: .\scripts\run-unit-tests.ps1 -SourcesDirectory "${{ github.workspace }}" -BuildConfiguration Release
+
+      - name: Delete files created by unit tests
+        shell: powershell
+        run: |
+          Get-ChildItem "${{ runner.temp }}" -Filter 'dummy.*' -Recurse -Attributes !Directory | Remove-Item
+
+      - name: SonarQube end
+        shell: powershell
+        env:
+          SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
+        run: '& "${{ runner.temp }}\S4NET\dotnet-sonarscanner" end /d:sonar.token="$env:SONAR_TOKEN"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,34 +157,3 @@ jobs:
           ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
           ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
         run: dotnet tool restore --tool-manifest .config/dotnet-tools.json --configfile "NuGet.Config"
-
-      - name: SonarQube begin
-        env:
-          SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
-        run: >
-          dotnet tool run dotnet-sonarscanner -- begin
-          /o:"sonarsource"
-          /k:"sonarscanner-msbuild"
-          /v:"${{ needs.version.outputs.SHORT_VERSION }}"
-          /d:sonar.token="$env:SONAR_TOKEN"
-          /d:sonar.cs.opencover.reportsPaths="${{ github.workspace }}\Coverage\*.xml"
-          /d:sonar.cs.vstest.reportsPaths="${{ github.workspace }}\TestResults\*.trx"
-          /d:sonar.sca.exclusions="its/projects/**"
-
-      - name: Build and analyze
-        run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release /p:RunAnalyzers=true /p:RunAnalyzersDuringBuild=true
-
-      - name: Run UTs and compute coverage
-        env:
-          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
-          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
-        run: .\scripts\run-unit-tests.ps1 -SourcesDirectory "${{ github.workspace }}" -BuildConfiguration Release
-
-      - name: Delete files created by unit tests
-        run: |
-          Get-ChildItem "${{ runner.temp }}" -Filter 'dummy.*' -Recurse -Attributes !Directory | Remove-Item
-
-      - name: SonarQube end
-        env:
-          SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
-        run: dotnet tool run dotnet-sonarscanner -- end /d:sonar.token="$env:SONAR_TOKEN"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
+env:
+  NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
+
 jobs:
   version:
     name: Compute version
@@ -54,7 +57,6 @@ jobs:
       id-token: write
       contents: read
     env:
-      NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
       BUILD_NUMBER: ${{ needs.version.outputs.BUILD_NUMBER }}
       SHORT_VERSION: ${{ needs.version.outputs.SHORT_VERSION }}
       FULL_VERSION: ${{ needs.version.outputs.FULL_VERSION }}
@@ -120,8 +122,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    env:
-      NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,6 @@ jobs:
 
       - name: Setup cache date variable
         id: cache-date
-        shell: powershell
         run: |
           "CACHE_DATE=$(Get-Date -Format 'yyyy-MM-dd')" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
@@ -160,21 +159,18 @@ jobs:
 
       - name: Install SonarScanner for .NET
         if: steps.s4net-cache.outputs.cache-hit != 'true'
-        shell: powershell
         env:
           ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
           ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
         run: dotnet tool update dotnet-sonarscanner --tool-path "${{ runner.temp }}\S4NET" --configfile "NuGet.Config"
 
       - name: SonarQube begin
-        shell: powershell
         env:
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
         run: >
           & "${{ runner.temp }}\S4NET\dotnet-sonarscanner" begin
           /o:"sonarsource"
           /k:"sonarscanner-msbuild"
-          /n:"SonarScanner for .NET"
           /v:"${{ needs.version.outputs.SHORT_VERSION }}"
           /d:sonar.token="$env:SONAR_TOKEN"
           /d:sonar.cs.opencover.reportsPaths="${{ github.workspace }}\Coverage\*.xml"
@@ -185,19 +181,16 @@ jobs:
         run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release /p:RunAnalyzers=true /p:RunAnalyzersDuringBuild=true
 
       - name: Run UTs and compute coverage
-        shell: powershell
         env:
           ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
           ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
         run: .\scripts\run-unit-tests.ps1 -SourcesDirectory "${{ github.workspace }}" -BuildConfiguration Release
 
       - name: Delete files created by unit tests
-        shell: powershell
         run: |
           Get-ChildItem "${{ runner.temp }}" -Filter 'dummy.*' -Recurse -Attributes !Directory | Remove-Item
 
       - name: SonarQube end
-        shell: powershell
         env:
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
         run: '& "${{ runner.temp }}\S4NET\dotnet-sonarscanner" end /d:sonar.token="$env:SONAR_TOKEN"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,7 @@ jobs:
         with:
           nuget-packages-path: ${{ env.NUGET_PACKAGES }}
           build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
+          short-version: ${{ needs.version.outputs.SHORT_VERSION }}
 
       - name: Fetch Vault Secrets
         id: secrets


### PR DESCRIPTION


Part of the Azure DevOps → GitHub Actions CI migration (stacked on the packaging-tests PR).
Part of NET-2037

----
## Summary by Gitar

- **CI/CD configuration:**
  - Added `qa_windows` job to `ci.yml` for Windows builds, UT execution, and SonarCloud analysis.
  - Exported `SHORT_VERSION` output in the `version` job for use in SonarQube project versioning.
  - Pinned `dotnet-sonarscanner` version via a new `.config/dotnet-tools.json` manifest.
  - Set `NUGET_PACKAGES` as a global environment variable and removed redundant `shell: powershell` declarations.
- **Test utilities:**
  - Added `ClearCIEnvironmentVariables` to `EnvironmentVariableScope` to isolate tests from ambient environment variables.
  - Updated `CIPlatformDetectorTests` and `TelemetryUtilsTests` to utilize the new clearing mechanism, ensuring reliable detection testing.

<sub>This will update automatically on new commits.</sub>