### PR TITLE
SCAN4NET-1685 Add telemetry for direct package references

### DIFF
--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
@@ -824,11 +824,13 @@ public class E2EAnalysisTests
 
     // On .NET Framework, UseWPF/UseWindowsForms make the SDK inject PresentationCore,PresentationFramework, WindowsBase and System.Windows.Forms into @(Reference) with IsImplicitlyDefined=true.
     [TestMethod]
+    [TestCategory(TestCategories.NoLinux)]
+    [TestCategory(TestCategories.NoMacOS)]
     public void E2E_TelemetryFiles_AssemblyReferences_Written()
     {
         var context = CreateContext();
         var result = BuildRunner.BuildTargets(TestContext, context.CreateProjectFile($"""
-            <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+            <PropertyGroup>
               <UseWPF>true</UseWPF>
               <UseWindowsForms>true</UseWindowsForms>
             </PropertyGroup>

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
@@ -814,6 +814,7 @@ public class E2EAnalysisTests
             <ItemGroup>
               <PackageReference Include="FluentAssertions" Version="7.2.2" />
               <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+              <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
             </ItemGroup>
             """));
         result.BuildSucceeded.Should().BeTrue();
@@ -822,6 +823,7 @@ public class E2EAnalysisTests
         var telemetryLines = File.ReadAllLines(projectTelemetryFile);
         telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.packages.fluentassertions.cnt":"true"}""");
         telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.packages.mstest_testframework.cnt":"true"}""");
+        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.packages.mstest_testadapter.cnt":"true"}""");
     }
 
     private BuildLog Execute_E2E_TestProjects_ProtobufFileNamesAreUpdated(bool isTestProject, string projectSpecificSubDir)

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
@@ -822,8 +822,46 @@ public class E2EAnalysisTests
         telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.castle_core.cnt":"true"}""");
     }
 
+    // On .NET Framework, UseWPF/UseWindowsForms make the SDK inject PresentationCore,PresentationFramework, WindowsBase and System.Windows.Forms into @(Reference) with IsImplicitlyDefined=true.
     [TestMethod]
     public void E2E_TelemetryFiles_AssemblyReferences_Written()
+    {
+        var context = CreateContext();
+        var result = BuildRunner.BuildTargets(TestContext, context.CreateProjectFile($"""
+            <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+              <UseWPF>true</UseWPF>
+              <UseWindowsForms>true</UseWindowsForms>
+            </PropertyGroup>
+            <ItemGroup>
+              <Compile Include='{context.CreateInputFile("codeFile1.cs")}' />
+            </ItemGroup>
+            <ItemGroup>
+              <!-- A whitelisted framework assembly the user references directly is reported. -->
+              <Reference Include="System.Web" />
+            </ItemGroup>
+            <!-- Capture how MSBuild/the SDK decorate the @(Reference) items handed to DependencyTelemetry -->
+            <Target Name="CaptureReferenceMetadata" AfterTargets="ResolveReferences" BeforeTargets="Build">
+              <Message Importance="high" Text="REF|%(Reference.Identity)|IsImplicitlyDefined=[%(Reference.IsImplicitlyDefined)]" />
+            </Target>
+            """));
+        result.BuildSucceeded.Should().BeTrue();
+        result.Messages.Should().Contain(x => x.Contains("REF|System.Web|IsImplicitlyDefined=[]"));
+        result.Messages.Should().Contain(x => x.Contains("REF|PresentationCore|IsImplicitlyDefined=[true]"));
+        result.Messages.Should().Contain(x => x.Contains("REF|PresentationFramework|IsImplicitlyDefined=[true]"));
+        result.Messages.Should().Contain(x => x.Contains("REF|WindowsBase|IsImplicitlyDefined=[true]"));
+        result.Messages.Should().Contain(x => x.Contains("REF|System.Windows.Forms|IsImplicitlyDefined=[true]"));
+
+        var telemetryLines = ReadTelemetryLines(context);
+        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.dependencies.system_web.cnt":"true"}""");
+        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.presentationcore.cnt":"true"}""");
+        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.presentationframework.cnt":"true"}""");
+        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.windowsbase.cnt":"true"}""");
+        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.system_windows_forms.cnt":"true"}""");
+    }
+
+    // Adding the direct, whitelisted package Microsoft.Extensions.Http makes NuGet resolve the whitelisted Microsoft.Extensions.Logging and Microsoft.Extensions.DependencyInjection transitively.
+    [TestMethod]
+    public void E2E_TelemetryFiles_TransitiveDependencies_AreNotReported()
     {
         var context = CreateContext();
         var result = BuildRunner.BuildTargets(TestContext, context.CreateProjectFile($"""
@@ -831,29 +869,26 @@ public class E2EAnalysisTests
               <Compile Include='{context.CreateInputFile("codeFile1.cs")}' />
             </ItemGroup>
             <ItemGroup>
-              <!-- Direct authored reference -> reported. -->
-              <Reference Include="System.Web" />
-              <!-- Whitelisted name, but resolved from a NuGet package -> must NOT be reported (direct NuGet
-                   references are caught via PackageReference). Guards the NuGetPackageId condition. -->
-              <Reference Include="System.Windows.Forms">
-                <NuGetPackageId>Some.Package</NuGetPackageId>
-              </Reference>
-              <!-- Whitelisted name, but implicitly defined by the SDK -> must NOT be reported.
-                   Guards the IsImplicitlyDefined condition. -->
-              <Reference Include="System.ServiceModel">
-                <IsImplicitlyDefined>true</IsImplicitlyDefined>
-              </Reference>
+              <!-- Direct, whitelisted package the user adds themselves -->
+              <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.32" />
             </ItemGroup>
+            <!-- Capture how NuGet decorates the resolved items -->
+            <Target Name="CaptureDependencyMetadata" AfterTargets="ResolveReferences" BeforeTargets="Build">
+              <Message Importance="high" Text="PKG_REF|[%(PackageReference.Identity)]" />
+              <Message Importance="high" Text="RESOLVED_REF|%(ReferencePath.Filename)|NuGetPackageId=[%(ReferencePath.NuGetPackageId)]" />
+            </Target>
             """));
         result.BuildSucceeded.Should().BeTrue();
+        result.Messages.Should().Contain(x => x.Contains("RESOLVED_REF|Microsoft.Extensions.Logging|NuGetPackageId=[Microsoft.Extensions.Logging]"));
+        result.Messages.Should().Contain(x => x.Contains("RESOLVED_REF|Microsoft.Extensions.DependencyInjection|NuGetPackageId=[Microsoft.Extensions.DependencyInjection]"));
+        result.Messages.Should().Contain(x => x.Contains("PKG_REF|[Microsoft.Extensions.Http]"));
+        result.Messages.Should().NotContain(x => x.Contains("PKG_REF|[Microsoft.Extensions.Logging]"));
+        result.Messages.Should().NotContain(x => x.Contains("PKG_REF|[Microsoft.Extensions.DependencyInjection]"));
+
         var telemetryLines = ReadTelemetryLines(context);
-        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.dependencies.system_web.cnt":"true"}""");
-        // System.Xml is referenced implicitly by the SDK for .NET Framework projects but is deliberately not whitelisted.
-        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.system_xml.cnt":"true"}""");
-        // Comes from a NuGet package, so it is caught via PackageReference, not as a direct assembly reference.
-        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.system_windows_forms.cnt":"true"}""");
-        // Implicitly defined by the SDK, so it is not a direct assembly reference.
-        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.system_servicemodel.cnt":"true"}""");
+        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.dependencies.microsoft_extensions_http.cnt":"true"}""");
+        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.microsoft_extensions_logging.cnt":"true"}""");
+        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.microsoft_extensions_dependencyinjection.cnt":"true"}""");
     }
 
     private BuildLog Execute_E2E_TestProjects_ProtobufFileNamesAreUpdated(bool isTestProject, string projectSpecificSubDir)

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
@@ -802,6 +802,28 @@ public class E2EAnalysisTests
             x => x.Should().Be("""{"dotnetenterprise.s4net.build.test_project_in_proj.cnt":"true"}"""));
     }
 
+    [TestMethod]
+    public void E2E_TelemetryFiles_PackageReferences_Written()
+    {
+        var context = CreateContext();
+
+        var result = BuildRunner.BuildTargets(TestContext, context.CreateProjectFile($"""
+            <ItemGroup>
+              <Compile Include='{context.CreateInputFile("codeFile1.cs")}' />
+            </ItemGroup>
+            <ItemGroup>
+              <PackageReference Include="FluentAssertions" Version="7.2.2" />
+              <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+            </ItemGroup>
+            """));
+        result.BuildSucceeded.Should().BeTrue();
+        var projectTelemetryFile = Path.Combine(context.OutputFolder, "0", "Telemetry.json");
+        File.Exists(projectTelemetryFile).Should().BeTrue();
+        var telemetryLines = File.ReadAllLines(projectTelemetryFile);
+        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.packages.fluentassertions.cnt":"true"}""");
+        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.packages.mstest_testframework.cnt":"true"}""");
+    }
+
     private BuildLog Execute_E2E_TestProjects_ProtobufFileNamesAreUpdated(bool isTestProject, string projectSpecificSubDir)
     {
         // Protobuf files containing metrics information should be created for test projects.

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
@@ -806,7 +806,6 @@ public class E2EAnalysisTests
     public void E2E_TelemetryFiles_PackageReferences_Written()
     {
         var context = CreateContext();
-
         var result = BuildRunner.BuildTargets(TestContext, context.CreateProjectFile($"""
             <ItemGroup>
               <Compile Include='{context.CreateInputFile("codeFile1.cs")}' />
@@ -814,16 +813,38 @@ public class E2EAnalysisTests
             <ItemGroup>
               <PackageReference Include="FluentAssertions" Version="7.2.2" />
               <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
-              <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+              <PackageReference Include="Castle.Core" Version="5.2.1" />
             </ItemGroup>
             """));
         result.BuildSucceeded.Should().BeTrue();
         var projectTelemetryFile = Path.Combine(context.OutputFolder, "0", "Telemetry.json");
         File.Exists(projectTelemetryFile).Should().BeTrue();
         var telemetryLines = File.ReadAllLines(projectTelemetryFile);
-        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.packages.fluentassertions.cnt":"true"}""");
-        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.packages.mstest_testframework.cnt":"true"}""");
-        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.packages.mstest_testadapter.cnt":"true"}""");
+        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.dependencies.fluentassertions.cnt":"true"}""");
+        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.dependencies.mstest_testframework.cnt":"true"}""");
+        // We whitelist the packages we care about. so Castle.Core should not be reported.
+        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.castle_core.cnt":"true"}""");
+    }
+
+    [TestMethod]
+    public void E2E_TelemetryFiles_AssemblyReferences_Written()
+    {
+        var context = CreateContext();
+        var result = BuildRunner.BuildTargets(TestContext, context.CreateProjectFile($"""
+            <ItemGroup>
+              <Compile Include='{context.CreateInputFile("codeFile1.cs")}' />
+            </ItemGroup>
+            <ItemGroup>
+              <Reference Include="System.Web" />
+            </ItemGroup>
+            """));
+        result.BuildSucceeded.Should().BeTrue();
+        var projectTelemetryFile = Path.Combine(context.OutputFolder, "0", "Telemetry.json");
+        File.Exists(projectTelemetryFile).Should().BeTrue();
+        var telemetryLines = File.ReadAllLines(projectTelemetryFile);
+        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.dependencies.system_web.cnt":"true"}""");
+        // System.Xml is referenced implicitly by the SDK for .NET Framework projects but is deliberately not whitelisted.
+        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.system_xml.cnt":"true"}""");
     }
 
     private BuildLog Execute_E2E_TestProjects_ProtobufFileNamesAreUpdated(bool isTestProject, string projectSpecificSubDir)

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
@@ -508,9 +508,7 @@ public class E2EAnalysisTests
         var filesToAnalyze = projectInfo.AssertAnalysisResultFileExists(nameof(AnalysisResultFileType.FilesToAnalyze));
         var actualFilesToAnalyze = File.ReadAllLines(filesToAnalyze.Location);
         actualFilesToAnalyze.Should().BeEquivalentTo([codeFile, contentFile], "Unexpected list of files to analyze");
-        var projectTelemetryFile = Path.Combine(context.OutputFolder, "0", "Telemetry.json");
-        File.Exists(projectTelemetryFile).Should().BeTrue();
-        File.ReadAllLines(projectTelemetryFile).Should().Contain("""{"dotnetenterprise.s4net.build.exclusion_file.cnt":"true"}""");
+        ReadTelemetryLines(context).Should().Contain("""{"dotnetenterprise.s4net.build.exclusion_file.cnt":"true"}""");
     }
 
     // Checks that projects that don't include the standard managed targets are still
@@ -817,12 +815,10 @@ public class E2EAnalysisTests
             </ItemGroup>
             """));
         result.BuildSucceeded.Should().BeTrue();
-        var projectTelemetryFile = Path.Combine(context.OutputFolder, "0", "Telemetry.json");
-        File.Exists(projectTelemetryFile).Should().BeTrue();
-        var telemetryLines = File.ReadAllLines(projectTelemetryFile);
+        var telemetryLines = ReadTelemetryLines(context);
         telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.dependencies.fluentassertions.cnt":"true"}""");
         telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.dependencies.mstest_testframework.cnt":"true"}""");
-        // We whitelist the packages we care about. so Castle.Core should not be reported.
+        // We whitelist the packages we care about, so Castle.Core should not be reported.
         telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.castle_core.cnt":"true"}""");
     }
 
@@ -835,16 +831,29 @@ public class E2EAnalysisTests
               <Compile Include='{context.CreateInputFile("codeFile1.cs")}' />
             </ItemGroup>
             <ItemGroup>
+              <!-- Direct authored reference -> reported. -->
               <Reference Include="System.Web" />
+              <!-- Whitelisted name, but resolved from a NuGet package -> must NOT be reported (direct NuGet
+                   references are caught via PackageReference). Guards the NuGetPackageId condition. -->
+              <Reference Include="System.Windows.Forms">
+                <NuGetPackageId>Some.Package</NuGetPackageId>
+              </Reference>
+              <!-- Whitelisted name, but implicitly defined by the SDK -> must NOT be reported.
+                   Guards the IsImplicitlyDefined condition. -->
+              <Reference Include="System.ServiceModel">
+                <IsImplicitlyDefined>true</IsImplicitlyDefined>
+              </Reference>
             </ItemGroup>
             """));
         result.BuildSucceeded.Should().BeTrue();
-        var projectTelemetryFile = Path.Combine(context.OutputFolder, "0", "Telemetry.json");
-        File.Exists(projectTelemetryFile).Should().BeTrue();
-        var telemetryLines = File.ReadAllLines(projectTelemetryFile);
+        var telemetryLines = ReadTelemetryLines(context);
         telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.dependencies.system_web.cnt":"true"}""");
         // System.Xml is referenced implicitly by the SDK for .NET Framework projects but is deliberately not whitelisted.
         telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.system_xml.cnt":"true"}""");
+        // Comes from a NuGet package, so it is caught via PackageReference, not as a direct assembly reference.
+        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.system_windows_forms.cnt":"true"}""");
+        // Implicitly defined by the SDK, so it is not a direct assembly reference.
+        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.system_servicemodel.cnt":"true"}""");
     }
 
     private BuildLog Execute_E2E_TestProjects_ProtobufFileNamesAreUpdated(bool isTestProject, string projectSpecificSubDir)
@@ -909,6 +918,13 @@ public class E2EAnalysisTests
 
     private TargetsTestsContext CreateContext(string language = "C#", string inputFolderName = "Inputs") =>
         new(TestContext, language, inputFolderName);
+
+    private static string[] ReadTelemetryLines(TargetsTestsContext context)
+    {
+        var projectTelemetryFile = Path.Combine(context.OutputFolder, "0", "Telemetry.json");
+        File.Exists(projectTelemetryFile).Should().BeTrue();
+        return File.ReadAllLines(projectTelemetryFile);
+    }
 
     private static void AssertNoAdditionalFilesInFolder(string folderPath, params string[] allowedFileNames)
     {

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/E2ETests/E2EAnalysisTests.cs
@@ -853,12 +853,8 @@ public class E2EAnalysisTests
         result.Messages.Should().Contain(x => x.Contains("REF|WindowsBase|IsImplicitlyDefined=[true]"));
         result.Messages.Should().Contain(x => x.Contains("REF|System.Windows.Forms|IsImplicitlyDefined=[true]"));
 
-        var telemetryLines = ReadTelemetryLines(context);
-        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.dependencies.system_web.cnt":"true"}""");
-        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.presentationcore.cnt":"true"}""");
-        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.presentationframework.cnt":"true"}""");
-        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.windowsbase.cnt":"true"}""");
-        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.system_windows_forms.cnt":"true"}""");
+        ReadTelemetryLines(context).Where(x => x.StartsWith("""{"dotnetenterprise.s4net.build.dependencies."""))
+            .Should().BeEquivalentTo(["""{"dotnetenterprise.s4net.build.dependencies.system_web.cnt":"true"}"""]);
     }
 
     // Adding the direct, whitelisted package Microsoft.Extensions.Http makes NuGet resolve the whitelisted Microsoft.Extensions.Logging and Microsoft.Extensions.DependencyInjection transitively.
@@ -887,10 +883,8 @@ public class E2EAnalysisTests
         result.Messages.Should().NotContain(x => x.Contains("PKG_REF|[Microsoft.Extensions.Logging]"));
         result.Messages.Should().NotContain(x => x.Contains("PKG_REF|[Microsoft.Extensions.DependencyInjection]"));
 
-        var telemetryLines = ReadTelemetryLines(context);
-        telemetryLines.Should().Contain("""{"dotnetenterprise.s4net.build.dependencies.microsoft_extensions_http.cnt":"true"}""");
-        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.microsoft_extensions_logging.cnt":"true"}""");
-        telemetryLines.Should().NotContain("""{"dotnetenterprise.s4net.build.dependencies.microsoft_extensions_dependencyinjection.cnt":"true"}""");
+        ReadTelemetryLines(context).Where(x => x.StartsWith("""{"dotnetenterprise.s4net.build.dependencies."""))
+            .Should().BeEquivalentTo(["""{"dotnetenterprise.s4net.build.dependencies.microsoft_extensions_http.cnt":"true"}"""]);
     }
 
     private BuildLog Execute_E2E_TestProjects_ProtobufFileNamesAreUpdated(bool isTestProject, string projectSpecificSubDir)

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTest/DependencyTelemetryTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTest/DependencyTelemetryTests.cs
@@ -1,0 +1,132 @@
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) SonarSource Sàrl
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace SonarScanner.MSBuild.Tasks.UnitTest;
+
+[TestClass]
+public class DependencyTelemetryTests
+{
+    [TestMethod]
+    [DataRow("FluentAssertions", "dotnetenterprise.s4net.build.dependencies.fluentassertions.cnt")]
+    [DataRow("Microsoft.EntityFrameworkCore", "dotnetenterprise.s4net.build.dependencies.microsoft_entityframeworkcore.cnt")]
+    public void WhitelistedPackage_IsReported(string id, string expectedKey) =>
+        Keys(Execute([Dependency(id)])).Should().ContainSingle().Which.Should().Be(expectedKey);
+
+    [TestMethod]
+    [DataRow("System.Web", "dotnetenterprise.s4net.build.dependencies.system_web.cnt")]
+    [DataRow("System.Web.Services", "dotnetenterprise.s4net.build.dependencies.system_web_services.cnt")]
+    [DataRow("System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "dotnetenterprise.s4net.build.dependencies.system_web.cnt")]
+    public void WhitelistedReference_IsReported(string spec, string expectedKey) =>
+        Keys(Execute(references: [Reference(spec)])).Should().ContainSingle().Which.Should().Be(expectedKey);
+
+    [TestMethod]
+    public void KnownDependency_TelemetryValueIsTrue() =>
+        Execute([Dependency("Serilog")]).Telemetry.Should().ContainSingle().Which.GetMetadata("Value").Should().Be("true");
+
+    [TestMethod]
+    [DataRow("Some.Random.Package", null, false)]
+    [DataRow("Newtonsoft.Json", "Newtonsoft.Json", false)]
+    [DataRow("System.Web", null, true)]
+    public void UnwantedReference_IsNotReported(string spec, string nuGetPackageId, bool isImplicit) =>
+        Execute(references: [Reference(spec, nuGetPackageId, isImplicit)]).Telemetry.Should().BeEmpty();
+
+    [TestMethod]
+    [DataRow("Some.Random.Package", false)]
+    [DataRow("Microsoft.Extensions.Logging", true)]
+    public void UnwantedPackage_IsNotReported(string id, bool isImplicit) =>
+    Execute([Dependency(id, isImplicit)]).Telemetry.Should().BeEmpty();
+
+    [TestMethod]
+    public void Matching_IsCaseInsensitive() =>
+        Keys(Execute([Dependency("fluentassertions")], [Reference("system.web")])).Should().BeEquivalentTo(
+            "dotnetenterprise.s4net.build.dependencies.fluentassertions.cnt",
+            "dotnetenterprise.s4net.build.dependencies.system_web.cnt");
+
+    [TestMethod]
+    public void MixedInputs_ReportedAndDeduplicated() =>
+        Keys(Execute(
+            [Dependency("Serilog"), Dependency("Dapper"), Dependency("Unknown"), Dependency("Serilog")],
+            [Reference("System.Windows.Forms"), Reference("mscorlib")])).Should().BeEquivalentTo(
+            "dotnetenterprise.s4net.build.dependencies.dapper.cnt",
+            "dotnetenterprise.s4net.build.dependencies.serilog.cnt",
+            "dotnetenterprise.s4net.build.dependencies.system_windows_forms.cnt");
+
+    [TestMethod]
+    public void Empty_Inputs_ProduceNoTelemetry() =>
+    Execute().Telemetry.Should().BeEmpty();
+
+    [TestMethod]
+    public void Null_Inputs_ProduceNoTelemetry()
+    {
+        var engine = new DummyBuildEngine();
+        var task = new DependencyTelemetry { BuildEngine = engine, PackageReferences = null, AssemblyReferences = null };
+
+        task.Execute().Should().BeTrue();
+        engine.AssertNoErrors();
+        engine.AssertNoWarnings();
+        task.Telemetry.Should().BeEmpty();
+    }
+
+    private static DependencyTelemetry Execute(ITaskItem[] packages = null, ITaskItem[] references = null)
+    {
+        var engine = new DummyBuildEngine();
+        var task = new DependencyTelemetry
+        {
+            BuildEngine = engine,
+            PackageReferences = packages ?? [],
+            AssemblyReferences = references ?? []
+        };
+
+        task.Execute().Should().BeTrue();
+        engine.AssertNoErrors();
+        engine.AssertNoWarnings();
+        return task;
+    }
+
+    private static IEnumerable<string> Keys(DependencyTelemetry task) =>
+        task.Telemetry.Select(x => x.ItemSpec);
+
+    private static TaskItem Dependency(string id, bool isImplicit = false)
+    {
+        var item = new TaskItem(id);
+        if (isImplicit)
+        {
+            item.SetMetadata("IsImplicitlyDefined", "true");
+        }
+        return item;
+    }
+
+    private static TaskItem Reference(string spec, string nuGetPackageId = null, bool isImplicit = false)
+    {
+        var item = new TaskItem(spec);
+        if (nuGetPackageId is not null)
+        {
+            item.SetMetadata("NuGetPackageId", nuGetPackageId);
+        }
+        if (isImplicit)
+        {
+            item.SetMetadata("IsImplicitlyDefined", "true");
+        }
+        return item;
+    }
+}

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTest/DependencyTelemetryTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTest/DependencyTelemetryTests.cs
@@ -30,50 +30,50 @@ public class DependencyTelemetryTests
     [DataRow("FluentAssertions", "dotnetenterprise.s4net.build.dependencies.fluentassertions.cnt")]
     [DataRow("Microsoft.EntityFrameworkCore", "dotnetenterprise.s4net.build.dependencies.microsoft_entityframeworkcore.cnt")]
     public void WhitelistedPackage_IsReported(string id, string expectedKey) =>
-        Keys(Execute([Dependency(id)])).Should().ContainSingle().Which.Should().Be(expectedKey);
+        Keys(Execute([CreateDependency(id)])).Should().ContainSingle().Which.Should().Be(expectedKey);
 
     [TestMethod]
     [DataRow("System.Web", "dotnetenterprise.s4net.build.dependencies.system_web.cnt")]
     [DataRow("System.Web.Services", "dotnetenterprise.s4net.build.dependencies.system_web_services.cnt")]
     [DataRow("System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a", "dotnetenterprise.s4net.build.dependencies.system_web.cnt")]
     public void WhitelistedReference_IsReported(string spec, string expectedKey) =>
-        Keys(Execute(references: [Reference(spec)])).Should().ContainSingle().Which.Should().Be(expectedKey);
+        Keys(Execute(references: [CreateReference(spec)])).Should().ContainSingle().Which.Should().Be(expectedKey);
 
     [TestMethod]
     public void KnownDependency_TelemetryValueIsTrue() =>
-        Execute([Dependency("Serilog")]).Telemetry.Should().ContainSingle().Which.GetMetadata("Value").Should().Be("true");
+        Execute([CreateDependency("Serilog")]).Telemetry.Should().ContainSingle().Which.GetMetadata("Value").Should().Be("true");
 
     [TestMethod]
     [DataRow("Some.Random.Package", null, false)]
     [DataRow("Newtonsoft.Json", "Newtonsoft.Json", false)]
     [DataRow("System.Web", null, true)]
     public void UnwantedReference_IsNotReported(string spec, string nuGetPackageId, bool isImplicit) =>
-        Execute(references: [Reference(spec, nuGetPackageId, isImplicit)]).Telemetry.Should().BeEmpty();
+        Execute(references: [CreateReference(spec, nuGetPackageId, isImplicit)]).Telemetry.Should().BeEmpty();
 
     [TestMethod]
     [DataRow("Some.Random.Package", false)]
     [DataRow("Microsoft.Extensions.Logging", true)]
     public void UnwantedPackage_IsNotReported(string id, bool isImplicit) =>
-    Execute([Dependency(id, isImplicit)]).Telemetry.Should().BeEmpty();
+        Execute([CreateDependency(id, isImplicit)]).Telemetry.Should().BeEmpty();
 
     [TestMethod]
     public void Matching_IsCaseInsensitive() =>
-        Keys(Execute([Dependency("fluentassertions")], [Reference("system.web")])).Should().BeEquivalentTo(
+        Keys(Execute([CreateDependency("fluentassertions")], [CreateReference("system.WEB")])).Should().BeEquivalentTo(
             "dotnetenterprise.s4net.build.dependencies.fluentassertions.cnt",
             "dotnetenterprise.s4net.build.dependencies.system_web.cnt");
 
     [TestMethod]
     public void MixedInputs_ReportedAndDeduplicated() =>
         Keys(Execute(
-            [Dependency("Serilog"), Dependency("Dapper"), Dependency("Unknown"), Dependency("Serilog")],
-            [Reference("System.Windows.Forms"), Reference("mscorlib")])).Should().BeEquivalentTo(
+            [CreateDependency("Serilog"), CreateDependency("Dapper"), CreateDependency("Unknown"), CreateDependency("Serilog")],
+            [CreateReference("System.Windows.Forms"), CreateReference("mscorlib")])).Should().BeEquivalentTo(
             "dotnetenterprise.s4net.build.dependencies.dapper.cnt",
             "dotnetenterprise.s4net.build.dependencies.serilog.cnt",
             "dotnetenterprise.s4net.build.dependencies.system_windows_forms.cnt");
 
     [TestMethod]
     public void Empty_Inputs_ProduceNoTelemetry() =>
-    Execute().Telemetry.Should().BeEmpty();
+        Execute().Telemetry.Should().BeEmpty();
 
     [TestMethod]
     public void Null_Inputs_ProduceNoTelemetry()
@@ -106,7 +106,7 @@ public class DependencyTelemetryTests
     private static IEnumerable<string> Keys(DependencyTelemetry task) =>
         task.Telemetry.Select(x => x.ItemSpec);
 
-    private static TaskItem Dependency(string id, bool isImplicit = false)
+    private static TaskItem CreateDependency(string id, bool isImplicit = false)
     {
         var item = new TaskItem(id);
         if (isImplicit)
@@ -116,7 +116,7 @@ public class DependencyTelemetryTests
         return item;
     }
 
-    private static TaskItem Reference(string spec, string nuGetPackageId = null, bool isImplicit = false)
+    private static TaskItem CreateReference(string spec, string nuGetPackageId = null, bool isImplicit = false)
     {
         var item = new TaskItem(spec);
         if (nuGetPackageId is not null)

--- a/its/projects/Telemetry/Telemetry/Telemetry/Telemetry.csproj
+++ b/its/projects/Telemetry/Telemetry/Telemetry/Telemetry.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="ExcludedFile.cs">
       <SonarQubeExclude>true</SonarQubeExclude>
     </Compile>

--- a/its/projects/Telemetry/Telemetry/Telemetry/packages.lock.json
+++ b/its/projects/Telemetry/Telemetry/Telemetry/packages.lock.json
@@ -54,6 +54,43 @@
           "System.Xml.XDocument": "4.3.0"
         }
       },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.3, )",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.3.0",
+          "NETStandard.Library": "1.6.1",
+          "System.ComponentModel.TypeConverter": "4.3.0",
+          "System.Runtime.Serialization.Formatters": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0",
+          "System.Xml.XmlDocument": "4.3.0"
+        }
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "P+MBhIM0YX+JqROuf7i306ZLJEjQYA9uUyRDE+OqwUI5sh41e2ZbPQV3LfAPh+29cmceE1pUffXsGfR4eMY3KA==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
         "resolved": "1.1.0",
@@ -228,6 +265,73 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.Collections.NonGeneric": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "prtjIEMhGUnQq6RnPEYLpFt8AtLbp9yq2zxOSrY7KJJZrw25Fi97IzBqY7iqssbM61Ek5b8f3MG/sG1N2sN5KA==",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Collections.Specialized": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Epx8PoVZR0iuOnJJDzp7pWvdfMMOAvpUo95pC4ScH2mJuXkKA2Y4aR3cG9qt2klHgSons1WFh4kcGW7cSXvrxg==",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ComponentModel": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "VyGn1jGRZVfxnh8EdvDCi71v3bMXrsu8aYJOwoV7SNDLVhiEqwP86pPMyRGsDsxhXAm2b3o9OIqeETfN5qfezw==",
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.ComponentModel.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "j8GUkCpM8V4d4vhLIIoBLGey2Z5bCkMVNjEZseyAlm4n5arcsJOeI3zkUP+zvZgzsbLTYh4lYeP/ZD/gdIAPrw==",
+        "dependencies": {
+          "System.ComponentModel": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.ComponentModel.TypeConverter": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "16pQ6P+EdhcXzPiEK4kbA953Fu0MNG2ovxTZU81/qsCd1zPRsKc3uif5NgvllCY598k6bI0KUyKW8fanlfaDQg==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Collections.NonGeneric": "4.3.0",
+          "System.Collections.Specialized": "4.3.0",
+          "System.ComponentModel": "4.3.0",
+          "System.ComponentModel.Primitives": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
       "System.Console": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -280,6 +384,27 @@
           "Microsoft.NETCore.Platforms": "1.1.0",
           "Microsoft.NETCore.Targets": "1.1.0",
           "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Dynamic.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
         }
       },
       "System.Globalization": {
@@ -648,6 +773,27 @@
           "System.Runtime.Extensions": "4.3.0"
         }
       },
+      "System.Runtime.Serialization.Formatters": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "KT591AkTNFOTbhZlaeMVvfax3RqhH1EJlcwF50Wm7sfnBLuHiOeZRRKrr1ns3NESkM20KPZ5Ol/ueMq5vg4QoQ==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
       "System.Security.Cryptography.Algorithms": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -898,6 +1044,23 @@
           "System.Globalization": "4.3.0",
           "System.IO": "4.3.0",
           "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Xml.XmlDocument": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "lJ8AxvkX7GQxpC6GFCeBj8ThYVyQczx2+f/cWHJU8tjS7YfI6Cv6bon70jVEgs2CiFbmmM8b9j1oZVx0dSI2Ww==",
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
           "System.Resources.ResourceManager": "4.3.0",
           "System.Runtime": "4.3.0",
           "System.Runtime.Extensions": "4.3.0",

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
@@ -114,7 +114,7 @@ class TelemetryTest {
       x -> assertThat(x).isEqualTo("dotnetenterprise.s4net.build.exclusion_file.true=1"),
       x -> assertThat(x).isEqualTo("dotnetenterprise.s4net.build.deterministic.true=3"),
       x -> assertThat(x).isEqualTo("dotnetenterprise.s4net.build.sonar_properties_in_project_file.set=1"),
-      x -> assertThat(x).isEqualTo("dotnetenterprise.s4net.build.packages.newtonsoft_json.true=1"));
+      x -> assertThat(x).isEqualTo("dotnetenterprise.s4net.build.dependencies.newtonsoft_json.true=1"));
   }
 
   @Test

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/TelemetryTest.java
@@ -113,7 +113,8 @@ class TelemetryTest {
       x -> assertThat(x).isEqualTo("dotnetenterprise.s4net.build.exclusion_proj.false=2"),
       x -> assertThat(x).isEqualTo("dotnetenterprise.s4net.build.exclusion_file.true=1"),
       x -> assertThat(x).isEqualTo("dotnetenterprise.s4net.build.deterministic.true=3"),
-      x -> assertThat(x).isEqualTo("dotnetenterprise.s4net.build.sonar_properties_in_project_file.set=1"));
+      x -> assertThat(x).isEqualTo("dotnetenterprise.s4net.build.sonar_properties_in_project_file.set=1"),
+      x -> assertThat(x).isEqualTo("dotnetenterprise.s4net.build.packages.newtonsoft_json.true=1"));
   }
 
   @Test

--- a/src/SonarScanner.MSBuild.Tasks/DependencyTelemetry.cs
+++ b/src/SonarScanner.MSBuild.Tasks/DependencyTelemetry.cs
@@ -32,30 +32,87 @@ public sealed class DependencyTelemetry : Task
     internal static readonly HashSet<string> KnownDependencies = new(StringComparer.OrdinalIgnoreCase)
         {
             // Test / mocking / assertions
-            "xunit", "NUnit", "MSTest.TestFramework", "Microsoft.NET.Test.Sdk", "Moq", "NSubstitute", "FluentAssertions",
-            "Shouldly", "coverlet.collector", "coverlet.msbuild", "AutoFixture", "Bogus", "BenchmarkDotNet",
+            "AutoFixture",
+            "BenchmarkDotNet",
+            "Bogus",
+            "coverlet.collector",
+            "coverlet.msbuild",
+            "FluentAssertions",
+            "Microsoft.NET.Test.Sdk",
+            "Moq",
+            "MSTest.TestFramework",
+            "NSubstitute",
+            "NUnit",
+            "Shouldly",
+            "xunit",
             // Logging / observability
-            "Serilog", "Serilog.AspNetCore", "NLog", "log4net", "Microsoft.Extensions.Logging", "OpenTelemetry.Extensions.Hosting",
-            "OpenTelemetry.Exporter.OpenTelemetryProtocol", "Microsoft.ApplicationInsights.AspNetCore",
+            "log4net",
+            "Microsoft.ApplicationInsights.AspNetCore",
+            "Microsoft.Extensions.Logging",
+            "NLog",
+            "OpenTelemetry.Exporter.OpenTelemetryProtocol",
+            "OpenTelemetry.Extensions.Hosting",
+            "Serilog",
+            "Serilog.AspNetCore",
             // Serialization
-            "Newtonsoft.Json", "System.Text.Json", "protobuf-net", "MessagePack", "YamlDotNet",
+            "MessagePack",
+            "Newtonsoft.Json",
+            "protobuf-net",
+            "System.Text.Json",
+            "YamlDotNet",
             // Web / API / validation / mapping / resilience
-            "Swashbuckle.AspNetCore", "MediatR", "FluentValidation", "AutoMapper", "Polly", "RestSharp", "Refit",
-            "Microsoft.Extensions.Http", "Grpc.AspNetCore", "HotChocolate.AspNetCore", "Microsoft.AspNetCore.SignalR.Client",
+            "AutoMapper",
+            "FluentValidation",
+            "Grpc.AspNetCore",
+            "HotChocolate.AspNetCore",
+            "MediatR",
             "Microsoft.AspNetCore.Authentication.JwtBearer",
+            "Microsoft.AspNetCore.SignalR.Client",
+            "Microsoft.Extensions.Http",
+            "Polly",
+            "Refit",
+            "RestSharp",
+            "Swashbuckle.AspNetCore",
             // Data / ORM / drivers
-            "Dapper", "Microsoft.EntityFrameworkCore", "Microsoft.EntityFrameworkCore.SqlServer", "Microsoft.EntityFrameworkCore.Design",
-            "Npgsql", "Npgsql.EntityFrameworkCore.PostgreSQL", "Pomelo.EntityFrameworkCore.MySql", "StackExchange.Redis",
-            "MongoDB.Driver", "Microsoft.Data.SqlClient", "EntityFramework",
+            "Dapper",
+            "EntityFramework",
+            "Microsoft.Data.SqlClient",
+            "Microsoft.EntityFrameworkCore",
+            "Microsoft.EntityFrameworkCore.Design",
+            "Microsoft.EntityFrameworkCore.SqlServer",
+            "MongoDB.Driver",
+            "Npgsql",
+            "Npgsql.EntityFrameworkCore.PostgreSQL",
+            "Pomelo.EntityFrameworkCore.MySql",
+            "StackExchange.Redis",
             // DI / cloud
-            "Microsoft.Extensions.DependencyInjection", "Autofac", "Azure.Identity", "Azure.Storage.Blobs",
-            "Azure.Messaging.ServiceBus", "Microsoft.Azure.Cosmos", "AWSSDK.S3", "AWSSDK.SQS", "AWSSDK.DynamoDBv2",
+            "Autofac",
+            "AWSSDK.DynamoDBv2",
+            "AWSSDK.S3",
+            "AWSSDK.SQS",
+            "Azure.Identity",
+            "Azure.Messaging.ServiceBus",
+            "Azure.Storage.Blobs",
+            "Microsoft.Azure.Cosmos",
+            "Microsoft.Extensions.DependencyInjection",
             // Auth / identity / misc
-            "Microsoft.IdentityModel.Tokens", "System.IdentityModel.Tokens.Jwt", "BCrypt.Net-Next", "NodaTime",
+            "BCrypt.Net-Next",
+            "Microsoft.IdentityModel.Tokens",
+            "NodaTime",
+            "System.IdentityModel.Tokens.Jwt",
             // .NET Framework assemblies referenced directly by non-SDK-style projects (no NuGet package)
-            "System.Web", "System.Web.Mvc", "System.Web.Services", "System.Web.Http", "System.Windows.Forms",
-            "System.ServiceModel", "PresentationFramework", "PresentationCore", "WindowsBase", "System.Configuration",
-            "System.DirectoryServices", "System.Messaging"
+            "PresentationCore",
+            "PresentationFramework",
+            "System.Configuration",
+            "System.DirectoryServices",
+            "System.Messaging",
+            "System.ServiceModel",
+            "System.Web",
+            "System.Web.Http",
+            "System.Web.Mvc",
+            "System.Web.Services",
+            "System.Windows.Forms",
+            "WindowsBase"
         };
 
     public ITaskItem[] PackageReferences { get; set; } = [];
@@ -69,6 +126,7 @@ public sealed class DependencyTelemetry : Task
     {
         Telemetry = PackageNames()
             .Concat(AssemblyNames())
+            .Where(KnownDependencies.Contains)
             .Select(TelemetryKey)
             .Distinct(StringComparer.Ordinal)
             .Select(CreateTelemetryItem)
@@ -79,14 +137,12 @@ public sealed class DependencyTelemetry : Task
     private IEnumerable<string> PackageNames() =>
         (PackageReferences ?? [])
             .Where(x => !string.IsNullOrEmpty(x.ItemSpec) && !string.Equals(x.GetMetadata("IsImplicitlyDefined"), "true", StringComparison.OrdinalIgnoreCase))
-            .Select(x => x.ItemSpec)
-            .Where(KnownDependencies.Contains);
+            .Select(x => x.ItemSpec);
 
     private IEnumerable<string> AssemblyNames() =>
         (AssemblyReferences ?? [])
             .Where(IsDirectReference)
-            .Select(x => SimpleAssemblyName(x.ItemSpec))
-            .Where(KnownDependencies.Contains);
+            .Select(x => SimpleAssemblyName(x.ItemSpec));
 
     // Keep only assemblies authored as plain <Reference> items. Skip those with NuGetPackageId as direct Nuget references are caught via PackageReferences, and transitive are unwanted.
     private static bool IsDirectReference(ITaskItem reference) =>

--- a/src/SonarScanner.MSBuild.Tasks/DependencyTelemetry.cs
+++ b/src/SonarScanner.MSBuild.Tasks/DependencyTelemetry.cs
@@ -1,0 +1,109 @@
+﻿/*
+ * SonarScanner for .NET
+ * Copyright (C) SonarSource Sàrl
+ * mailto: info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace SonarScanner.MSBuild.Tasks;
+
+public sealed class DependencyTelemetry : Task
+{
+    private const string TelemetryKeyPrefix = "dotnetenterprise.s4net.build.dependencies.";
+
+    // Well-known dependencies, matched against both PackageReference ids (SDK-style) and authored <Reference>
+    // assembly names (non-SDK-style); for most libraries the two are identical.
+    internal static readonly HashSet<string> KnownDependencies = new(StringComparer.OrdinalIgnoreCase)
+        {
+            // Test / mocking / assertions
+            "xunit", "NUnit", "MSTest.TestFramework", "Microsoft.NET.Test.Sdk", "Moq", "NSubstitute", "FluentAssertions",
+            "Shouldly", "coverlet.collector", "coverlet.msbuild", "AutoFixture", "Bogus", "BenchmarkDotNet",
+            // Logging / observability
+            "Serilog", "Serilog.AspNetCore", "NLog", "log4net", "Microsoft.Extensions.Logging", "OpenTelemetry.Extensions.Hosting",
+            "OpenTelemetry.Exporter.OpenTelemetryProtocol", "Microsoft.ApplicationInsights.AspNetCore",
+            // Serialization
+            "Newtonsoft.Json", "System.Text.Json", "protobuf-net", "MessagePack", "YamlDotNet",
+            // Web / API / validation / mapping / resilience
+            "Swashbuckle.AspNetCore", "MediatR", "FluentValidation", "AutoMapper", "Polly", "RestSharp", "Refit",
+            "Microsoft.Extensions.Http", "Grpc.AspNetCore", "HotChocolate.AspNetCore", "Microsoft.AspNetCore.SignalR.Client",
+            "Microsoft.AspNetCore.Authentication.JwtBearer",
+            // Data / ORM / drivers
+            "Dapper", "Microsoft.EntityFrameworkCore", "Microsoft.EntityFrameworkCore.SqlServer", "Microsoft.EntityFrameworkCore.Design",
+            "Npgsql", "Npgsql.EntityFrameworkCore.PostgreSQL", "Pomelo.EntityFrameworkCore.MySql", "StackExchange.Redis",
+            "MongoDB.Driver", "Microsoft.Data.SqlClient", "EntityFramework",
+            // DI / cloud
+            "Microsoft.Extensions.DependencyInjection", "Autofac", "Azure.Identity", "Azure.Storage.Blobs",
+            "Azure.Messaging.ServiceBus", "Microsoft.Azure.Cosmos", "AWSSDK.S3", "AWSSDK.SQS", "AWSSDK.DynamoDBv2",
+            // Auth / identity / misc
+            "Microsoft.IdentityModel.Tokens", "System.IdentityModel.Tokens.Jwt", "BCrypt.Net-Next", "NodaTime",
+            // .NET Framework assemblies referenced directly by non-SDK-style projects (no NuGet package)
+            "System.Web", "System.Web.Mvc", "System.Web.Services", "System.Web.Http", "System.Windows.Forms",
+            "System.ServiceModel", "PresentationFramework", "PresentationCore", "WindowsBase", "System.Configuration",
+            "System.DirectoryServices", "System.Messaging"
+        };
+
+    public ITaskItem[] PackageReferences { get; set; } = [];
+
+    public ITaskItem[] AssemblyReferences { get; set; } = [];
+
+    [Output]
+    public ITaskItem[] Telemetry { get; private set; } = [];
+
+    public override bool Execute()
+    {
+        Telemetry = PackageNames()
+            .Concat(AssemblyNames())
+            .Select(TelemetryKey)
+            .Distinct(StringComparer.Ordinal)
+            .Select(CreateTelemetryItem)
+            .ToArray();
+        return true;
+    }
+
+    private IEnumerable<string> PackageNames() =>
+        (PackageReferences ?? [])
+            .Where(x => !string.IsNullOrEmpty(x.ItemSpec) && !string.Equals(x.GetMetadata("IsImplicitlyDefined"), "true", StringComparison.OrdinalIgnoreCase))
+            .Select(x => x.ItemSpec)
+            .Where(KnownDependencies.Contains);
+
+    private IEnumerable<string> AssemblyNames() =>
+        (AssemblyReferences ?? [])
+            .Where(IsDirectReference)
+            .Select(x => SimpleAssemblyName(x.ItemSpec))
+            .Where(KnownDependencies.Contains);
+
+    // Keep only assemblies authored as plain <Reference> items. Skip those with NuGetPackageId as direct Nuget references are caught via PackageReferences, and transitive are unwanted.
+    private static bool IsDirectReference(ITaskItem reference) =>
+        !string.IsNullOrEmpty(reference.ItemSpec)
+        && string.IsNullOrEmpty(reference.GetMetadata("NuGetPackageId"))
+        && !string.Equals(reference.GetMetadata("IsImplicitlyDefined"), "true", StringComparison.OrdinalIgnoreCase);
+
+    private static string TelemetryKey(string name) =>
+        $"{TelemetryKeyPrefix}{TelemetryUtils.SanitizeKey(name)}.cnt";
+
+    private static ITaskItem CreateTelemetryItem(string key)
+    {
+        var item = new TaskItem(key);
+        item.SetMetadata("Value", "true");
+        return item;
+    }
+
+    private static string SimpleAssemblyName(string itemSpec) =>
+        itemSpec.Split(',')[0].Trim();
+}

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -390,6 +390,29 @@
       <SonarReportFilePath Condition= "$(SonarErrorLogExists) == 'true'" Include="$(SonarErrorLog)" />
     </ItemGroup>
 
+    <!-- Whitelist of well-known NuGet packages reported in telemetry. -->
+    <ItemGroup>
+      <!-- Test / mocking / assertions -->
+      <SonarKnownTelemetryPackage Include="xunit;NUnit;MSTest.TestFramework;Microsoft.NET.Test.Sdk;Moq;NSubstitute;FluentAssertions;Shouldly;coverlet.collector;coverlet.msbuild;AutoFixture;Bogus;BenchmarkDotNet" />
+      <!-- Logging / observability -->
+      <SonarKnownTelemetryPackage Include="Serilog;Serilog.AspNetCore;NLog;log4net;Microsoft.Extensions.Logging;OpenTelemetry.Extensions.Hosting;OpenTelemetry.Exporter.OpenTelemetryProtocol;Microsoft.ApplicationInsights.AspNetCore" />
+      <!-- Serialization -->
+      <SonarKnownTelemetryPackage Include="Newtonsoft.Json;System.Text.Json;protobuf-net;MessagePack;YamlDotNet" />
+      <!-- Web / API / validation / mapping / resilience -->
+      <SonarKnownTelemetryPackage Include="Swashbuckle.AspNetCore;MediatR;FluentValidation;AutoMapper;Polly;RestSharp;Refit;Microsoft.Extensions.Http;Grpc.AspNetCore;HotChocolate.AspNetCore;Microsoft.AspNetCore.SignalR.Client;Microsoft.AspNetCore.Authentication.JwtBearer" />
+      <!-- Data / ORM / drivers -->
+      <SonarKnownTelemetryPackage Include="Dapper;Microsoft.EntityFrameworkCore;Microsoft.EntityFrameworkCore.SqlServer;Microsoft.EntityFrameworkCore.Design;Npgsql;Npgsql.EntityFrameworkCore.PostgreSQL;Pomelo.EntityFrameworkCore.MySql;StackExchange.Redis;MongoDB.Driver;Microsoft.Data.SqlClient" />
+      <!-- DI / cloud -->
+      <SonarKnownTelemetryPackage Include="Microsoft.Extensions.DependencyInjection;Autofac;Azure.Identity;Azure.Storage.Blobs;Azure.Messaging.ServiceBus;Microsoft.Azure.Cosmos;AWSSDK.S3;AWSSDK.SQS;AWSSDK.DynamoDBv2" />
+      <!-- Auth / identity / misc -->
+      <SonarKnownTelemetryPackage Include="Microsoft.IdentityModel.Tokens;System.IdentityModel.Tokens.Jwt;BCrypt.Net-Next;NodaTime" />
+      <!-- Candidate: user-declared (non-implicit) PackageReferences -->
+      <SonarTelemetryPackage Include="@(PackageReference)" Condition="'%(PackageReference.IsImplicitlyDefined)' != 'true' AND '%(PackageReference.Identity)' != ''" />
+
+      <SonarTelemetryPackageNotKnown Include="@(SonarTelemetryPackage)" Exclude="@(SonarKnownTelemetryPackage)" />
+      <SonarTelemetryPackage Remove="@(SonarTelemetryPackageNotKnown)" />
+    </ItemGroup>
+
     <ItemGroup>
       <SonarProjectTelemetry Condition="$(TargetFrameworkMoniker) != ''" Include="dotnetenterprise.s4net.build.target_framework_moniker" >
         <Value>$(TargetFrameworkMoniker)</Value>
@@ -416,7 +439,8 @@
       <SonarProjectTelemetry Condition="$(SonarQubeHasFileExclusions) == 'true'" Include="dotnetenterprise.s4net.build.exclusion_file.cnt">
         <Value>true</Value>
       </SonarProjectTelemetry>
-      <SonarProjectTelemetry Condition="'%(PackageReference.IsImplicitlyDefined)' != 'true' AND '%(PackageReference.Identity)' != ''" Include="dotnetenterprise.s4net.build.packages.$([System.Text.RegularExpressions.Regex]::Replace('%(PackageReference.Identity)', '[^a-zA-Z0-9]', '_').ToLower()).cnt">
+      <SonarProjectTelemetry Condition="'%(SonarTelemetryPackage.Identity)' != ''"
+          Include="dotnetenterprise.s4net.build.packages.$([System.Text.RegularExpressions.Regex]::Replace('%(SonarTelemetryPackage.Identity)', '[^a-zA-Z0-9]', '_').ToLower()).cnt">
         <Value>true</Value>
       </SonarProjectTelemetry>
     </ItemGroup>

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -416,7 +416,7 @@
       <SonarProjectTelemetry Condition="$(SonarQubeHasFileExclusions) == 'true'" Include="dotnetenterprise.s4net.build.exclusion_file.cnt">
         <Value>true</Value>
       </SonarProjectTelemetry>
-      <SonarProjectTelemetry Condition="'%(PackageReference.IsImplicitlyDefined)' != 'true'" Include="dotnetenterprise.s4net.build.packages.$([System.Text.RegularExpressions.Regex]::Replace('%(PackageReference.Identity)', '[^a-zA-Z0-9]', '_').ToLower()).cnt">
+      <SonarProjectTelemetry Condition="'%(PackageReference.IsImplicitlyDefined)' != 'true' AND '%(PackageReference.Identity)' != ''" Include="dotnetenterprise.s4net.build.packages.$([System.Text.RegularExpressions.Regex]::Replace('%(PackageReference.Identity)', '[^a-zA-Z0-9]', '_').ToLower()).cnt">
         <Value>true</Value>
       </SonarProjectTelemetry>
     </ItemGroup>

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -128,6 +128,7 @@
   <UsingTask TaskName="GetAnalyzerSettings" AssemblyFile="$([MSBUILD]::Unescape($(SonarQubeBuildTasksAssemblyFile)))" />
   <UsingTask TaskName="MakeUniqueDir" AssemblyFile="$([MSBUILD]::Unescape($(SonarQubeBuildTasksAssemblyFile)))" />
   <UsingTask TaskName="WriteZeroLengthFiles" AssemblyFile="$([MSBUILD]::Unescape($(SonarQubeBuildTasksAssemblyFile)))" />
+  <UsingTask TaskName="DependencyTelemetry" AssemblyFile="$([MSBUILD]::Unescape($(SonarQubeBuildTasksAssemblyFile)))" />
   <UsingTask TaskName="WriteSonarTelemetry" AssemblyFile="$([MSBUILD]::Unescape($(SonarQubeBuildTasksAssemblyFile)))" />
 
   <!-- **************************************************************************** -->
@@ -390,29 +391,6 @@
       <SonarReportFilePath Condition= "$(SonarErrorLogExists) == 'true'" Include="$(SonarErrorLog)" />
     </ItemGroup>
 
-    <!-- Whitelist of well-known NuGet packages reported in telemetry. -->
-    <ItemGroup>
-      <!-- Test / mocking / assertions -->
-      <SonarKnownTelemetryPackage Include="xunit;NUnit;MSTest.TestFramework;Microsoft.NET.Test.Sdk;Moq;NSubstitute;FluentAssertions;Shouldly;coverlet.collector;coverlet.msbuild;AutoFixture;Bogus;BenchmarkDotNet" />
-      <!-- Logging / observability -->
-      <SonarKnownTelemetryPackage Include="Serilog;Serilog.AspNetCore;NLog;log4net;Microsoft.Extensions.Logging;OpenTelemetry.Extensions.Hosting;OpenTelemetry.Exporter.OpenTelemetryProtocol;Microsoft.ApplicationInsights.AspNetCore" />
-      <!-- Serialization -->
-      <SonarKnownTelemetryPackage Include="Newtonsoft.Json;System.Text.Json;protobuf-net;MessagePack;YamlDotNet" />
-      <!-- Web / API / validation / mapping / resilience -->
-      <SonarKnownTelemetryPackage Include="Swashbuckle.AspNetCore;MediatR;FluentValidation;AutoMapper;Polly;RestSharp;Refit;Microsoft.Extensions.Http;Grpc.AspNetCore;HotChocolate.AspNetCore;Microsoft.AspNetCore.SignalR.Client;Microsoft.AspNetCore.Authentication.JwtBearer" />
-      <!-- Data / ORM / drivers -->
-      <SonarKnownTelemetryPackage Include="Dapper;Microsoft.EntityFrameworkCore;Microsoft.EntityFrameworkCore.SqlServer;Microsoft.EntityFrameworkCore.Design;Npgsql;Npgsql.EntityFrameworkCore.PostgreSQL;Pomelo.EntityFrameworkCore.MySql;StackExchange.Redis;MongoDB.Driver;Microsoft.Data.SqlClient" />
-      <!-- DI / cloud -->
-      <SonarKnownTelemetryPackage Include="Microsoft.Extensions.DependencyInjection;Autofac;Azure.Identity;Azure.Storage.Blobs;Azure.Messaging.ServiceBus;Microsoft.Azure.Cosmos;AWSSDK.S3;AWSSDK.SQS;AWSSDK.DynamoDBv2" />
-      <!-- Auth / identity / misc -->
-      <SonarKnownTelemetryPackage Include="Microsoft.IdentityModel.Tokens;System.IdentityModel.Tokens.Jwt;BCrypt.Net-Next;NodaTime" />
-      <!-- Candidate: user-declared (non-implicit) PackageReferences -->
-      <SonarTelemetryPackage Include="@(PackageReference)" Condition="'%(PackageReference.IsImplicitlyDefined)' != 'true' AND '%(PackageReference.Identity)' != ''" />
-
-      <SonarTelemetryPackageNotKnown Include="@(SonarTelemetryPackage)" Exclude="@(SonarKnownTelemetryPackage)" />
-      <SonarTelemetryPackage Remove="@(SonarTelemetryPackageNotKnown)" />
-    </ItemGroup>
-
     <ItemGroup>
       <SonarProjectTelemetry Condition="$(TargetFrameworkMoniker) != ''" Include="dotnetenterprise.s4net.build.target_framework_moniker" >
         <Value>$(TargetFrameworkMoniker)</Value>
@@ -439,11 +417,12 @@
       <SonarProjectTelemetry Condition="$(SonarQubeHasFileExclusions) == 'true'" Include="dotnetenterprise.s4net.build.exclusion_file.cnt">
         <Value>true</Value>
       </SonarProjectTelemetry>
-      <SonarProjectTelemetry Condition="'%(SonarTelemetryPackage.Identity)' != ''"
-          Include="dotnetenterprise.s4net.build.packages.$([System.Text.RegularExpressions.Regex]::Replace('%(SonarTelemetryPackage.Identity)', '[^a-zA-Z0-9]', '_').ToLower()).cnt">
-        <Value>true</Value>
-      </SonarProjectTelemetry>
     </ItemGroup>
+
+    <DependencyTelemetry PackageReferences="@(PackageReference)" AssemblyReferences="@(Reference)">
+      <Output TaskParameter="Telemetry" ItemName="SonarProjectTelemetry" />
+    </DependencyTelemetry>
+
     <WriteSonarTelemetry Condition="$(SonarProjectTelemetryFilePath)!=''" Filename="$(SonarProjectTelemetryFilePath)" Telemetry="@(SonarProjectTelemetry)" />
 
     <ItemGroup>

--- a/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
+++ b/src/SonarScanner.MSBuild.Tasks/Targets/SonarQube.Integration.targets
@@ -416,6 +416,9 @@
       <SonarProjectTelemetry Condition="$(SonarQubeHasFileExclusions) == 'true'" Include="dotnetenterprise.s4net.build.exclusion_file.cnt">
         <Value>true</Value>
       </SonarProjectTelemetry>
+      <SonarProjectTelemetry Condition="'%(PackageReference.IsImplicitlyDefined)' != 'true'" Include="dotnetenterprise.s4net.build.packages.$([System.Text.RegularExpressions.Regex]::Replace('%(PackageReference.Identity)', '[^a-zA-Z0-9]', '_').ToLower()).cnt">
+        <Value>true</Value>
+      </SonarProjectTelemetry>
     </ItemGroup>
     <WriteSonarTelemetry Condition="$(SonarProjectTelemetryFilePath)!=''" Filename="$(SonarProjectTelemetryFilePath)" Telemetry="@(SonarProjectTelemetry)" />
 


### PR DESCRIPTION
Part of RC-16
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent 
-->

----
## Summary by Gitar

- **New telemetry task:**
    - Added `DependencyTelemetry` MSBuild task to collect known direct package and assembly references.
- **Build integration & tests:**
    - Integrated `DependencyTelemetry` into `SonarQube.Integration.targets` and added comprehensive unit and E2E tests.

<sub>This will update automatically on new commits.</sub>