### PR TITLE
SCAN4NET-1672 Add Cloud scenario to Linux ITs

### DIFF
--- a/.github/actions/its-unix/action.yml
+++ b/.github/actions/its-unix/action.yml
@@ -20,9 +20,7 @@ inputs:
     default: ""
   sonarcloud-project-token:
     description: >-
-      SonarCloud project token for the Cloud leg. Composite actions cannot read the caller workflow's
-      "secrets" context directly, so callers with a Cloud leg (currently only Linux) must pass
-      secrets.SONARCLOUD_PROJECT_TOKEN in explicitly. Left empty by callers with no Cloud leg (e.g. macOS).
+      SonarCloud project token for the Cloud leg.
     required: false
     default: ""
 

--- a/.github/actions/its-unix/action.yml
+++ b/.github/actions/its-unix/action.yml
@@ -78,6 +78,7 @@ runs:
       with:
         artifactory-reader-role: private-reader
         working-directory: its
+
     - name: Run Maven ITs
       env:
         MAVEN_OPTS: -Xmx3072m

--- a/.github/actions/its-unix/action.yml
+++ b/.github/actions/its-unix/action.yml
@@ -14,8 +14,7 @@ inputs:
     required: true
   sq-version:
     description: >-
-      Value passed through to run-its.sh as SQ_VERSION. Omit for legs that don't boot a local SonarQube
-      server (e.g. Cloud/Others).
+      Value passed through to run-its.sh as SQ_VERSION. Omit for legs that don't boot a local SonarQube server.
     required: false
     default: ""
   sonarcloud-project-token:

--- a/.github/actions/its-unix/action.yml
+++ b/.github/actions/its-unix/action.yml
@@ -7,14 +7,24 @@ description: >-
 
 inputs:
   scenario:
-    description: Matrix leg name (e.g. LATEST_RELEASE, Others), used only for step/check-run display names.
+    description: Matrix leg name (e.g. LATEST_RELEASE, Others, Cloud), used only for step/check-run display names.
     required: true
   test-include:
     description: Value passed through to run-its.sh as TEST_INCLUDE (e.g. "**/sonarqube/*").
     required: true
   sq-version:
-    description: Value passed through to run-its.sh as SQ_VERSION. A valid empty string for the Others leg.
-    required: true
+    description: >-
+      Value passed through to run-its.sh as SQ_VERSION. Omit for legs that don't boot a local SonarQube
+      server (e.g. Cloud/Others).
+    required: false
+    default: ""
+  sonarcloud-project-token:
+    description: >-
+      SonarCloud project token for the Cloud leg. Composite actions cannot read the caller workflow's
+      "secrets" context directly, so callers with a Cloud leg (currently only Linux) must pass
+      secrets.SONARCLOUD_PROJECT_TOKEN in explicitly. Left empty by callers with no Cloud leg (e.g. macOS).
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -68,7 +78,6 @@ runs:
       with:
         artifactory-reader-role: private-reader
         working-directory: its
-
     - name: Run Maven ITs
       env:
         MAVEN_OPTS: -Xmx3072m
@@ -77,6 +86,10 @@ runs:
         SQ_EDITION: DEVELOPER
         ARTIFACTORY_USER: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USER }}
         GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GH_LICENSES_TOKEN }}
+        SONARCLOUD_PROJECT_TOKEN: ${{ inputs.sonarcloud-project-token }}
+        SONARCLOUD_URL: https://sc-staging.io/
+        SONARCLOUD_API_URL: https://api.sc-staging.io
+        SONARCLOUD_ORGANIZATION: s4net-its
       shell: bash
       run: bash scripts/run-its.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,15 +311,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [LATEST_RELEASE, Others]
+        scenario: [LATEST_RELEASE, Others, Cloud]
         include:
           - scenario: LATEST_RELEASE
             sqVersion: LATEST_RELEASE
             testInclude: "**/sonarqube/*"
             runsOn: sonar-s
           - scenario: Others
-            sqVersion: ""
             testInclude: "**/others/*"
+            runsOn: sonar-xs
+          # No local SQ server boot (hits real SonarQube Cloud instead), so sonar-xs is enough - same reasoning as Others.
+          - scenario: Cloud
+            testInclude: "**/sonarcloud/*"
             runsOn: sonar-xs
     steps:
       - name: Checkout
@@ -333,3 +336,4 @@ jobs:
           scenario: ${{ matrix.scenario }}
           test-include: ${{ matrix.testInclude }}
           sq-version: ${{ matrix.sqVersion }}
+          sonarcloud-project-token: ${{ secrets.SONARCLOUD_PROJECT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,6 @@ jobs:
           - scenario: Others
             testInclude: "**/others/*"
             runsOn: sonar-xs
-          # No local SQ server boot (hits real SonarQube Cloud instead), so sonar-xs is enough - same reasoning as Others.
           - scenario: Cloud
             testInclude: "**/sonarcloud/*"
             runsOn: sonar-xs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,13 +55,11 @@ You can run the Unit Tests via the Test Explorer of Visual Studio.
 In order to be able to run the ITs for SonarCloud the following environment variables need to be set:
 - SONARCLOUD_URL
 - SONARCLOUD_ORGANIZATION
-- SONARCLOUD_PROJECT_KEY
 - SONARCLOUD_PROJECT_TOKEN
 
 In our CI/CD pipeline, we use the following:
 - SONARCLOUD_URL=https://sc-staging.io
-- SONARCLOUD_ORGANIZATION=team-lang-dotnet
-- SONARCLOUD_PROJECT_KEY=team-lang-dotnet_incremental-pr-analysis
+- SONARCLOUD_ORGANIZATION=s4net-its
 - SONARCLOUD_PROJECT_TOKEN=[user-token]
 
 These can be set either on the operating system or your preferred IDE test run configuration.


### PR DESCRIPTION
## What
Adds the `Cloud` (SonarCloud) scenario to the Linux ITs matrix (`its` job), alongside the existing `LATEST_RELEASE`/`Others`.

## Why
#3279 deferred this - `SONARCLOUD_PROJECT_TOKEN`'s Vault path was genuinely unresolvable at the time (checked `re-terraform-aws-vault`, Jira, sibling repos). That's since been resolved for the Windows ITs Cloud leg (#3282): a personal token against a dedicated test org (`s4net-its`, Free plan so no Scoped Organization Tokens), stored as a GitHub repo secret rather than Vault. This PR reuses that same secret/org for Linux - no new Vault work needed, since `SONARCLOUD_PROJECT_TOKEN` is already a repo-wide secret.

## Notable design points
- `Cloud` runs on `sonar-xs`, same sizing as `Others` - no local SonarQube server boot (hits real SonarQube Cloud instead), so it doesn't need `LATEST_RELEASE`'s `sonar-s` bump.
- No plugin-version `-D` flags needed to vary for Cloud - matches Azure's own `its-jobs.yml` Cloud leg, which only overrides `PRODUCT`/`SQ_VERSION`/`MSBUILD_PATH`/`TEST_INCLUDE`, leaving every plugin version at its default (unused by Cloud's test classes either way).

## What stays out
- Any change to `azure-pipelines.yml`, branch protection, or required checks.