### PR TITLE
SCAN4NET-1641 Publish test results as a GitHub check run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: read
+      checks: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -179,6 +181,14 @@ jobs:
           ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
           ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
         run: .\scripts\run-unit-tests.ps1 -SourcesDirectory "${{ github.workspace }}" -BuildConfiguration Release
+
+      - name: Publish test results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: ${{ !cancelled() }}
+        with:
+          name: Unit Test Results
+          path: TestResults/*.trx
+          reporter: dotnet-trx
 
       - name: Delete files created by unit tests
         run: |


### PR DESCRIPTION
Continues from Tim/CiSonarAnalysis. Azure Pipelines has a native Tests tab (PublishTestResults@2); GitHub Actions has no first-party equivalent, so this adds dorny/test-reporter to render the .trx results as a check run instead.

Runs on \`!cancelled()\` so it still reports when tests fail - that's the case that matters most.

----
## Summary by Gitar

- **CI Pipeline architecture:**
    - Introduced a dedicated `version` job for centralized build number and version computation.
    - Implemented a new `qa_windows` job for unit testing, SonarQube analysis, and artifact signing.
- **Build and packaging updates:**
    - Added signing for `.NET` binaries using `gh-action_azure-artifact-signing`.
    - Automated creation of NuGet and Chocolatey packages within the `build` workflow.
- **Secrets and environment:**
    - Integrated `vault-action-wrapper` to securely handle Artifactory and SonarCloud credentials.
    - Configured persistent NuGet package caching using `gh-action_cache`.
- **Testing infrastructure:**
    - Added `dorny/test-reporter` to publish `.trx` test results as a GitHub check run.
    - Updated job permissions to include `actions: read` and `checks: write` for reporting.

<sub>This will update automatically on new commits.</sub>