### PR TITLE
SCAN4NET-1659 Run Linux and MAC ITs only on master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -342,6 +342,7 @@ stages:
 
       - template: templates/its-jobs.yml
         parameters:
+          condition: eq(variables['Build.SourceBranchName'], 'master')
           matrix:
             LTA-89:
               PRODUCT: "SonarQube"

--- a/templates/its-jobs.yml
+++ b/templates/its-jobs.yml
@@ -4,10 +4,14 @@ parameters:
   - name: initSteps
     type: stepList
     default: []
+  - name: condition
+    type: string
+    default: 'true'
 
 jobs:
   - job: its
     displayName: 'Run ITs'
+    condition: ${{ parameters.condition }}
     workspace:
       clean: all
     strategy:

--- a/templates/unix-qa-stage.yml
+++ b/templates/unix-qa-stage.yml
@@ -56,6 +56,7 @@ stages:
 
       - template: ./its-jobs.yml
         parameters:
+          # Restricted to master while the Azure->GHA CI migration is in progress: these ITs are slow and unrelated to the migration PRs, so skipping them on branches/PRs avoids delaying that work.
           condition: eq(variables['Build.SourceBranchName'], 'master')
           initSteps:
             - powershell: $(Build.SourcesDirectory)/scripts/ci-self-signed-certificate.ps1

--- a/templates/unix-qa-stage.yml
+++ b/templates/unix-qa-stage.yml
@@ -56,6 +56,7 @@ stages:
 
       - template: ./its-jobs.yml
         parameters:
+          condition: eq(variables['Build.SourceBranchName'], 'master')
           initSteps:
             - powershell: $(Build.SourcesDirectory)/scripts/ci-self-signed-certificate.ps1
               displayName: "Create self-signed certificate"


### PR DESCRIPTION
Part of  NET-2037

----
## Summary by Gitar

- **CI Configuration:**
    - Added a `condition` parameter to `templates/its-jobs.yml` to allow filtering job execution.
    - Restricted Linux and macOS integration tests in `templates/unix-qa-stage.yml` to run only on the `master` branch.
- **SBOM Generation:**
    - Added a `Generate SBOM` step to `.github/workflows/ci.yml` using `dotnet CycloneDX` to export dependency data.

<sub>This will update automatically on new commits.</sub>