### PR TITLE
SCAN4NET-1629 Sign built assemblies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,15 @@ jobs:
       - name: Build
         run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release /m
 
+      - name: Sign DLLs
+        uses: SonarSource/gh-action_azure-artifact-signing@v1
+        with:
+          files: |
+            Packaging/Binaries/Net/Sonar*.dll
+            Packaging/Binaries/Net/Sonar*.exe
+            Packaging/Binaries/Net-Framework/Sonar*.dll
+            Packaging/Binaries/Net-Framework/Sonar*.exe
+
       - name: Upload binaries as pipeline artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## What
Adds "Sign DLLs" (`SonarSource/gh-action_azure-artifact-signing`) steps between Build and Zip.

## Why
Replaces azure-pipelines.yml's DigiCert/signtool Authenticode signing with the Azure Key Vault-based mechanism, matching sonar-dotnet-autoscan's already-reviewed pattern (unconditional — the action selects its own signing profile internally based on branch).

Strong-name (.snk) signing is intentionally out of scope — it's being dropped from the product entirely, not just deferred.

Part of the Azure DevOps → GitHub Actions CI migration (stacked on the SBOM PR).
Part of NET-2037

---
Recreated from #3231, which GitHub auto-closed and got stuck in a state where it couldn't be reopened after a `git pull --rebase` incident dropped commits from the branch and a subsequent force-push restored them.