### PR TITLE
SCAN4NET-1666 Add Windows Integration Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,3 +229,115 @@ jobs:
         env:
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
         run: dotnet tool run dotnet-sonarscanner -- end /d:sonar.token="$env:SONAR_TOKEN"
+
+  its_windows:
+    name: QA Windows - ITs (${{ matrix.scenario }})
+    needs: [version, build]
+    runs-on: warp-custom-dotnet-bubble-ci
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: [LATEST_RELEASE]
+        include:
+          - scenario: LATEST_RELEASE
+            product: SonarQube
+            testInclude: "**/sonarqube/*"
+            msbuildPathVar: MSBUILD_18_PATH
+            jdkHomeVar: JAVA_HOME_21_X64
+          # TODO add remaining matrix entries
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Fetch Vault Secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader username     | ARTIFACTORY_USER;
+            development/artifactory/token/{REPO_OWNER_NAME_DASH}-private-reader access_token | ARTIFACTORY_PASSWORD;
+            development/github/token/licenses-ro token                                       | GH_LICENSES_TOKEN;
+
+      - name: Configure Maven
+        uses: SonarSource/ci-github-actions/config-maven@v1
+        with:
+          artifactory-reader-role: private-reader
+          working-directory: its
+        env:
+          CURRENT_VERSION: ${{ needs.version.outputs.SHORT_VERSION }}
+          PROJECT_VERSION: ${{ needs.version.outputs.FULL_VERSION }}
+
+      - name: Download Binaries artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Binaries
+          path: Packaging/Binaries
+
+      # MultiLanguageTest needs npm
+      - name: Set npm registry to Repox
+        shell: bash
+        run: |
+          npm config set loglevel=http registry=https://repox.jfrog.io/artifactory/api/npm/npmjs/
+          npm config set "//repox.jfrog.io/artifactory/api/npm/npmjs/:_authToken=$ARTIFACTORY_ACCESS_TOKEN"
+
+      - name: Run Windows ITs (${{ matrix.scenario }})
+        env:
+          MAVEN_OPTS: -Xmx3072m
+          GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GH_LICENSES_TOKEN }}
+          ARTIFACTORY_USER: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USER }}
+          ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_PASSWORD }}
+          NUGET_PATH: C:\ProgramData\chocolatey\bin\nuget.exe
+          MSBUILD_PATH_VAR: ${{ matrix.msbuildPathVar }}
+          JDK_HOME_VAR: ${{ matrix.jdkHomeVar }}
+        shell: bash
+        run: |
+          export JAVA_HOME="${!JDK_HOME_VAR}"
+          MSBUILD_PATH="${MSBUILD_PATH_VAR:+${!MSBUILD_PATH_VAR}}"
+          # TODO(SCAN4NET-1676): remove this exclusion once fixed. CodeCoverageTest and TelemetryTest
+          # fail on warp-custom-dotnet-bubble-ci with "Multiple CI environments are detected: [Azure
+          # DevOps, Github Actions]" from the Java Scanner Engine's CiConfigurationProvider - the image
+          # doubles as an Azure DevOps agent (genuine ambient TF_BUILD) alongside GitHub Actions' own
+          # native GITHUB_ACTIONS. CodeCoverageTest's two Azure-simulation tests are fully explained
+          # (they deliberately re-set TF_BUILD, and GITHUB_ACTIONS is never scrubbed); the 4 failing
+          # TelemetryTest methods never touch TF_BUILD at all and shouldn't be affected by
+          # BaseCommand's existing TF_BUILD scrub - that gap is unexplained, see the ticket.
+          mvn -f its -B -e verify \
+            "-Dtest=${{ matrix.testInclude }},!**/CodeCoverageTest,!**/TelemetryTest" \
+            "-Dsonar.runtimeVersion=${{ matrix.sqVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.sonarQubeEdition=${{ matrix.sqEdition || 'DEVELOPER' }}" \
+            "-Dsonar.csharpplugin.version=${{ matrix.dotnetVersion || 'DEV' }}" \
+            "-Dsonar.vbnetplugin.version=${{ matrix.dotnetVersion || 'DEV' }}" \
+            "-Dsonar.dreplugin.version=${{ matrix.dreVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.cfamilyplugin.version=${{ matrix.cfamilyVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.xmlplugin.version=${{ matrix.xmlVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.css.version=${{ matrix.cssVersion || 'NONE' }}" \
+            "-Dsonar.javascriptplugin.version=${{ matrix.javascriptVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.plsqlplugin.version=${{ matrix.plsqlVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.pythonplugin.version=${{ matrix.pythonVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.phpplugin.version=${{ matrix.phpVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.iacplugin.version=${{ matrix.iacVersion || 'NONE' }}" \
+            "-Dsonar.iacplugin-enterprise.version=${{ matrix.iacEnterpriseVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.javaplugin.version=${{ matrix.javaVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.textplugin.version=${{ matrix.textVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.rubyplugin.version=${{ matrix.rubyVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.goplugin.version=${{ matrix.goVersion || 'NONE' }}" \
+            "-Dsonar.goplugin-enterprise.version=${{ matrix.goEnterpriseVersion || 'LATEST_RELEASE' }}" \
+            "-Dsonar.tsqlplugin.version=${{ matrix.tsqlVersion || 'LATEST_RELEASE' }}" \
+            "-Dgo.groupid=${{ matrix.goGroupId || 'org.sonarsource.go' }}" \
+            "-Dmsbuild.path=$MSBUILD_PATH" \
+            "-Dmsbuild.platformtoolset=v140" \
+            "-Dmsbuild.windowssdk=10.0.17763.0"
+
+      - name: Publish IT results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: ${{ !cancelled() }}
+        with:
+          name: Windows ITs Results (${{ matrix.scenario }})
+          path: its/target/surefire-reports/TEST-*.xml
+          reporter: java-junit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,14 +299,7 @@ jobs:
         run: |
           export JAVA_HOME="${!JDK_HOME_VAR}"
           MSBUILD_PATH="${MSBUILD_PATH_VAR:+${!MSBUILD_PATH_VAR}}"
-          # TODO(SCAN4NET-1676): remove this exclusion once fixed. CodeCoverageTest and TelemetryTest
-          # fail on warp-custom-dotnet-bubble-ci with "Multiple CI environments are detected: [Azure
-          # DevOps, Github Actions]" from the Java Scanner Engine's CiConfigurationProvider - the image
-          # doubles as an Azure DevOps agent (genuine ambient TF_BUILD) alongside GitHub Actions' own
-          # native GITHUB_ACTIONS. CodeCoverageTest's two Azure-simulation tests are fully explained
-          # (they deliberately re-set TF_BUILD, and GITHUB_ACTIONS is never scrubbed); the 4 failing
-          # TelemetryTest methods never touch TF_BUILD at all and shouldn't be affected by
-          # BaseCommand's existing TF_BUILD scrub - that gap is unexplained, see the ticket.
+          # TODO(SCAN4NET-1676): remove this exclusion once fixed.
           mvn -f its -B -e verify \
             "-Dtest=${{ matrix.testInclude }},!**/CodeCoverageTest,!**/TelemetryTest" \
             "-Dsonar.runtimeVersion=${{ matrix.sqVersion || 'LATEST_RELEASE' }}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,37 +295,10 @@ jobs:
           NUGET_PATH: C:\ProgramData\chocolatey\bin\nuget.exe
           MSBUILD_PATH_VAR: ${{ matrix.msbuildPathVar }}
           JDK_HOME_VAR: ${{ matrix.jdkHomeVar }}
-        shell: bash
-        run: |
-          export JAVA_HOME="${!JDK_HOME_VAR}"
-          MSBUILD_PATH="${MSBUILD_PATH_VAR:+${!MSBUILD_PATH_VAR}}"
+          TEST_INCLUDE: ${{ matrix.testInclude }}
           # TODO(SCAN4NET-1676): remove this exclusion once fixed.
-          mvn -f its -B -e verify \
-            "-Dtest=${{ matrix.testInclude }},!**/CodeCoverageTest,!**/TelemetryTest" \
-            "-Dsonar.runtimeVersion=${{ matrix.sqVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.sonarQubeEdition=${{ matrix.sqEdition || 'DEVELOPER' }}" \
-            "-Dsonar.csharpplugin.version=${{ matrix.dotnetVersion || 'DEV' }}" \
-            "-Dsonar.vbnetplugin.version=${{ matrix.dotnetVersion || 'DEV' }}" \
-            "-Dsonar.dreplugin.version=${{ matrix.dreVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.cfamilyplugin.version=${{ matrix.cfamilyVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.xmlplugin.version=${{ matrix.xmlVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.css.version=${{ matrix.cssVersion || 'NONE' }}" \
-            "-Dsonar.javascriptplugin.version=${{ matrix.javascriptVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.plsqlplugin.version=${{ matrix.plsqlVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.pythonplugin.version=${{ matrix.pythonVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.phpplugin.version=${{ matrix.phpVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.iacplugin.version=${{ matrix.iacVersion || 'NONE' }}" \
-            "-Dsonar.iacplugin-enterprise.version=${{ matrix.iacEnterpriseVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.javaplugin.version=${{ matrix.javaVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.textplugin.version=${{ matrix.textVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.rubyplugin.version=${{ matrix.rubyVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.goplugin.version=${{ matrix.goVersion || 'NONE' }}" \
-            "-Dsonar.goplugin-enterprise.version=${{ matrix.goEnterpriseVersion || 'LATEST_RELEASE' }}" \
-            "-Dsonar.tsqlplugin.version=${{ matrix.tsqlVersion || 'LATEST_RELEASE' }}" \
-            "-Dgo.groupid=${{ matrix.goGroupId || 'org.sonarsource.go' }}" \
-            "-Dmsbuild.path=$MSBUILD_PATH" \
-            "-Dmsbuild.platformtoolset=v140" \
-            "-Dmsbuild.windowssdk=10.0.17763.0"
+          EXTRA_TEST_EXCLUSIONS: ',!**/CodeCoverageTest,!**/TelemetryTest'
+        run: bash scripts/run-its.sh
 
       - name: Publish IT results
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/scripts/run-its.sh
+++ b/scripts/run-its.sh
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
-# Shared IT runner for the Windows/Linux/macOS ITs jobs; each caller resolves its own per-matrix-leg
-# values into the env vars read below (job-specific data), while the ~18 plugin-version defaults and
-# the mvn invocation shape (logic common to all three jobs) live here.
 set -euo pipefail
 
 : "${TEST_INCLUDE:?TEST_INCLUDE environment variable is required but was not set.}"
 
-# SQ_VERSION defaults to LATEST_RELEASE when unset/empty, matching the original Windows job's
-# "${{ matrix.sqVersion || 'LATEST_RELEASE' }}" fallback - GH Actions' || treats "" as falsy too, so Windows's
-# own Cloud/Others legs (which explicitly set sqVersion: "") already resolved to LATEST_RELEASE today, not empty.
-# Inert for Cloud/Others either way (sonar.runtimeVersion is only read by the sonarqube-package tests those legs'
-# -Dtest filters never select), so this is a safe, uniform default for every caller.
 SQ_VERSION="${SQ_VERSION:-LATEST_RELEASE}"
 SQ_EDITION="${SQ_EDITION:-DEVELOPER}"
 
@@ -33,20 +25,12 @@ GO_ENTERPRISE_VERSION="${GO_ENTERPRISE_VERSION:-LATEST_RELEASE}"
 TSQL_VERSION="${TSQL_VERSION:-LATEST_RELEASE}"
 GO_GROUP_ID="${GO_GROUP_ID:-org.sonarsource.go}"
 
-# EXTRA_TEST_EXCLUSIONS is caller-supplied (e.g. Windows's legs pass ",!**/CodeCoverageTest,!**/TelemetryTest");
-# Linux/macOS never set it, so -Dtest stays a clean pass-through of TEST_INCLUDE.
 TEST_VALUE="${TEST_INCLUDE}${EXTRA_TEST_EXCLUSIONS:-}"
 
-# JDK_HOME_VAR holds the NAME of another env var (e.g. "JAVA_HOME_17_X64"), the same bash indirection the original
-# its_windows job used inline; Linux/macOS never set JDK_HOME_VAR and keep mise's ambient JAVA_HOME instead.
 if [ -n "${JDK_HOME_VAR:-}" ]; then
   export JAVA_HOME="${!JDK_HOME_VAR}"
 fi
 
-# Built as one array (rather than a separate MSBUILD_ARGS appended at the call site) because expanding an empty
-# array under "set -u" throws "unbound variable" on bash 3.2 - the fixed system /bin/bash on macOS runners (Apple
-# never shipped bash 4+ for licensing reasons) - even though newer bash (Linux, Windows git-bash) handles it fine.
-# Since MVN_ARGS always has the base args below, it's never empty, so this bug can't trigger.
 MVN_ARGS=(
   -f its -B -e verify
   -Denable-repo=qa
@@ -73,10 +57,6 @@ MVN_ARGS=(
   "-Dsonar.tsqlplugin.version=${TSQL_VERSION}"
   "-Dgo.groupid=${GO_GROUP_ID}"
 )
-
-# Presence, not emptiness, gates these flags: Windows's "Others" leg sets MSBUILD_PATH_VAR="" and still expects
-# them (with an empty path); Linux/macOS never set MSBUILD_PATH_VAR at all, so they must never get them - the IT
-# harness only reads msbuild.* on Windows anyway.
 if [ "${MSBUILD_PATH_VAR+set}" = "set" ]; then
   MSBUILD_PATH="${MSBUILD_PATH_VAR:+${!MSBUILD_PATH_VAR}}"
   MVN_ARGS+=(

--- a/scripts/run-its.sh
+++ b/scripts/run-its.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Shared IT runner for the Windows/Linux/macOS ITs jobs; each caller resolves its own per-matrix-leg
+# values into the env vars read below (job-specific data), while the ~18 plugin-version defaults and
+# the mvn invocation shape (logic common to all three jobs) live here.
+set -euo pipefail
+
+: "${TEST_INCLUDE:?TEST_INCLUDE environment variable is required but was not set.}"
+
+# SQ_VERSION defaults to LATEST_RELEASE when unset/empty, matching the original Windows job's
+# "${{ matrix.sqVersion || 'LATEST_RELEASE' }}" fallback - GH Actions' || treats "" as falsy too, so Windows's
+# own Cloud/Others legs (which explicitly set sqVersion: "") already resolved to LATEST_RELEASE today, not empty.
+# Inert for Cloud/Others either way (sonar.runtimeVersion is only read by the sonarqube-package tests those legs'
+# -Dtest filters never select), so this is a safe, uniform default for every caller.
+SQ_VERSION="${SQ_VERSION:-LATEST_RELEASE}"
+SQ_EDITION="${SQ_EDITION:-DEVELOPER}"
+
+DOTNET_VERSION="${DOTNET_VERSION:-DEV}"
+DRE_VERSION="${DRE_VERSION:-LATEST_RELEASE}"
+CFAMILY_VERSION="${CFAMILY_VERSION:-LATEST_RELEASE}"
+XML_VERSION="${XML_VERSION:-LATEST_RELEASE}"
+CSS_VERSION="${CSS_VERSION:-NONE}"
+JAVASCRIPT_VERSION="${JAVASCRIPT_VERSION:-LATEST_RELEASE}"
+PLSQL_VERSION="${PLSQL_VERSION:-LATEST_RELEASE}"
+PYTHON_VERSION="${PYTHON_VERSION:-LATEST_RELEASE}"
+PHP_VERSION="${PHP_VERSION:-LATEST_RELEASE}"
+IAC_VERSION="${IAC_VERSION:-NONE}"
+IAC_ENTERPRISE_VERSION="${IAC_ENTERPRISE_VERSION:-LATEST_RELEASE}"
+JAVA_VERSION="${JAVA_VERSION:-LATEST_RELEASE}"
+TEXT_VERSION="${TEXT_VERSION:-LATEST_RELEASE}"
+RUBY_VERSION="${RUBY_VERSION:-LATEST_RELEASE}"
+GO_VERSION="${GO_VERSION:-NONE}"
+GO_ENTERPRISE_VERSION="${GO_ENTERPRISE_VERSION:-LATEST_RELEASE}"
+TSQL_VERSION="${TSQL_VERSION:-LATEST_RELEASE}"
+GO_GROUP_ID="${GO_GROUP_ID:-org.sonarsource.go}"
+
+# EXTRA_TEST_EXCLUSIONS is caller-supplied (e.g. Windows's legs pass ",!**/CodeCoverageTest,!**/TelemetryTest");
+# Linux/macOS never set it, so -Dtest stays a clean pass-through of TEST_INCLUDE.
+TEST_VALUE="${TEST_INCLUDE}${EXTRA_TEST_EXCLUSIONS:-}"
+
+# JDK_HOME_VAR holds the NAME of another env var (e.g. "JAVA_HOME_17_X64"), the same bash indirection the original
+# its_windows job used inline; Linux/macOS never set JDK_HOME_VAR and keep mise's ambient JAVA_HOME instead.
+if [ -n "${JDK_HOME_VAR:-}" ]; then
+  export JAVA_HOME="${!JDK_HOME_VAR}"
+fi
+
+# Built as one array (rather than a separate MSBUILD_ARGS appended at the call site) because expanding an empty
+# array under "set -u" throws "unbound variable" on bash 3.2 - the fixed system /bin/bash on macOS runners (Apple
+# never shipped bash 4+ for licensing reasons) - even though newer bash (Linux, Windows git-bash) handles it fine.
+# Since MVN_ARGS always has the base args below, it's never empty, so this bug can't trigger.
+MVN_ARGS=(
+  -f its -B -e verify
+  -Denable-repo=qa
+  "-Dtest=${TEST_VALUE}"
+  "-Dsonar.runtimeVersion=${SQ_VERSION}"
+  "-Dsonar.sonarQubeEdition=${SQ_EDITION}"
+  "-Dsonar.csharpplugin.version=${DOTNET_VERSION}"
+  "-Dsonar.vbnetplugin.version=${DOTNET_VERSION}"
+  "-Dsonar.dreplugin.version=${DRE_VERSION}"
+  "-Dsonar.cfamilyplugin.version=${CFAMILY_VERSION}"
+  "-Dsonar.xmlplugin.version=${XML_VERSION}"
+  "-Dsonar.css.version=${CSS_VERSION}"
+  "-Dsonar.javascriptplugin.version=${JAVASCRIPT_VERSION}"
+  "-Dsonar.plsqlplugin.version=${PLSQL_VERSION}"
+  "-Dsonar.pythonplugin.version=${PYTHON_VERSION}"
+  "-Dsonar.phpplugin.version=${PHP_VERSION}"
+  "-Dsonar.iacplugin.version=${IAC_VERSION}"
+  "-Dsonar.iacplugin-enterprise.version=${IAC_ENTERPRISE_VERSION}"
+  "-Dsonar.javaplugin.version=${JAVA_VERSION}"
+  "-Dsonar.textplugin.version=${TEXT_VERSION}"
+  "-Dsonar.rubyplugin.version=${RUBY_VERSION}"
+  "-Dsonar.goplugin.version=${GO_VERSION}"
+  "-Dsonar.goplugin-enterprise.version=${GO_ENTERPRISE_VERSION}"
+  "-Dsonar.tsqlplugin.version=${TSQL_VERSION}"
+  "-Dgo.groupid=${GO_GROUP_ID}"
+)
+
+# Presence, not emptiness, gates these flags: Windows's "Others" leg sets MSBUILD_PATH_VAR="" and still expects
+# them (with an empty path); Linux/macOS never set MSBUILD_PATH_VAR at all, so they must never get them - the IT
+# harness only reads msbuild.* on Windows anyway.
+if [ "${MSBUILD_PATH_VAR+set}" = "set" ]; then
+  MSBUILD_PATH="${MSBUILD_PATH_VAR:+${!MSBUILD_PATH_VAR}}"
+  MVN_ARGS+=(
+    "-Dmsbuild.path=$MSBUILD_PATH"
+    "-Dmsbuild.platformtoolset=v140"
+    "-Dmsbuild.windowssdk=10.0.17763.0"
+  )
+fi
+
+mvn "${MVN_ARGS[@]}"


### PR DESCRIPTION
## What
Adds an `its_windows` job to `ci.yml`, mirroring Azure's Windows `templates/its-jobs.yml` invocation. Scoped to a single matrix leg (`LATEST_RELEASE`, SonarQube Developer Edition) rather than porting the full ~15-entry Azure matrix in one shot.

## Why
Continues the Azure Pipelines -> GitHub Actions CI migration. `LATEST_RELEASE` alone exercises the full novel risk surface of this job (real Orchestrator-managed SonarQube boot, Maven+MSBuild+NuGet on `warp-custom-dotnet-bubble-ci`) .

Notable findings along the way:
- MSBuild paths, JDK homes, and the self-signed SSL cert used by ITs are all baked into the `warp-custom-dotnet-bubble-ci` image already (via `SonarSource/ci-ami-images`) — no extra setup needed, matching why Azure's own Windows ITs pass no `initSteps`.
- `SonarSource/ci-github-actions/config-maven@v1` needed `artifactory-reader-role: private-reader` (this repo is public; the default `public-reader` can't see proprietary SQ/plugin artifacts) and a version-bump skip, since `its/pom.xml` has no explicit `<version>` of its own (inherited from the repo-root reactor `pom.xml`), which trips up the plugin's default `versions:set`.
- A separate NuGet-auth path (the JUnit5 `OrchestratorState` bootstrap's own `dotnet build`/restore against Repox) needed its own Vault-sourced credentials, distinct from `config-maven`'s Maven-only token.

Part of NET-2037.