### PR TITLE
SCAN4NET-1661 Remove `actions: read` permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      actions: read
       checks: write
     steps:
       - name: Checkout


### PR DESCRIPTION
Part of NET-2037

----
## Summary by Gitar

- **CI Configuration:**
    - Removed unnecessary `actions: read` permission from `.github/workflows/ci.yml`.

<sub>This will update automatically on new commits.</sub>