### PR TITLE
SCAN4NET-1673 Add Cloud scenario to macOS ITs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,13 +349,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [LATEST_RELEASE, Others]
+        scenario: [LATEST_RELEASE, Others, Cloud]
         include:
           - scenario: LATEST_RELEASE
             sqVersion: LATEST_RELEASE
             testInclude: "**/sonarqube/*"
           - scenario: Others
             testInclude: "**/others/*"
+          - scenario: Cloud
+            testInclude: "**/sonarcloud/*"
     steps:
       - name: Setup Cloudflare WARP
         uses: SonarSource/gh-action_setup-cloudflare-warp@v1
@@ -375,3 +377,4 @@ jobs:
           scenario: ${{ matrix.scenario }}
           test-include: ${{ matrix.testInclude }}
           sq-version: ${{ matrix.sqVersion }}
+          sonarcloud-project-token: ${{ secrets.SONARCLOUD_PROJECT_TOKEN }}


### PR DESCRIPTION
## What
Widens `its_macos`'s matrix from `[LATEST_RELEASE, Others]` to `[LATEST_RELEASE, Others, Cloud]` - the natural follow-up flagged in #3284's description ("Widening to the full ITs matrix (LTA/DEV/Cloud legs)").

## Why
Azure's `templates/unix-qa-stage.yml` (shared by Linux and macOS) only ever defined 3 scenarios - `LATEST_RELEASE`, `Others`, `Cloud` - there's no LTA/DEV multi-version matrix for Unix ITs, that's exclusively a Windows thing (`templates/its-jobs.yml` invoked directly, not through `unix-qa-stage.yml`). So this *is* the full matrix for macOS, mirroring exactly what #3283 already did for Linux: add the `Cloud` leg and pass `sonarcloud-project-token` through to `its-unix`. Reuses the same `s4net-its` SonarCloud secret/org as the Linux and Windows Cloud legs.

## What stays out
- Any change to `azure-pipelines.yml`, branch protection, or required checks.