### PR TITLE
SCAN4NET-1683 Simplify ci.yml: hardcode nuget-packages-path, dedupe release-branch check, drop unneeded fetch-depth

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -2,9 +2,6 @@ name: Prepare
 description: Install tools, cache NuGet, fetch secrets, compute version, and restore.
 
 inputs:
-  nuget-packages-path:
-    description: Directory NuGet packages are restored into and cached from.
-    required: true
   build-number:
     description: Build number used to set Version.targets before building.
     required: true
@@ -34,12 +31,12 @@ runs:
     - name: Cache NuGet packages
       uses: SonarSource/gh-action_cache@v1
       with:
-        path: ${{ inputs.nuget-packages-path }}
+        path: ${{ github.workspace }}/.nuget/packages
         key: nuget-${{ steps.cache-month.outputs.CACHE_MONTH }}-${{ hashFiles('**/packages.lock.json') }}
         restore-keys: nuget-${{ steps.cache-month.outputs.CACHE_MONTH }}-
 
     - name: Restore
       shell: powershell
       env:
-        NUGET_PACKAGES: ${{ inputs.nuget-packages-path }}
+        NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
       run: dotnet restore SonarScanner.MSBuild.sln --locked-mode --configfile "NuGet.Config"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       SHORT_VERSION: ${{ steps.set-version.outputs.SHORT_VERSION }}
       FULL_VERSION: ${{ steps.set-version.outputs.FULL_VERSION }}
       PATCH_VERSION: ${{ steps.set-version.outputs.PATCH_VERSION }}
+      IS_RELEASE_BRANCH: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-') }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -71,13 +72,11 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref || github.ref_name }}
-          fetch-depth: 0
 
       - name: Prepare
         id: prepare
         uses: ./.github/actions/prepare
         with:
-          nuget-packages-path: ${{ env.NUGET_PACKAGES }}
           build-number: ${{ env.BUILD_NUMBER }}
           short-version: ${{ env.SHORT_VERSION }}
 
@@ -114,14 +113,14 @@ jobs:
 
       # We can't use Azure Artifact Signing for NuGets: https://github.com/NuGet/NuGetGallery/issues/10027
       - name: Sign NuGet package
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-')
+        if: needs.version.outputs.IS_RELEASE_BRANCH == 'true'
         uses: SonarSource/core-languages-tooling-public/dotnet_pipeline/digicert-sign@master
         with:
           files: ${{ env.PACKAGING_BINARIES_NUGET }}/dotnet-sonarscanner*.nupkg
 
       - name: Run packaging tests
         env:
-          IS_RELEASE_BRANCH: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-') }}
+          IS_RELEASE_BRANCH: ${{ needs.version.outputs.IS_RELEASE_BRANCH }}
         run: dotnet test Tests\SonarScanner.MSBuild.PackagingTest\SonarScanner.MSBuild.PackagingTest.csproj --configuration Release --no-build --no-restore
 
       - name: Set Maven project version
@@ -165,7 +164,6 @@ jobs:
       - name: Prepare
         uses: ./.github/actions/prepare
         with:
-          nuget-packages-path: ${{ env.NUGET_PACKAGES }}
           build-number: ${{ needs.version.outputs.BUILD_NUMBER }}
           short-version: ${{ needs.version.outputs.SHORT_VERSION }}
 
@@ -238,7 +236,7 @@ jobs:
           ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Install tools
-        uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
           cache: true
           tool_versions: |
@@ -260,7 +258,7 @@ jobs:
     name: UTs macOS
     needs: [version, build]
     runs-on: macos-latest-xlarge
-    if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/branch-')
+    if: needs.version.outputs.IS_RELEASE_BRANCH == 'true'
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary
- `prepare/action.yml`'s `nuget-packages-path` input never varied across its two callers (always `env.NUGET_PACKAGES`) - hardcoded the path directly and dropped the input plus both call-site pass-throughs.
- The release-branch check (`github.ref == master || startsWith(..., branch-)`) was hand-copied three times (Sign NuGet package, packaging-tests env var, `qa_macos`'s job `if:`) - computed once as the `version` job's `IS_RELEASE_BRANCH` output instead.
- `build`'s checkout doesn't need full history (no git-log/blame/describe consumers in its steps) - dropped `fetch-depth: 0`.
- Bumped `qa_linux`'s `mise-action` pin to a newer stable release (v4.0.0 -> v4.2.0).

Surfaced by a `/simplify` pass over the downstream GHA CI stack; this piece touches only
already-merged `feature/GHA` code, so it's a standalone PR rather than part of that stack.

## Test plan
- [ ] CI green on this branch (`build`, `qa_windows`, `qa_linux`, `qa_macos`)
- [ ] Confirm `IS_RELEASE_BRANCH` output resolves correctly on a `branch-*` push

Part of NET-2037