### PR TITLE
SCAN4NET-1664 Add Repox artifact promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,10 +389,6 @@ jobs:
     env:
       BUILD_NUMBER: ${{ needs.version.outputs.BUILD_NUMBER }}
     steps:
-      # Azure's IS_RELEASE_BRANCH-gated "Set GitHub commit status for release automation" step is
-      # intentionally not ported: the promote action already posts a repox-<branch> commit status
-      # unconditionally. Revisit only if release automation owners say the Azure-specific gating is
-      # still required once this is GH-native.
       - uses: SonarSource/ci-github-actions/promote@v1
         with:
           promote-pull-request: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,10 @@ jobs:
     # uts_macos/its_macos are conditionally skipped (see their own `if:`), and GitHub Actions skips a job whenever
     # any of its `needs` was skipped unless told otherwise - without this, promote would never run on PR builds or
     # non-master/branch-* pushes, exactly where it's supposed to promote to sonarsource-public-dev/-builds.
-    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
+    # Always runs (never skips due to a dependency's outcome) so that a real failure surfaces as this job actually
+    # FAILING rather than being SKIPPED: GitHub treats a skipped required check as satisfying it, which would let a
+    # broken Build/UTs/ITs run merge silently if this job's own `if:` were the one doing the failure/cancel check.
+    if: always()
     runs-on: sonar-xs
     permissions:
       id-token: write
@@ -393,6 +396,10 @@ jobs:
     env:
       BUILD_NUMBER: ${{ needs.version.outputs.BUILD_NUMBER }}
     steps:
+      - name: Fail if a dependency failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
+
       - uses: SonarSource/ci-github-actions/promote@v1
         with:
           promote-pull-request: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,10 @@ jobs:
   promote:
     name: Promote
     needs: [version, build, qa_windows, qa_linux, qa_macos, its_windows, its, its_macos]
+    # qa_macos/its_macos are conditionally skipped (see their own `if:`), and GitHub Actions skips a job whenever
+    # any of its `needs` was skipped unless told otherwise - without this, promote would never run on PR builds or
+    # non-master/branch-* pushes, exactly where it's supposed to promote to sonarsource-public-dev/-builds.
+    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     runs-on: sonar-xs
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,8 +381,8 @@ jobs:
 
   promote:
     name: Promote
-    needs: [version, build, qa_windows, qa_linux, qa_macos, its_windows, its, its_macos]
-    # qa_macos/its_macos are conditionally skipped (see their own `if:`), and GitHub Actions skips a job whenever
+    needs: [version, build, uts_windows, uts_linux, uts_macos, its_windows, its_linux, its_macos]
+    # uts_macos/its_macos are conditionally skipped (see their own `if:`), and GitHub Actions skips a job whenever
     # any of its `needs` was skipped unless told otherwise - without this, promote would never run on PR builds or
     # non-master/branch-* pushes, exactly where it's supposed to promote to sonarsource-public-dev/-builds.
     if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,12 +382,8 @@ jobs:
   promote:
     name: Promote
     needs: [version, build, uts_windows, uts_linux, uts_macos, its_windows, its_linux, its_macos]
-    # uts_macos/its_macos are conditionally skipped (see their own `if:`), and GitHub Actions skips a job whenever
-    # any of its `needs` was skipped unless told otherwise - without this, promote would never run on PR builds or
-    # non-master/branch-* pushes, exactly where it's supposed to promote to sonarsource-public-dev/-builds.
-    # Always runs (never skips due to a dependency's outcome) so that a real failure surfaces as this job actually
-    # FAILING rather than being SKIPPED: GitHub treats a skipped required check as satisfying it, which would let a
-    # broken Build/UTs/ITs run merge silently if this job's own `if:` were the one doing the failure/cancel check.
+    # always() is needed because uts_macos/its_macos are conditionally skipped, and GitHub would then
+    # skip this job too - but a skipped required check counts as passing, letting a real failure merge silently.
     if: always()
     runs-on: sonar-xs
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,3 +378,21 @@ jobs:
           test-include: ${{ matrix.testInclude }}
           sq-version: ${{ matrix.sqVersion }}
           sonarcloud-project-token: ${{ secrets.SONARCLOUD_PROJECT_TOKEN }}
+
+  promote:
+    name: Promote
+    needs: [version, build, qa_windows, qa_linux, qa_macos, its_windows, its, its_macos]
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+      contents: write
+    env:
+      BUILD_NUMBER: ${{ needs.version.outputs.BUILD_NUMBER }}
+    steps:
+      # Azure's IS_RELEASE_BRANCH-gated "Set GitHub commit status for release automation" step is
+      # intentionally not ported: the promote action already posts a repox-<branch> commit status
+      # unconditionally. Revisit only if release automation owners say the Azure-specific gating is
+      # still required once this is GH-native.
+      - uses: SonarSource/ci-github-actions/promote@v1
+        with:
+          promote-pull-request: true


### PR DESCRIPTION
## What
Adds a `promote` job to `ci.yml` that promotes the build already staged to Repox (by #3237's "Stage to repox" step) using `SonarSource/ci-github-actions/promote@v1` — the same shared action `sonar-dotnet-a3s` and `sonar-dotnet-autoscan` use for this.

## Why
Replaces Azure's `artifacts` stage / `promoteRepox` job (`JFrogBuildPromotion@1` task) with the org's shared promote action instead of a hand-rolled equivalent.

`artifactory-target-repo` is intentionally left unset — the action auto-derives it from branch type and the deploy repo. Since this repo publishes a public NuGet package, `build-maven`'s default deploy repo (`sonarsource-public-qa`) combined with the action's `qa->dev`/`qa->builds` suffix logic should resolve to `sonarsource-public-dev` (PR runs) / `sonarsource-public-builds` (release branches) — matching Azure's current hardcoded values exactly. This couldn't be verified via a manual `workflow_dispatch` run (the action's own `check_branch()` gate only allows real `pull_request`/`master`/`branch-*`/`dogfood` events, same restriction Azure has), so this PR itself is the first real verification of that.

Azure's `IS_RELEASE_BRANCH`-gated GitHub-commit-status step (posts a `repox-<branch>` status for release automation) was intentionally not ported — the promote action already does an unconditional equivalent internally.

Part of NET-2037.