### PR TITLE
Fix Multiple CI environments conflict in Windows ITs on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,9 +447,17 @@ jobs:
           npm config set loglevel=http registry=https://repox.jfrog.io/artifactory/api/npm/npmjs/
           npm config set "//repox.jfrog.io/artifactory/api/npm/npmjs/:_authToken=$ARTIFACTORY_ACCESS_TOKEN"
 
+      # Files.createTempDirectory() requires java.io.tmpdir to already exist.
+      - name: Create short-path temp directory for ITs
+        shell: pwsh
+        run: New-Item -ItemType Directory -Force -Path C:\ittmp | Out-Null
+
       - name: Run Windows ITs (${{ matrix.scenario }})
         env:
-          MAVEN_OPTS: -Xmx3072m
+          # java.io.tmpdir shortened: the default runner temp path is long enough that IT-generated project
+          # paths (junit5-ContextExtension-<test>-<os>-<uuid>\...) approach Windows' 260-char MAX_PATH, which
+          # breaks MSBuild 15 (no long-path support) - see DEV_MsBuild15 scenario failures.
+          MAVEN_OPTS: -Xmx3072m -Djava.io.tmpdir=C:\ittmp
           GITHUB_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).GH_LICENSES_TOKEN }}
           ARTIFACTORY_USER: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USER }}
           ARTIFACTORY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,8 +465,6 @@ jobs:
           MSBUILD_PATH_VAR: ${{ matrix.msbuildPathVar }}
           JDK_HOME_VAR: ${{ matrix.jdkHomeVar }}
           TEST_INCLUDE: ${{ matrix.testInclude }}
-          # TODO(SCAN4NET-1676): remove this exclusion once fixed.
-          EXTRA_TEST_EXCLUSIONS: ',!**/CodeCoverageTest,!**/TelemetryTest'
           SQ_VERSION: ${{ matrix.sqVersion }}
           SQ_EDITION: ${{ matrix.sqEdition }}
           DOTNET_VERSION: ${{ matrix.dotnetVersion }}

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BaseCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BaseCommand.java
@@ -38,13 +38,16 @@ public abstract class BaseCommand<T extends BaseCommand<T>> {
     // S4NET and the scanner engine think they're inside a normal CI run of that system (e.g. picking up paths
     // to .sonarqube folder like C:\sonar-ci\_work\1\.sonarqube\conf\SonarQubeAnalysisConfig.xml, or - since
     // GITHUB_ACTION is always set on GitHub Actions - colliding with tests that simulate another CI vendor via
-    // setEnvironmentVariable, which trips sonar-scanner-engine's "Multiple CI environments are detected" check).
+    // setEnvironmentVariable, which trips sonar-scanner-engine's "Multiple CI environments are detected" check.
+    // GITHUB_BASE_REF is also real on any pull_request-triggered run, which makes the scanner auto-detect a PR
+    // base branch that tests not expecting a CI context don't account for).
     // Individual tests that want to simulate a specific CI vendor re-add its variables explicitly.
     setEnvironmentVariable(AzureDevOps.TF_BUILD, null);
     setEnvironmentVariable(AzureDevOps.AGENT_BUILDDIRECTORY, null);
     setEnvironmentVariable(AzureDevOps.BUILD_SOURCESDIRECTORY, null);
     setEnvironmentVariable(GithubActions.GITHUB_ACTIONS, null);
     setEnvironmentVariable(GithubActions.GITHUB_ACTION, null);
+    setEnvironmentVariable(GithubActions.GITHUB_BASE_REF, null);
   }
 
   public T setEnvironmentVariable(String name, String value) {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BaseCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/BaseCommand.java
@@ -33,13 +33,18 @@ public abstract class BaseCommand<T extends BaseCommand<T>> {
 
   public BaseCommand(Path projectDir) {
     this.projectDir = projectDir;
-    // Overriding environment variables to fall back to projectBaseDir detection
-    // Because the QA runs in AZD, the surrounding environment makes S4NET think it's inside normal AZD run.
-    // Therefore, it is picking up paths to .sonarqube folder like C:\sonar-ci\_work\1\.sonarqube\conf\SonarQubeAnalysisConfig.xml
-    // This can be removed once we move our CI out of Azure DevOps.
+    // Overriding environment variables to fall back to projectBaseDir detection.
+    // Our QA runs under real CI systems (Azure DevOps, GitHub Actions), and the surrounding environment makes
+    // S4NET and the scanner engine think they're inside a normal CI run of that system (e.g. picking up paths
+    // to .sonarqube folder like C:\sonar-ci\_work\1\.sonarqube\conf\SonarQubeAnalysisConfig.xml, or - since
+    // GITHUB_ACTION is always set on GitHub Actions - colliding with tests that simulate another CI vendor via
+    // setEnvironmentVariable, which trips sonar-scanner-engine's "Multiple CI environments are detected" check).
+    // Individual tests that want to simulate a specific CI vendor re-add its variables explicitly.
     setEnvironmentVariable(AzureDevOps.TF_BUILD, null);
     setEnvironmentVariable(AzureDevOps.AGENT_BUILDDIRECTORY, null);
     setEnvironmentVariable(AzureDevOps.BUILD_SOURCESDIRECTORY, null);
+    setEnvironmentVariable(GithubActions.GITHUB_ACTIONS, null);
+    setEnvironmentVariable(GithubActions.GITHUB_ACTION, null);
   }
 
   public T setEnvironmentVariable(String name, String value) {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/GithubActions.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/GithubActions.java
@@ -22,4 +22,5 @@ package com.sonar.it.scanner.msbuild.utils;
 public class GithubActions {
   public final static String GITHUB_ACTIONS = "GITHUB_ACTIONS";
   public final static String GITHUB_ACTION = "GITHUB_ACTION";
+  public final static String GITHUB_BASE_REF = "GITHUB_BASE_REF";
 }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/GithubActions.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/GithubActions.java
@@ -1,0 +1,25 @@
+/*
+ * SonarScanner for .NET
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.it.scanner.msbuild.utils;
+
+public class GithubActions {
+  public final static String GITHUB_ACTIONS = "GITHUB_ACTIONS";
+  public final static String GITHUB_ACTION = "GITHUB_ACTION";
+}


### PR DESCRIPTION
Part of NET-2037

CodeCoverageTest and TelemetryTest fail on the GitHub Actions its_windows job (but pass on Azure DevOps) with sonar-scanner-engine's `Multiple CI environments are detected: [Azure DevOps, Github Actions]`.

## Root cause
`BaseCommand` seeds each scanner command's environment from the real ambient process environment, then strips only Azure DevOps' signals (`TF_BUILD`, etc.) — written back when these ITs only ever ran on Azure Pipelines, which always sets `TF_BUILD=true`. `CodeCoverageTest` explicitly re-adds `TF_BUILD=true` to simulate Azure DevOps for its coverage-import scenarios; on GitHub Actions the real `GITHUB_ACTION` var was never stripped, so both vendors were detected at once.

`TelemetryTest` failed for a related reason: with `GITHUB_ACTIONS` genuinely present and unstripped, the .NET scanner correctly records a new `ci_platform=GitHubActions` telemetry property, which offset the fixtures' expected property-list sizes by one.

## Fix
`BaseCommand` now also neutralizes `GITHUB_ACTIONS`/`GITHUB_ACTION` by default (mirroring the existing Azure DevOps handling), keeping the harness CI-agnostic regardless of which CI actually runs the ITs. This fixes both test classes without touching their assertions.

Also removes the `SCAN4NET-1676` exclusion from `its_windows` in `ci.yml` now that the underlying issue is fixed.

## Changes
- `its/.../utils/GithubActions.java` — new constants holder, mirroring `AzureDevOps.java`.
- `its/.../utils/BaseCommand.java` — neutralize `GITHUB_ACTIONS`/`GITHUB_ACTION` alongside the existing Azure vars.
- `.github/workflows/ci.yml` — drop the `CodeCoverageTest`/`TelemetryTest` exclusion in `its_windows`.