### PR TITLE
SCAN4NET-1674 Rename UT jobs and group ci.yml by UTs/ITs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
           if-no-files-found: error
 
   uts_windows:
-    name: UTs Windows
+    name: UTs Windows and analysis
     needs: version
     runs-on: warp-custom-dotnet-bubble-ci
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,8 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  qa_windows:
-    name: QA Windows - UTs and analysis
+  uts_windows:
+    name: UTs Windows
     needs: version
     runs-on: warp-custom-dotnet-bubble-ci
     permissions:
@@ -223,22 +223,8 @@ jobs:
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
         run: dotnet tool run dotnet-sonarscanner -- end /d:sonar.token="$env:SONAR_TOKEN"
 
-  its_windows:
-    name: ITs Windows
-    needs: [version, build]
-    uses: ./.github/workflows/its-windows.yml
-    permissions:
-      id-token: write
-      contents: read
-      checks: write
-    with:
-      short-version: ${{ needs.version.outputs.SHORT_VERSION }}
-      full-version: ${{ needs.version.outputs.FULL_VERSION }}
-    secrets:
-      SONARCLOUD_PROJECT_TOKEN: ${{ secrets.SONARCLOUD_PROJECT_TOKEN }}
-
-  qa_linux:
-    name: QA Linux - UTs
+  uts_linux:
+    name: UTs Linux
     needs: [version, build]
     runs-on: sonar-xs
     permissions:
@@ -270,8 +256,8 @@ jobs:
           rid: linux-x64
           os-name: Linux
 
-  qa_macos:
-    name: QA macOS - UTs
+  uts_macos:
+    name: UTs macOS
     needs: [version, build]
     runs-on: macos-latest-xlarge
     if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-')
@@ -299,6 +285,20 @@ jobs:
           short-version: ${{ needs.version.outputs.SHORT_VERSION }}
           rid: osx-arm64
           os-name: MacOS
+
+  its_windows:
+    name: ITs Windows
+    needs: [version, build]
+    uses: ./.github/workflows/its-windows.yml
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+    with:
+      short-version: ${{ needs.version.outputs.SHORT_VERSION }}
+      full-version: ${{ needs.version.outputs.FULL_VERSION }}
+    secrets:
+      SONARCLOUD_PROJECT_TOKEN: ${{ secrets.SONARCLOUD_PROJECT_TOKEN }}
 
   its_linux:
     name: ITs Linux (${{ matrix.scenario }})


### PR DESCRIPTION
## What
Pure naming/organization cleanup on top of the ITs migration, no functional change:
- Renames `qa_windows`/`qa_linux`/`qa_macos` to `uts_windows`/`uts_linux`/`uts_macos`, matching `its_windows`/`its_linux`/`its_macos`'s naming exactly. Display names become "UTs Windows"/"UTs Linux"/"UTs macOS", mirroring "ITs Windows"/"ITs Linux"/"ITs macOS" (dropping the "QA" prefix and "- UTs and analysis"/"- UTs" suffixes).
- Reorders `ci.yml` so all three UTs jobs sit together, followed by all three ITs jobs, instead of the previous ad-hoc interleaving (`qa_windows`, `its_windows`, `qa_linux`, `qa_macos`, `its_linux`, `its_macos`).

## Why
Now that all three OSes have both a UTs and an ITs job in GitHub Actions, the naming had drifted: ITs jobs already used the concise `<Type> <OS>` pattern, UTs jobs still carried over Azure's "QA" terminology. Same for file layout - grouping by job type reads more predictably than the order jobs happened to land in as each OS was migrated independently.

## Heads up
This renames required-status-check names (`QA Windows - UTs and analysis` -> `UTs Windows`, etc.). `re-service-config#2371` (still open) is being updated in the same pass to reference the new names and add the Linux/macOS/Promote contexts it was already planning to add once they existed with full parity.

## What stays out
- Job keys/names for `version`, `build`, `promote`, and the Windows ITs per-leg matrix names (`${{ matrix.scenario }}`) - already concise, no change needed.
- Any functional/behavioral change - purely renames and a map-key reorder.