### PR TITLE
SCAN4NET-1673 Add macOS Integration Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
   its_macos:
     name: ITs macOS (${{ matrix.scenario }})
     needs: build
-    if: github.ref_name == 'master' || github.event_name == 'workflow_dispatch'
+    if: github.ref_name == 'master' || startsWith(github.ref_name, 'branch-') || startsWith(github.ref_name, 'feature/') || github.event_name == 'workflow_dispatch'
     runs-on: macos-latest-xlarge
     permissions:
       id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
     needs: build
     # Ported from azure-pipelines.yml's Unix ITs (templates/unix-qa-stage.yml -> its-jobs.yml), which only run on master.
     # workflow_dispatch is additionally allowed so this can be triggered manually from any branch, e.g. while iterating on this job.
-    if: github.ref_name == 'master' || github.event_name == 'workflow_dispatch'
+    if: true # TEMPORARY: smoke-test on this PR before restoring the master/workflow_dispatch-only gate above
     # GitHub-hosted macos-latest-xlarge is the only macOS runner available (no Sonar-managed macOS runner exists org-wide,
     # per the qa_macos job) - unlike Linux ITs there's no self-hosted sonar-* option to size per scenario.
     runs-on: macos-latest-xlarge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,7 +359,6 @@ jobs:
             sqVersion: LATEST_RELEASE
             testInclude: "**/sonarqube/*"
           - scenario: Others
-            sqVersion: ""
             testInclude: "**/others/*"
     steps:
       # Must be the literal first step, before checkout: GitHub-hosted macOS runners have no static IP, so every later step

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,24 +356,11 @@ jobs:
         scenario: [LATEST_RELEASE, Others]
         include:
           - scenario: LATEST_RELEASE
-            product: SonarQube
             sqVersion: LATEST_RELEASE
             testInclude: "**/sonarqube/*"
           - scenario: Others
-            product: others
             sqVersion: ""
             testInclude: "**/others/*"
-    env:
-      # Matches the Xmx used by the Azure equivalent (templates/its-jobs.yml). config-maven defaults to -Xmx1536m, which is too
-      # small for the Orchestrator-driven ITs.
-      MAVEN_OPTS: -Xmx3072m
-      # Opts config-maven out of its automatic -SNAPSHOT -> build-number version bump: the ITs don't publish anything, so the
-      # root pom.xml's real release version must not be touched by this job.
-      CURRENT_VERSION: unused
-      PROJECT_VERSION: unused
-      # Overrides the workflow-level NUGET_PACKAGES (${{ github.workspace }}\.nuget\packages), which is only valid on the
-      # Windows runners build/qa_windows run on - same fix as the Linux ITs job.
-      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
     steps:
       # Must be the literal first step, before checkout: GitHub-hosted macOS runners have no static IP, so every later step
       # that reaches Vault or private repos depends on this tunnel being up (same requirement as qa_macos).
@@ -393,6 +380,5 @@ jobs:
         uses: ./.github/actions/its-unix
         with:
           scenario: ${{ matrix.scenario }}
-          product: ${{ matrix.product }}
           test-include: ${{ matrix.testInclude }}
           sq-version: ${{ matrix.sqVersion }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,3 +336,63 @@ jobs:
           test-include: ${{ matrix.testInclude }}
           sq-version: ${{ matrix.sqVersion }}
           sonarcloud-project-token: ${{ secrets.SONARCLOUD_PROJECT_TOKEN }}
+
+  its_macos:
+    name: ITs macOS (${{ matrix.scenario }})
+    needs: build
+    # Ported from azure-pipelines.yml's Unix ITs (templates/unix-qa-stage.yml -> its-jobs.yml), which only run on master.
+    # workflow_dispatch is additionally allowed so this can be triggered manually from any branch, e.g. while iterating on this job.
+    if: github.ref_name == 'master' || github.event_name == 'workflow_dispatch'
+    # GitHub-hosted macos-latest-xlarge is the only macOS runner available (no Sonar-managed macOS runner exists org-wide,
+    # per the qa_macos job) - unlike Linux ITs there's no self-hosted sonar-* option to size per scenario.
+    runs-on: macos-latest-xlarge
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: [LATEST_RELEASE, Others]
+        include:
+          - scenario: LATEST_RELEASE
+            product: SonarQube
+            sqVersion: LATEST_RELEASE
+            testInclude: "**/sonarqube/*"
+          - scenario: Others
+            product: others
+            sqVersion: ""
+            testInclude: "**/others/*"
+    env:
+      # Matches the Xmx used by the Azure equivalent (templates/its-jobs.yml). config-maven defaults to -Xmx1536m, which is too
+      # small for the Orchestrator-driven ITs.
+      MAVEN_OPTS: -Xmx3072m
+      # Opts config-maven out of its automatic -SNAPSHOT -> build-number version bump: the ITs don't publish anything, so the
+      # root pom.xml's real release version must not be touched by this job.
+      CURRENT_VERSION: unused
+      PROJECT_VERSION: unused
+      # Overrides the workflow-level NUGET_PACKAGES (${{ github.workspace }}\.nuget\packages), which is only valid on the
+      # Windows runners build/qa_windows run on - same fix as the Linux ITs job.
+      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+    steps:
+      # Must be the literal first step, before checkout: GitHub-hosted macOS runners have no static IP, so every later step
+      # that reaches Vault or private repos depends on this tunnel being up (same requirement as qa_macos).
+      - name: Setup Cloudflare WARP
+        uses: SonarSource/gh-action_setup-cloudflare-warp@v1
+        id: warp
+
+      - name: Remove pre-existing .bash_profile
+        run: rm -f ~/.bash_profile
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Run ITs
+        uses: ./.github/actions/its-unix
+        with:
+          scenario: ${{ matrix.scenario }}
+          product: ${{ matrix.product }}
+          test-include: ${{ matrix.testInclude }}
+          sq-version: ${{ matrix.sqVersion }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,11 +340,7 @@ jobs:
   its_macos:
     name: ITs macOS (${{ matrix.scenario }})
     needs: build
-    # Ported from azure-pipelines.yml's Unix ITs (templates/unix-qa-stage.yml -> its-jobs.yml), which only run on master.
-    # workflow_dispatch is additionally allowed so this can be triggered manually from any branch, e.g. while iterating on this job.
     if: true # TEMPORARY: smoke-test on this PR before restoring the master/workflow_dispatch-only gate above
-    # GitHub-hosted macos-latest-xlarge is the only macOS runner available (no Sonar-managed macOS runner exists org-wide,
-    # per the qa_macos job) - unlike Linux ITs there's no self-hosted sonar-* option to size per scenario.
     runs-on: macos-latest-xlarge
     permissions:
       id-token: write
@@ -361,8 +357,6 @@ jobs:
           - scenario: Others
             testInclude: "**/others/*"
     steps:
-      # Must be the literal first step, before checkout: GitHub-hosted macOS runners have no static IP, so every later step
-      # that reaches Vault or private repos depends on this tunnel being up (same requirement as qa_macos).
       - name: Setup Cloudflare WARP
         uses: SonarSource/gh-action_setup-cloudflare-warp@v1
         id: warp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
   its_macos:
     name: ITs macOS (${{ matrix.scenario }})
     needs: build
-    if: true # TEMPORARY: smoke-test on this PR before restoring the master/workflow_dispatch-only gate above
+    if: github.ref_name == 'master' || github.event_name == 'workflow_dispatch'
     runs-on: macos-latest-xlarge
     permissions:
       id-token: write

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/OSPlatform.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/OSPlatform.java
@@ -42,14 +42,14 @@ public class OSPlatform {
   public static String currentArchitecture() {
     var arch = System.getProperty("os.arch");
 
-    // Java 'os.arch' returns:
-    // - amd64 on Linux
-    // - x86_64 on MacOS
-    // While .NET 'RuntimeInformation.OSArchitecture' returns "x64" on both
-    //
-    // This should not be an issue during the integration tests unless we start running the ITs on ARM architectures.
-    // In which case 'os.arch' can return either arm64 or aarch64.
-    return arch.endsWith("64") ? "x64" : arch;
+    // Java 'os.arch' returns amd64 (Linux x64), x86_64 (macOS Intel), or aarch64 (Linux/macOS ARM64, e.g.
+    // GitHub's macos-latest-xlarge). .NET 'RuntimeInformation.OSArchitecture' reports "x64"/"arm64" respectively -
+    // a naive "ends with 64" check collapses aarch64 into "x64" too, since it also ends in "64".
+    return switch (arch) {
+      case "amd64", "x86_64" -> "x64";
+      case "aarch64", "arm64" -> "arm64";
+      default -> arch;
+    };
   }
 
   public static boolean isWindows() {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/OSPlatform.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/OSPlatform.java
@@ -42,9 +42,7 @@ public class OSPlatform {
   public static String currentArchitecture() {
     var arch = System.getProperty("os.arch");
 
-    // Java 'os.arch' returns amd64 (Linux x64), x86_64 (macOS Intel), or aarch64 (Linux/macOS ARM64, e.g.
-    // GitHub's macos-latest-xlarge). .NET 'RuntimeInformation.OSArchitecture' reports "x64"/"arm64" respectively -
-    // a naive "ends with 64" check collapses aarch64 into "x64" too, since it also ends in "64".
+    // Java 'os.arch' returns amd64 (Linux x64), x86_64 (macOS Intel), or aarch64 (Linux/macOS ARM64). .NET 'RuntimeInformation.OSArchitecture' reports "x64"/"arm64" respectively.
     return switch (arch) {
       case "amd64", "x86_64" -> "x64";
       case "aarch64", "arm64" -> "arm64";


### PR DESCRIPTION
## What
Adds `its_macos` to `ci.yml`, mirroring Azure's second `templates/unix-qa-stage.yml` invocation (`vmImage: macOS-14` -> `its-jobs.yml`) - the one OS with no ITs job at all anywhere in the GH Actions migration so far. Scoped to the same `[LATEST_RELEASE, Others]` pair the Linux ITs job (#3279) started with, not the full matrix - that's a natural follow-up, same as Linux/Windows.

## Why
Combines two already-proven patterns rather than introducing anything new:
- macOS runner conventions from `qa_macos` (#3277): Cloudflare WARP setup as the literal first step (GitHub-hosted macOS runners have no static IP, so every later step touching Vault/private repos depends on the tunnel being up), and the `.bash_profile` removal for the same stray-env-var reason documented there.
- ITs harness setup from the Linux `its` job (#3279): `mise`-installed Java/Maven/.NET/Node (`macos-latest-xlarge` has none preinstalled, unlike Windows's baked-in AMI), the self-signed cert step (adapted for macOS's keychain via `security add-trusted-cert` instead of Linux's `update-ca-certificates`), and the same Maven command/plugin-version defaults.

## What stays out
- Widening to the full ITs matrix (LTA/DEV/Cloud legs) - natural follow-up, same as Linux/Windows.
- Any change to `azure-pipelines.yml`, branch protection, or required checks.


----
## Summary by Gitar

- **Build / CI:**
    - Added `its_macos` workflow job to `ci.yml` targeting `macos-latest-xlarge` runners
- **Fixes:**
    - Updated `OSPlatform.currentArchitecture()` to correctly distinguish arm64 from x64 on macOS and Linux

<sub>This will update automatically on new commits.</sub>