### PR TITLE
SCAN4NET-1665 Add Linux and macOS UT jobs

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -16,7 +16,6 @@ runs:
   using: composite
   steps:
     - name: Version and secrets
-      id: version-and-secrets
       uses: ./.github/actions/version-and-secrets
       with:
         build-number: ${{ inputs.build-number }}
@@ -42,7 +41,5 @@ runs:
     - name: Restore
       shell: powershell
       env:
-        NUGET_PACKAGES:       ${{ inputs.nuget-packages-path }}
-        ARTIFACTORY_USER:     ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_USER }}
-        ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_TOKEN }}
+        NUGET_PACKAGES: ${{ inputs.nuget-packages-path }}
       run: dotnet restore SonarScanner.MSBuild.sln --locked-mode --configfile "NuGet.Config"

--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -15,23 +15,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set version
-      #TODO: Wait for https://sonarsource.atlassian.net/browse/NET-4093 (rewrite set-version-ci.ps1), then adopt the same approach here.
-      shell: powershell
-      env:
-        SHORT_VERSION:          ${{ inputs.short-version }}
-        BUILD_BUILDID:          ${{ inputs.build-number }}
-        BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
-        BUILD_SOURCEVERSION:    ${{ github.sha }}
-      run: ./scripts/set-version-ci.ps1
-
-    - name: Fetch Vault Secrets
-      id: secrets
-      uses: SonarSource/vault-action-wrapper@v3
+    - name: Version and secrets
+      id: version-and-secrets
+      uses: ./.github/actions/version-and-secrets
       with:
-        secrets: |
-          development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
-          development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
+        build-number: ${{ inputs.build-number }}
+        short-version: ${{ inputs.short-version }}
 
     # The cache bucket is the current month. It's part of the cache key so the cache
     # rotates monthly, preventing it from growing unbounded with stale packages.
@@ -54,6 +43,6 @@ runs:
       shell: powershell
       env:
         NUGET_PACKAGES:       ${{ inputs.nuget-packages-path }}
-        ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
-        ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+        ARTIFACTORY_USER:     ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_USER }}
+        ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_TOKEN }}
       run: dotnet restore SonarScanner.MSBuild.sln --locked-mode --configfile "NuGet.Config"

--- a/.github/actions/qa-unix/action.yml
+++ b/.github/actions/qa-unix/action.yml
@@ -1,5 +1,5 @@
 name: QA UTs
-description: Checkout, set version, restore, build test pre-requisites, and run UTs on a Unix QA runner.
+description: Set version, restore, build test pre-requisites, and run UTs on a Unix QA runner.
 
 inputs:
   build-number:
@@ -18,11 +18,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        ref: ${{ github.head_ref || github.ref_name }}
-
     - name: Version and secrets
       uses: ./.github/actions/version-and-secrets
       with:

--- a/.github/actions/qa-unix/action.yml
+++ b/.github/actions/qa-unix/action.yml
@@ -1,0 +1,54 @@
+name: QA UTs
+description: Checkout, set version, restore, build test pre-requisites, and run UTs on a Unix QA runner.
+
+inputs:
+  build-number:
+    description: Build number used to set Version.targets.
+    required: true
+  short-version:
+    description: Short version (e.g. 5.15) used to set Version.targets.
+    required: true
+  rid:
+    description: .NET runtime identifier for the LogArgs test helper (e.g. linux-x64, osx-arm64).
+    required: true
+  os-name:
+    description: TestCategory/display-name suffix (Linux or MacOS).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        ref: ${{ github.head_ref || github.ref_name }}
+
+    - name: Version and secrets
+      uses: ./.github/actions/version-and-secrets
+      with:
+        build-number: ${{ inputs.build-number }}
+        short-version: ${{ inputs.short-version }}
+
+    - name: Download Binaries artifact
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: Binaries
+        path: Packaging/Binaries
+
+    - name: Build test pre-requisites
+      shell: bash
+      run: dotnet publish ./Tests/LogArgs/LogArgs.csproj --framework net9.0 --self-contained -r ${{ inputs.rid }}
+
+    - name: Run UTs
+      shell: bash
+      run: |
+        unset LANGUAGE
+        dotnet test --framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=No${{ inputs.os-name }}" --logger trx --results-directory TestResults /p:AutomaticallyUseReferenceAssemblyPackages=true
+
+    - name: Publish test results
+      uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+      if: ${{ !cancelled() }}
+      with:
+        name: Unit Test Results ${{ inputs.os-name }}
+        path: TestResults/*.trx
+        reporter: dotnet-trx

--- a/.github/actions/version-and-secrets/action.yml
+++ b/.github/actions/version-and-secrets/action.yml
@@ -8,26 +8,28 @@ inputs:
   short-version:
     description: Short version (e.g. 5.15) used to set Version.targets.
     required: true
-  shell:
-    description: >
-      PowerShell host used to run set-version-ci.ps1. Windows runners ship the
-      Desktop edition as 'powershell' (default); Linux/macOS have no built-in
-      PowerShell, so callers there must pass 'pwsh' (PowerShell Core) and ensure
-      it's installed (e.g. via mise) before calling this action.
-    required: false
-    default: powershell
-
-outputs:
-  vault:
-    description: Raw vault-action-wrapper output; read fields via fromJSON(...).REPOX_USER / REPOX_TOKEN.
-    value: ${{ steps.secrets.outputs.vault }}
 
 runs:
   using: composite
   steps:
-    - name: Set version
+    # A composite step's 'shell:' can't read runner.os directly (only inputs/literals), so each
+    # PowerShell step below is split into a Windows/non-Windows pair with identical bodies: Windows
+    # ships 'powershell' (Desktop edition) built in; Linux/macOS have no built-in PowerShell, so they
+    # need 'pwsh' (PowerShell Core) installed separately (e.g. via mise) and run that instead.
+    - name: Set version (Windows)
+      if: runner.os == 'Windows'
       #TODO: Wait for https://sonarsource.atlassian.net/browse/NET-4093 (rewrite set-version-ci.ps1), then adopt the same approach here.
-      shell: ${{ inputs.shell }}
+      shell: powershell
+      env:
+        SHORT_VERSION:          ${{ inputs.short-version }}
+        BUILD_BUILDID:          ${{ inputs.build-number }}
+        BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
+        BUILD_SOURCEVERSION:    ${{ github.sha }}
+      run: ./scripts/set-version-ci.ps1
+
+    - name: Set version (Linux/macOS)
+      if: runner.os != 'Windows'
+      shell: pwsh
       env:
         SHORT_VERSION:          ${{ inputs.short-version }}
         BUILD_BUILDID:          ${{ inputs.build-number }}
@@ -42,3 +44,26 @@ runs:
         secrets: |
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
+
+    # Exported as job-level env vars (rather than an action output) so every later step in the
+    # job that touches NuGet restore - explicit or implicit via build/test/publish - picks these
+    # up without repeating fromJSON(steps.*.outputs.vault) at each call site.
+    - name: Export Artifactory credentials (Windows)
+      if: runner.os == 'Windows'
+      shell: powershell
+      env:
+        ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
+        ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+      run: |
+        "ARTIFACTORY_USER=$env:ARTIFACTORY_USER"         | Out-File -FilePath $env:GITHUB_ENV -Append
+        "ARTIFACTORY_PASSWORD=$env:ARTIFACTORY_PASSWORD" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+    - name: Export Artifactory credentials (Linux/macOS)
+      if: runner.os != 'Windows'
+      shell: pwsh
+      env:
+        ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
+        ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+      run: |
+        "ARTIFACTORY_USER=$env:ARTIFACTORY_USER"         | Out-File -FilePath $env:GITHUB_ENV -Append
+        "ARTIFACTORY_PASSWORD=$env:ARTIFACTORY_PASSWORD" | Out-File -FilePath $env:GITHUB_ENV -Append

--- a/.github/actions/version-and-secrets/action.yml
+++ b/.github/actions/version-and-secrets/action.yml
@@ -12,36 +12,17 @@ inputs:
 runs:
   using: composite
   steps:
-    # sonar-xs (the Linux qa runner) is bare and ships no PowerShell at all; installed here so
-    # callers don't need to provision it themselves before calling in. GitHub-hosted macOS
-    # runners ship pwsh preinstalled, so this only runs on Linux.
+    # Only GitHub-hosted macOS runners ship pwsh preinstalled; sonar-xs (Linux) and
+    # warp-custom-dotnet-bubble-ci (Windows) don't, so mise installs it on both.
     - name: Install PowerShell Core
-      if: runner.os == 'Linux'
+      if: runner.os != 'macOS'
       uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
       with:
         cache: true
         tool_versions: |
           powershell-core 7.5.4
 
-    # A composite step's 'shell:' can't read runner.os directly (only inputs/literals), so each
-    # PowerShell step below is split into a Windows/non-Windows pair with identical bodies: Windows
-    # ships 'powershell' (Desktop edition) built in; Linux/macOS run the 'pwsh' (PowerShell Core)
-    # installed above (Linux) or preinstalled (macOS) instead. The split is a real constraint, not
-    # just caution: this repo's Windows runner image (ci-ami-images' dotnet-bubble-ci playbook)
-    # never installs pwsh, only the Windows PowerShell 5.1 that ships with the OS.
-    - name: Set version (Windows)
-      if: runner.os == 'Windows'
-      #TODO: Wait for https://sonarsource.atlassian.net/browse/NET-4093 (rewrite set-version-ci.ps1), then adopt the same approach here.
-      shell: powershell
-      env:
-        SHORT_VERSION:          ${{ inputs.short-version }}
-        BUILD_BUILDID:          ${{ inputs.build-number }}
-        BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
-        BUILD_SOURCEVERSION:    ${{ github.sha }}
-      run: ./scripts/set-version-ci.ps1
-
-    - name: Set version (Linux/macOS)
-      if: runner.os != 'Windows'
+    - name: Set version
       shell: pwsh
       env:
         SHORT_VERSION:          ${{ inputs.short-version }}
@@ -61,18 +42,7 @@ runs:
     # Exported as job-level env vars (rather than an action output) so every later step in the
     # job that touches NuGet restore - explicit or implicit via build/test/publish - picks these
     # up without repeating fromJSON(steps.*.outputs.vault) at each call site.
-    - name: Export Artifactory credentials (Windows)
-      if: runner.os == 'Windows'
-      shell: powershell
-      env:
-        ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
-        ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
-      run: |
-        "ARTIFACTORY_USER=$env:ARTIFACTORY_USER"         | Out-File -FilePath $env:GITHUB_ENV -Append
-        "ARTIFACTORY_PASSWORD=$env:ARTIFACTORY_PASSWORD" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-    - name: Export Artifactory credentials (Linux/macOS)
-      if: runner.os != 'Windows'
+    - name: Export Artifactory credentials
       shell: pwsh
       env:
         ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}

--- a/.github/actions/version-and-secrets/action.yml
+++ b/.github/actions/version-and-secrets/action.yml
@@ -12,10 +12,23 @@ inputs:
 runs:
   using: composite
   steps:
+    # sonar-xs (the Linux qa runner) is bare and ships no PowerShell at all; installed here so
+    # callers don't need to provision it themselves before calling in. GitHub-hosted macOS
+    # runners ship pwsh preinstalled, so this only runs on Linux.
+    - name: Install PowerShell Core
+      if: runner.os == 'Linux'
+      uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
+      with:
+        cache: true
+        tool_versions: |
+          powershell-core 7.5.4
+
     # A composite step's 'shell:' can't read runner.os directly (only inputs/literals), so each
     # PowerShell step below is split into a Windows/non-Windows pair with identical bodies: Windows
-    # ships 'powershell' (Desktop edition) built in; Linux/macOS have no built-in PowerShell, so they
-    # need 'pwsh' (PowerShell Core) installed separately (e.g. via mise) and run that instead.
+    # ships 'powershell' (Desktop edition) built in; Linux/macOS run the 'pwsh' (PowerShell Core)
+    # installed above (Linux) or preinstalled (macOS) instead. The split is a real constraint, not
+    # just caution: this repo's Windows runner image (ci-ami-images' dotnet-bubble-ci playbook)
+    # never installs pwsh, only the Windows PowerShell 5.1 that ships with the OS.
     - name: Set version (Windows)
       if: runner.os == 'Windows'
       #TODO: Wait for https://sonarsource.atlassian.net/browse/NET-4093 (rewrite set-version-ci.ps1), then adopt the same approach here.

--- a/.github/actions/version-and-secrets/action.yml
+++ b/.github/actions/version-and-secrets/action.yml
@@ -12,24 +12,28 @@ inputs:
 runs:
   using: composite
   steps:
-    # Only GitHub-hosted macOS runners ship pwsh preinstalled; sonar-xs (Linux) and
-    # warp-custom-dotnet-bubble-ci (Windows) don't, so mise installs it on both.
+    # sonar-xs (the Linux qa runner) is bare and ships no PowerShell at all. Windows ships
+    # Windows PowerShell 5.1 built in; GitHub-hosted macOS ships pwsh preinstalled - neither
+    # needs anything installed.
     - name: Install PowerShell Core
-      if: runner.os != 'macOS'
+      if: runner.os == 'Linux'
       uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
       with:
         cache: true
         tool_versions: |
           powershell-core 7.5.4
 
+    # shell: only accepts a static value or ${{ inputs.x }} - not runner.os or any other
+    # context - but a run: command's own text has no such restriction, so the PowerShell host
+    # (powershell on Windows, pwsh elsewhere) is picked there instead, under a plain bash shell.
     - name: Set version
-      shell: pwsh
+      shell: bash
       env:
         SHORT_VERSION:          ${{ inputs.short-version }}
         BUILD_BUILDID:          ${{ inputs.build-number }}
         BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
         BUILD_SOURCEVERSION:    ${{ github.sha }}
-      run: ./scripts/set-version-ci.ps1
+      run: ${{ runner.os == 'Windows' && 'powershell' || 'pwsh' }} -File ./scripts/set-version-ci.ps1
 
     - name: Fetch Vault Secrets
       id: secrets
@@ -41,12 +45,13 @@ runs:
 
     # Exported as job-level env vars (rather than an action output) so every later step in the
     # job that touches NuGet restore - explicit or implicit via build/test/publish - picks these
-    # up without repeating fromJSON(steps.*.outputs.vault) at each call site.
+    # up without repeating fromJSON(steps.*.outputs.vault) at each call site. Plain env-file
+    # plumbing, so this doesn't need PowerShell at all - just bash, like the step above.
     - name: Export Artifactory credentials
-      shell: pwsh
+      shell: bash
       env:
         ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
         ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
       run: |
-        "ARTIFACTORY_USER=$env:ARTIFACTORY_USER"         | Out-File -FilePath $env:GITHUB_ENV -Append
-        "ARTIFACTORY_PASSWORD=$env:ARTIFACTORY_PASSWORD" | Out-File -FilePath $env:GITHUB_ENV -Append
+        echo "ARTIFACTORY_USER=$ARTIFACTORY_USER" >> "$GITHUB_ENV"
+        echo "ARTIFACTORY_PASSWORD=$ARTIFACTORY_PASSWORD" >> "$GITHUB_ENV"

--- a/.github/actions/version-and-secrets/action.yml
+++ b/.github/actions/version-and-secrets/action.yml
@@ -1,0 +1,44 @@
+name: Version and secrets
+description: Set Version.targets and fetch Artifactory credentials from Vault.
+
+inputs:
+  build-number:
+    description: Build number used to set Version.targets.
+    required: true
+  short-version:
+    description: Short version (e.g. 5.15) used to set Version.targets.
+    required: true
+  shell:
+    description: >
+      PowerShell host used to run set-version-ci.ps1. Windows runners ship the
+      Desktop edition as 'powershell' (default); Linux/macOS have no built-in
+      PowerShell, so callers there must pass 'pwsh' (PowerShell Core) and ensure
+      it's installed (e.g. via mise) before calling this action.
+    required: false
+    default: powershell
+
+outputs:
+  vault:
+    description: Raw vault-action-wrapper output; read fields via fromJSON(...).REPOX_USER / REPOX_TOKEN.
+    value: ${{ steps.secrets.outputs.vault }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set version
+      #TODO: Wait for https://sonarsource.atlassian.net/browse/NET-4093 (rewrite set-version-ci.ps1), then adopt the same approach here.
+      shell: ${{ inputs.shell }}
+      env:
+        SHORT_VERSION:          ${{ inputs.short-version }}
+        BUILD_BUILDID:          ${{ inputs.build-number }}
+        BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
+        BUILD_SOURCEVERSION:    ${{ github.sha }}
+      run: ./scripts/set-version-ci.ps1
+
+    - name: Fetch Vault Secrets
+      id: secrets
+      uses: SonarSource/vault-action-wrapper@v3
+      with:
+        secrets: |
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
+          development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;

--- a/.github/actions/version-and-secrets/action.yml
+++ b/.github/actions/version-and-secrets/action.yml
@@ -12,20 +12,6 @@ inputs:
 runs:
   using: composite
   steps:
-    # sonar-xs (the Linux qa runner) is bare and ships no PowerShell at all. Windows ships
-    # Windows PowerShell 5.1 built in; GitHub-hosted macOS ships pwsh preinstalled - neither
-    # needs anything installed.
-    - name: Install PowerShell Core
-      if: runner.os == 'Linux'
-      uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
-      with:
-        cache: true
-        tool_versions: |
-          powershell-core 7.5.4
-
-    # shell: only accepts a static value or ${{ inputs.x }} - not runner.os or any other
-    # context - but a run: command's own text has no such restriction, so the PowerShell host
-    # (powershell on Windows, pwsh elsewhere) is picked there instead, under a plain bash shell.
     - name: Set version
       shell: bash
       env:
@@ -43,10 +29,6 @@ runs:
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
           development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
 
-    # Exported as job-level env vars (rather than an action output) so every later step in the
-    # job that touches NuGet restore - explicit or implicit via build/test/publish - picks these
-    # up without repeating fromJSON(steps.*.outputs.vault) at each call site. Plain env-file
-    # plumbing, so this doesn't need PowerShell at all - just bash, like the step above.
     - name: Export Artifactory credentials
       shell: bash
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,11 +343,11 @@ jobs:
             powershell-core 7.5.4
 
       # Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/MSBuildExecution/MSBuildLocator.cs only
-      # looks for dotnet at the well-known paths used by Microsoft's official install script
-      # (which is what provisions dotnet on the Azure agents this job mirrors), not wherever a
-      # tool manager happens to put it. mise installs elsewhere, so symlink it into place.
+      # looks for the dotnet executable at a few hardcoded file paths used by Microsoft's official
+      # install script (which is what provisions dotnet on the Azure agents this job mirrors), not
+      # wherever a tool manager happens to put it. mise installs elsewhere, so symlink it into place.
       - name: Make dotnet discoverable at the well-known Linux path
-        run: sudo ln -sfn "$DOTNET_ROOT" /usr/share/dotnet
+        run: sudo ln -sfn "$(command -v dotnet)" /usr/local/bin/dotnet
 
       - name: Set version
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,9 +174,7 @@ jobs:
         uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
-            development/kv/data/sonarcloud token                                             | SONAR_TOKEN;
+            development/kv/data/sonarcloud token | SONAR_TOKEN;
 
       - name: Cache SonarScanner for .NET
         id: s4net-cache
@@ -186,9 +184,6 @@ jobs:
           key: s4net-${{ hashFiles('.config/dotnet-tools.json') }}
 
       - name: Restore SonarScanner for .NET
-        env:
-          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
-          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
         run: dotnet tool restore --tool-manifest .config/dotnet-tools.json --configfile "NuGet.Config"
 
       - name: SonarQube Analysis begin
@@ -208,9 +203,6 @@ jobs:
         run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release /p:RunAnalyzers=true /p:RunAnalyzersDuringBuild=true
 
       - name: Run UTs and compute coverage
-        env:
-          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
-          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
         run: .\scripts\run-unit-tests.ps1 -SourcesDirectory "${{ github.workspace }}" -BuildConfiguration Release
 
       - name: Publish test results
@@ -322,17 +314,16 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
-      # sonar-xs is a bare runner and doesn't ship the .NET SDK or PowerShell Core,
-      # unlike the Azure Linux/macOS agents this job mirrors (which have both preinstalled).
-      # dotnet 9 (not 10) is required: the test host needs a runtime matching the
-      # `--framework net9.0` filter below, and .NET doesn't roll forward across major versions.
+      # sonar-xs is a bare runner and doesn't ship the .NET SDK, unlike the Azure Linux/macOS
+      # agents this job mirrors. dotnet 9 (not 10) is required: the test host needs a runtime
+      # matching the `--framework net9.0` filter below, and .NET doesn't roll forward across
+      # major versions. (PowerShell Core is installed by the version-and-secrets action below.)
       - name: Install tools
         uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           tool_versions: |
             dotnet 9
-            powershell-core 7.5.4
 
       # Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/MSBuildExecution/MSBuildLocator.cs only
       # looks for the dotnet executable at a few hardcoded file paths used by Microsoft's official

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,21 +309,17 @@ jobs:
       contents: read
       checks: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
-
-      # sonar-xs is a bare runner and doesn't ship the .NET SDK, unlike the Azure Linux/macOS
-      # agents this job mirrors. dotnet 9 (not 10) is required: the test host needs a runtime
-      # matching the `--framework net9.0` filter below, and .NET doesn't roll forward across
-      # major versions. (PowerShell Core is installed by the version-and-secrets action below.)
+      # sonar-xs is a bare runner and doesn't ship the .NET SDK or PowerShell Core, unlike the
+      # Azure Linux/macOS agents this job mirrors (which have both preinstalled). dotnet 9 (not
+      # 10) is required: the test host needs a runtime matching the `--framework net9.0` filter
+      # below, and .NET doesn't roll forward across major versions.
       - name: Install tools
         uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           tool_versions: |
             dotnet 9
+            powershell-core 7.5.4
 
       # Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/MSBuildExecution/MSBuildLocator.cs only
       # looks for the dotnet executable at a few hardcoded file paths used by Microsoft's official
@@ -332,37 +328,13 @@ jobs:
       - name: Make dotnet discoverable at the well-known Linux path
         run: sudo ln -sfn "$(command -v dotnet)" /usr/local/bin/dotnet
 
-      - name: Version and secrets
-        uses: ./.github/actions/version-and-secrets
+      - name: QA UTs
+        uses: ./.github/actions/qa-unix
         with:
           build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
           short-version: ${{ needs.version.outputs.SHORT_VERSION }}
-
-      - name: Download Binaries artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: Binaries
-          path: Packaging/Binaries
-
-      - name: Build test pre-requisites
-        run: dotnet publish ./Tests/LogArgs/LogArgs.csproj --framework net9.0 --self-contained -r linux-x64
-
-      # The runner's LANGUAGE env var (e.g. en_US.UTF-8) is picked up by MSBuild as the implicit
-      # $(Language) global property (env vars become properties, matched case-insensitively),
-      # which leaks into ProjectLanguage="$(Language)" in SonarQube.Integration.targets and fails
-      # tests that expect a bare/unrecognized project type to have a null project language.
-      - name: Run UTs
-        run: |
-          unset LANGUAGE
-          dotnet test --framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=NoLinux" --logger trx --results-directory TestResults /p:AutomaticallyUseReferenceAssemblyPackages=true
-
-      - name: Publish test results
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        if: ${{ !cancelled() }}
-        with:
-          name: Unit Test Results Linux
-          path: TestResults/*.trx
-          reporter: dotnet-trx
+          rid: linux-x64
+          os-name: Linux
 
   qa_macos:
     name: QA macOS - UTs
@@ -381,33 +353,10 @@ jobs:
       - name: Remove pre-existing .bash_profile
         run: rm -f ~/.bash_profile
 
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
-
-      - name: Version and secrets
-        uses: ./.github/actions/version-and-secrets
+      - name: QA UTs
+        uses: ./.github/actions/qa-unix
         with:
           build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
           short-version: ${{ needs.version.outputs.SHORT_VERSION }}
-
-      - name: Download Binaries artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: Binaries
-          path: Packaging/Binaries
-
-      - name: Build test pre-requisites
-        run: dotnet publish ./Tests/LogArgs/LogArgs.csproj --framework net9.0 --self-contained -r osx-arm64
-
-      - name: Run UTs
-        run: dotnet test --framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=NoMacOS" --logger trx --results-directory TestResults /p:AutomaticallyUseReferenceAssemblyPackages=true
-
-      - name: Publish test results
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        if: ${{ !cancelled() }}
-        with:
-          name: Unit Test Results MacOS
-          path: TestResults/*.trx
-          reporter: dotnet-trx
+          rid: osx-arm64
+          os-name: MacOS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,15 +341,11 @@ jobs:
       - name: Make dotnet discoverable at the well-known Linux path
         run: sudo ln -sfn "$(command -v dotnet)" /usr/local/bin/dotnet
 
-      # Linux has no built-in 'powershell' (Windows PowerShell Desktop), so this runs on the
-      # 'pwsh' (PowerShell Core) mise just installed above, unlike the Windows prepare action.
       - name: Version and secrets
-        id: version-and-secrets
         uses: ./.github/actions/version-and-secrets
         with:
           build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
           short-version: ${{ needs.version.outputs.SHORT_VERSION }}
-          shell: pwsh
 
       - name: Download Binaries artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -358,9 +354,6 @@ jobs:
           path: Packaging/Binaries
 
       - name: Build test pre-requisites
-        env:
-          ARTIFACTORY_USER:     ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_USER }}
-          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_TOKEN }}
         run: dotnet publish ./Tests/LogArgs/LogArgs.csproj --framework net9.0 --self-contained -r linux-x64
 
       # The runner's LANGUAGE env var (e.g. en_US.UTF-8) is picked up by MSBuild as the implicit
@@ -368,9 +361,6 @@ jobs:
       # which leaks into ProjectLanguage="$(Language)" in SonarQube.Integration.targets and fails
       # tests that expect a bare/unrecognized project type to have a null project language.
       - name: Run UTs
-        env:
-          ARTIFACTORY_USER:     ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_USER }}
-          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_TOKEN }}
         run: |
           unset LANGUAGE
           dotnet test --framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=NoLinux" --logger trx --results-directory TestResults /p:AutomaticallyUseReferenceAssemblyPackages=true
@@ -405,15 +395,11 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
-      # macOS has no built-in 'powershell' (Windows PowerShell Desktop); GitHub-hosted macOS
-      # images ship 'pwsh' (PowerShell Core) preinstalled, unlike the Windows prepare action.
       - name: Version and secrets
-        id: version-and-secrets
         uses: ./.github/actions/version-and-secrets
         with:
           build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
           short-version: ${{ needs.version.outputs.SHORT_VERSION }}
-          shell: pwsh
 
       - name: Download Binaries artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -422,15 +408,9 @@ jobs:
           path: Packaging/Binaries
 
       - name: Build test pre-requisites
-        env:
-          ARTIFACTORY_USER:     ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_USER }}
-          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_TOKEN }}
         run: dotnet publish ./Tests/LogArgs/LogArgs.csproj --framework net9.0 --self-contained -r osx-arm64
 
       - name: Run UTs
-        env:
-          ARTIFACTORY_USER:     ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_USER }}
-          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_TOKEN }}
         run: dotnet test --framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=NoMacOS" --logger trx --results-directory TestResults /p:AutomaticallyUseReferenceAssemblyPackages=true
 
       - name: Publish test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,12 +330,14 @@ jobs:
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
 
-      # sonar-xs doesn't ship PowerShell Core, unlike the Azure Linux/macOS agents this job mirrors.
-      - name: Install PowerShell Core
+      # sonar-xs is a bare runner and doesn't ship the .NET SDK or PowerShell Core,
+      # unlike the Azure Linux/macOS agents this job mirrors (which have both preinstalled).
+      - name: Install tools
         uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           tool_versions: |
+            dotnet 10
             powershell-core 7.5.4
 
       - name: Set version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,7 @@ jobs:
     name: QA macOS - UTs
     needs: [version, build]
     runs-on: macos-latest-xlarge
-    if: true # TEMPORARY: smoke-test version-and-secrets on this branch before restoring the release-branch-only gate
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-')
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,11 +370,17 @@ jobs:
           ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
         run: dotnet publish ./Tests/LogArgs/LogArgs.csproj --framework net9.0 --self-contained -r linux-x64
 
+      # The runner's LANGUAGE env var (e.g. en_US.UTF-8) is picked up by MSBuild as the implicit
+      # $(Language) global property (env vars become properties, matched case-insensitively),
+      # which leaks into ProjectLanguage="$(Language)" in SonarQube.Integration.targets and fails
+      # tests that expect a bare/unrecognized project type to have a null project language.
       - name: Run UTs
         env:
           ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
           ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
-        run: dotnet test --framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=NoLinux" --logger trx --results-directory TestResults /p:AutomaticallyUseReferenceAssemblyPackages=true
+        run: |
+          unset LANGUAGE
+          dotnet test --framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=NoLinux" --logger trx --results-directory TestResults /p:AutomaticallyUseReferenceAssemblyPackages=true
 
       - name: Publish test results
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,7 @@ jobs:
     name: QA macOS - UTs
     needs: [version, build]
     runs-on: macos-latest-xlarge
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-')
+    if: true # TEMPORARY: smoke-test on this branch before restoring the release-branch-only gate
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,19 @@ env:
   NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
 
 jobs:
+  test_dynamic_shell:
+    name: TEMPORARY - test shell from steps.outputs
+    runs-on: sonar-xs
+    steps:
+      - name: select_shell
+        id: select_shell
+        shell: bash
+        run: echo "chosen_shell=bash" >> "$GITHUB_OUTPUT"
+
+      - name: use dynamic shell
+        shell: ${{ steps.select_shell.outputs.chosen_shell }}
+        run: echo "it worked, dynamic shell resolved"
+
   version:
     name: Compute version
     runs-on: sonar-xs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,7 @@ jobs:
     name: QA macOS - UTs
     needs: [version, build]
     runs-on: macos-latest-xlarge
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-')
+    if: true # TEMPORARY: smoke-test version-and-secrets on this branch before restoring the release-branch-only gate
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,7 @@ jobs:
     name: QA macOS - UTs
     needs: [version, build]
     runs-on: macos-latest-xlarge
-    if: true # TEMPORARY: smoke-test on this branch before restoring the release-branch-only gate
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-')
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,11 @@ jobs:
       contents: read
       checks: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
       # sonar-xs is a bare runner and doesn't ship the .NET SDK or PowerShell Core, unlike the
       # Azure Linux/macOS agents this job mirrors (which have both preinstalled). dotnet 9 (not
       # 10) is required: the test host needs a runtime matching the `--framework net9.0` filter
@@ -352,6 +357,11 @@ jobs:
 
       - name: Remove pre-existing .bash_profile
         run: rm -f ~/.bash_profile
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: QA UTs
         uses: ./.github/actions/qa-unix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,6 @@ env:
   NUGET_PACKAGES: ${{ github.workspace }}\.nuget\packages
 
 jobs:
-  test_dynamic_shell:
-    name: TEMPORARY - test shell from steps.outputs
-    runs-on: sonar-xs
-    steps:
-      - name: select_shell
-        id: select_shell
-        shell: bash
-        run: echo "chosen_shell=bash" >> "$GITHUB_OUTPUT"
-
-      - name: use dynamic shell
-        shell: ${{ steps.select_shell.outputs.chosen_shell }}
-        run: echo "it worked, dynamic shell resolved"
-
   version:
     name: Compute version
     runs-on: sonar-xs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,10 +314,6 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
-      # sonar-xs is a bare runner and doesn't ship the .NET SDK or PowerShell Core, unlike the
-      # Azure Linux/macOS agents this job mirrors (which have both preinstalled). dotnet 9 (not
-      # 10) is required: the test host needs a runtime matching the `--framework net9.0` filter
-      # below, and .NET doesn't roll forward across major versions.
       - name: Install tools
         uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
@@ -326,10 +322,7 @@ jobs:
             dotnet 9
             powershell-core 7.5.4
 
-      # Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/MSBuildExecution/MSBuildLocator.cs only
-      # looks for the dotnet executable at a few hardcoded file paths used by Microsoft's official
-      # install script (which is what provisions dotnet on the Azure agents this job mirrors), not
-      # wherever a tool manager happens to put it. mise installs elsewhere, so symlink it into place.
+      # 
       - name: Make dotnet discoverable at the well-known Linux path
         run: sudo ln -sfn "$(command -v dotnet)" /usr/local/bin/dotnet
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,12 +332,14 @@ jobs:
 
       # sonar-xs is a bare runner and doesn't ship the .NET SDK or PowerShell Core,
       # unlike the Azure Linux/macOS agents this job mirrors (which have both preinstalled).
+      # dotnet 9 (not 10) is required: the test host needs a runtime matching the
+      # `--framework net9.0` filter below, and .NET doesn't roll forward across major versions.
       - name: Install tools
         uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           tool_versions: |
-            dotnet 10
+            dotnet 9
             powershell-core 7.5.4
 
       - name: Set version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,14 +322,6 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
-      - name: Fetch Vault Secrets
-        id: secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
-
       # sonar-xs is a bare runner and doesn't ship the .NET SDK or PowerShell Core,
       # unlike the Azure Linux/macOS agents this job mirrors (which have both preinstalled).
       # dotnet 9 (not 10) is required: the test host needs a runtime matching the
@@ -349,14 +341,15 @@ jobs:
       - name: Make dotnet discoverable at the well-known Linux path
         run: sudo ln -sfn "$(command -v dotnet)" /usr/local/bin/dotnet
 
-      - name: Set version
-        shell: pwsh
-        env:
-          SHORT_VERSION:          ${{ needs.version.outputs.SHORT_VERSION }}
-          BUILD_BUILDID:          ${{ needs.version.outputs.BUILD_NUMBER }}
-          BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
-          BUILD_SOURCEVERSION:    ${{ github.sha }}
-        run: ./scripts/set-version-ci.ps1
+      # Linux has no built-in 'powershell' (Windows PowerShell Desktop), so this runs on the
+      # 'pwsh' (PowerShell Core) mise just installed above, unlike the Windows prepare action.
+      - name: Version and secrets
+        id: version-and-secrets
+        uses: ./.github/actions/version-and-secrets
+        with:
+          build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
+          short-version: ${{ needs.version.outputs.SHORT_VERSION }}
+          shell: pwsh
 
       - name: Download Binaries artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -366,8 +359,8 @@ jobs:
 
       - name: Build test pre-requisites
         env:
-          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
-          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+          ARTIFACTORY_USER:     ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_USER }}
+          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_TOKEN }}
         run: dotnet publish ./Tests/LogArgs/LogArgs.csproj --framework net9.0 --self-contained -r linux-x64
 
       # The runner's LANGUAGE env var (e.g. en_US.UTF-8) is picked up by MSBuild as the implicit
@@ -376,8 +369,8 @@ jobs:
       # tests that expect a bare/unrecognized project type to have a null project language.
       - name: Run UTs
         env:
-          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
-          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+          ARTIFACTORY_USER:     ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_USER }}
+          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_TOKEN }}
         run: |
           unset LANGUAGE
           dotnet test --framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=NoLinux" --logger trx --results-directory TestResults /p:AutomaticallyUseReferenceAssemblyPackages=true
@@ -412,22 +405,15 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
 
-      - name: Fetch Vault Secrets
-        id: secrets
-        uses: SonarSource/vault-action-wrapper@v3
+      # macOS has no built-in 'powershell' (Windows PowerShell Desktop); GitHub-hosted macOS
+      # images ship 'pwsh' (PowerShell Core) preinstalled, unlike the Windows prepare action.
+      - name: Version and secrets
+        id: version-and-secrets
+        uses: ./.github/actions/version-and-secrets
         with:
-          secrets: |
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
-            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
-
-      - name: Set version
-        shell: pwsh
-        env:
-          SHORT_VERSION:          ${{ needs.version.outputs.SHORT_VERSION }}
-          BUILD_BUILDID:          ${{ needs.version.outputs.BUILD_NUMBER }}
-          BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
-          BUILD_SOURCEVERSION:    ${{ github.sha }}
-        run: ./scripts/set-version-ci.ps1
+          build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
+          short-version: ${{ needs.version.outputs.SHORT_VERSION }}
+          shell: pwsh
 
       - name: Download Binaries artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -437,14 +423,14 @@ jobs:
 
       - name: Build test pre-requisites
         env:
-          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
-          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+          ARTIFACTORY_USER:     ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_USER }}
+          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_TOKEN }}
         run: dotnet publish ./Tests/LogArgs/LogArgs.csproj --framework net9.0 --self-contained -r osx-arm64
 
       - name: Run UTs
         env:
-          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
-          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+          ARTIFACTORY_USER:     ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_USER }}
+          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.version-and-secrets.outputs.vault).REPOX_TOKEN }}
         run: dotnet test --framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=NoMacOS" --logger trx --results-directory TestResults /p:AutomaticallyUseReferenceAssemblyPackages=true
 
       - name: Publish test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,3 +307,125 @@ jobs:
           name: Windows ITs Results (${{ matrix.scenario }})
           path: its/target/surefire-reports/TEST-*.xml
           reporter: java-junit
+
+  qa_linux:
+    name: QA Linux - UTs
+    needs: [version, build]
+    runs-on: sonar-xs
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Fetch Vault Secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
+
+      - name: Set version
+        shell: pwsh
+        env:
+          SHORT_VERSION:          ${{ needs.version.outputs.SHORT_VERSION }}
+          BUILD_BUILDID:          ${{ needs.version.outputs.BUILD_NUMBER }}
+          BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
+          BUILD_SOURCEVERSION:    ${{ github.sha }}
+        run: ./scripts/set-version-ci.ps1
+
+      - name: Download Binaries artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Binaries
+          path: Packaging/Binaries
+
+      - name: Build test pre-requisites
+        env:
+          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
+          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+        run: dotnet publish ./Tests/LogArgs/LogArgs.csproj --framework net9.0 --self-contained -r linux-x64
+
+      - name: Run UTs
+        env:
+          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
+          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+        run: dotnet test --framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=NoLinux" --logger trx --results-directory TestResults /p:AutomaticallyUseReferenceAssemblyPackages=true
+
+      - name: Publish test results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: ${{ !cancelled() }}
+        with:
+          name: Unit Test Results Linux
+          path: TestResults/*.trx
+          reporter: dotnet-trx
+
+  qa_macos:
+    name: QA macOS - UTs
+    needs: [version, build]
+    runs-on: macos-latest-xlarge
+    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-')
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+    steps:
+      - name: Setup Cloudflare WARP
+        uses: SonarSource/gh-action_setup-cloudflare-warp@v1
+        id: warp
+
+      - name: Remove pre-existing .bash_profile
+        run: rm -f ~/.bash_profile
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Fetch Vault Secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
+
+      - name: Set version
+        shell: pwsh
+        env:
+          SHORT_VERSION:          ${{ needs.version.outputs.SHORT_VERSION }}
+          BUILD_BUILDID:          ${{ needs.version.outputs.BUILD_NUMBER }}
+          BUILD_SOURCEBRANCHNAME: ${{ github.ref_name }}
+          BUILD_SOURCEVERSION:    ${{ github.sha }}
+        run: ./scripts/set-version-ci.ps1
+
+      - name: Download Binaries artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Binaries
+          path: Packaging/Binaries
+
+      - name: Build test pre-requisites
+        env:
+          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
+          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+        run: dotnet publish ./Tests/LogArgs/LogArgs.csproj --framework net9.0 --self-contained -r osx-arm64
+
+      - name: Run UTs
+        env:
+          ARTIFACTORY_USER:     ${{ fromJSON(steps.secrets.outputs.vault).REPOX_USER }}
+          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).REPOX_TOKEN }}
+        run: dotnet test --framework net9.0 --filter "TestCategory!=NoUnixNeedsReview&TestCategory!=NoMacOS" --logger trx --results-directory TestResults /p:AutomaticallyUseReferenceAssemblyPackages=true
+
+      - name: Publish test results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: ${{ !cancelled() }}
+        with:
+          name: Unit Test Results MacOS
+          path: TestResults/*.trx
+          reporter: dotnet-trx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,13 @@ jobs:
             dotnet 9
             powershell-core 7.5.4
 
+      # Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/MSBuildExecution/MSBuildLocator.cs only
+      # looks for dotnet at the well-known paths used by Microsoft's official install script
+      # (which is what provisions dotnet on the Azure agents this job mirrors), not wherever a
+      # tool manager happens to put it. mise installs elsewhere, so symlink it into place.
+      - name: Make dotnet discoverable at the well-known Linux path
+        run: sudo ln -sfn "$DOTNET_ROOT" /usr/share/dotnet
+
       - name: Set version
         shell: pwsh
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,14 @@ jobs:
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | REPOX_USER;
             development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | REPOX_TOKEN;
 
+      # sonar-xs doesn't ship PowerShell Core, unlike the Azure Linux/macOS agents this job mirrors.
+      - name: Install PowerShell Core
+        uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
+        with:
+          cache: true
+          tool_versions: |
+            powershell-core 7.5.4
+
       - name: Set version
         shell: pwsh
         env:

--- a/Tests/SonarScanner.MSBuild.Common.Test/ProcessRunnerTests.cs
+++ b/Tests/SonarScanner.MSBuild.Common.Test/ProcessRunnerTests.cs
@@ -647,7 +647,10 @@ public class ProcessRunnerTests
         }
         else // MacOs
         {
-            return Path.Combine(basePath.Replace("Debug", "Release"), "osx-x64", "LogArgs");
+            // Azure's macOS-14 hosted agent publishes/runs osx-x64 (templates/unix-qa-stage.yml);
+            // GitHub's macos-latest-xlarge is native Apple Silicon and publishes osx-arm64 (ci.yml).
+            var rid = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "osx-arm64" : "osx-x64";
+            return Path.Combine(basePath.Replace("Debug", "Release"), rid, "LogArgs");
         }
     }
 


### PR DESCRIPTION
## What
Adds `qa_linux` and `qa_macos` jobs to `ci.yml`, mirroring Azure's `templates/unix-qa-stage.yml` `uts` job (Integration Tests are explicitly out of scope here — tracked separately).

## Why
Continues the Azure Pipelines -> GitHub Actions CI migration. Runner choice follows org convention rather than defaulting to plain GitHub-hosted labels: `qa_linux` runs on self-hosted `sonar-xs`; `qa_macos` runs on GitHub-hosted `macos-latest-xlarge` (no Sonar-managed macOS runner exists org-wide) with mandatory `SonarSource/gh-action_setup-cloudflare-warp` for private-network access, gated to release branches only since GitHub-hosted macOS runners cost ~10x a Linux runner.

**`qa_linux`: fully green.** Required installing PowerShell Core and the .NET SDK via `mise` (`sonar-xs` has neither preinstalled, unlike Azure's Microsoft-hosted images), pinning dotnet 9 to match the `net9.0` test filter, and symlinking the mise-installed `dotnet` into a path `Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/MSBuildExecution/MSBuildLocator.cs` actually searches (it checks a handful of hardcoded install paths, not `$PATH` — a pre-existing narrow assumption in that helper that only ever mattered once dotnet stopped being installed via the "standard" methods). Also had to `unset LANGUAGE` before running tests: `SonarQube.Integration.targets` sets `ProjectLanguage="$(Language)"`, and MSBuild's undefined-property-falls-back-to-env-var behavior means Linux's `LANGUAGE` locale variable was leaking into it for 2 "bare project" tests that assert it should be empty.

**`qa_macos`: written and smoke-tested (temporarily enabled, verified, reverted), but currently blocked** by a Vault ACL gap — `gh-action_setup-cloudflare-warp`'s fetch for `development/kv/data/cloudflare/warp-github-runner` 403s because this repo's Vault role isn't authorized for that path yet. Fix is up at SonarSource/re-terraform-aws-vault#9491; `qa_macos` will start working once that merges, no further change needed here.

Part of NET-2037.