### PR TITLE
SCAN4NET-1689 Add quality gate time out and publish test reports as artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
         with:
           name: CoverageReport
           path: ${{ github.workspace }}/Coverage
-          retention-days: 1
+          retention-days: 7
           if-no-files-found: error
 
       - name: Publish test results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,12 +196,22 @@ jobs:
           /d:sonar.cs.opencover.reportsPaths="${{ github.workspace }}\Coverage\*.xml"
           /d:sonar.cs.vstest.reportsPaths="${{ github.workspace }}\TestResults\*.trx"
           /d:sonar.sca.exclusions="its/projects/**"
+          /d:sonar.qualitygate.wait=true
+          /d:sonar.qualitygate.timeout=300
 
       - name: Build and analyze
         run: dotnet build SonarScanner.MSBuild.sln --no-restore -c Release /p:RunAnalyzers=true /p:RunAnalyzersDuringBuild=true
 
       - name: Run UTs and compute coverage
         run: .\scripts\run-unit-tests.ps1 -SourcesDirectory "${{ github.workspace }}" -BuildConfiguration Release
+
+      - name: Upload coverage report as pipeline artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: CoverageReport
+          path: ${{ github.workspace }}/Coverage
+          retention-days: 1
+          if-no-files-found: error
 
       - name: Publish test results
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0

--- a/scripts/run-unit-tests.ps1
+++ b/scripts/run-unit-tests.ps1
@@ -8,7 +8,12 @@ function Test-ExitCode([string]$errorMessage = "ERROR: Command FAILED.") {
 
 function Run-Tests-With-Coverage ([string]$ProjectPath) {
     $ProjectNameLiteral = '$(ProjectName)'  #AltCover will replace this MsBuild-style variable with actual project name. The '' deals with PowerShell evaluation
-    dotnet test $ProjectPath --configuration $BuildConfiguration --results-directory "$SourcesDirectory\TestResults" -l trx --no-build --no-restore --filter "TestCategory!=NoWindows" /p:AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter="testhost|AltCover|Microsoft|protobuf|Humanizer|GraphQL|StructuredLogger|Test",AltCoverAttributeFilter="ExcludeFromCodeCoverage",AltCoverReport="$SourcesDirectory/Coverage/$ProjectNameLiteral.xml"
+    # Built as its own string first, then passed as a single quoted argument: $SourcesDirectory/$ProjectNameLiteral only interpolate
+    # reliably this way. Embedded inside an unquoted /p:Key=Val,... token passed straight to the dotnet native executable, pwsh's
+    # native-argument-passing left both variables un-interpolated, silently misdirecting every coverage report (unlike Windows
+    # PowerShell 5.1, which Azure Pipelines used, where this same pattern happened to interpolate correctly).
+    $msbuildProperties = "AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter=testhost|AltCover|Microsoft|protobuf|Humanizer|GraphQL|StructuredLogger|Test,AltCoverAttributeFilter=ExcludeFromCodeCoverage,AltCoverReport=$SourcesDirectory/Coverage/$ProjectNameLiteral.xml"
+    dotnet test $ProjectPath --configuration $BuildConfiguration --results-directory "$SourcesDirectory\TestResults" -l trx --no-build --no-restore --filter "TestCategory!=NoWindows" "/p:$msbuildProperties"
     Test-ExitCode "ERROR: Unit tests for '$ProjectPath' FAILED."
 }
 

--- a/scripts/run-unit-tests.ps1
+++ b/scripts/run-unit-tests.ps1
@@ -8,12 +8,10 @@ function Test-ExitCode([string]$errorMessage = "ERROR: Command FAILED.") {
 
 function Run-Tests-With-Coverage ([string]$ProjectPath) {
     $ProjectNameLiteral = '$(ProjectName)'  #AltCover will replace this MsBuild-style variable with actual project name. The '' deals with PowerShell evaluation
-    # Built as its own string first, then passed as a single quoted argument: $SourcesDirectory/$ProjectNameLiteral only interpolate
-    # reliably this way. Embedded inside an unquoted /p:Key=Val,... token passed straight to the dotnet native executable, pwsh's
-    # native-argument-passing left both variables un-interpolated, silently misdirecting every coverage report (unlike Windows
-    # PowerShell 5.1, which Azure Pipelines used, where this same pattern happened to interpolate correctly).
-    $msbuildProperties = "AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter=testhost|AltCover|Microsoft|protobuf|Humanizer|GraphQL|StructuredLogger|Test,AltCoverAttributeFilter=ExcludeFromCodeCoverage,AltCoverReport=$SourcesDirectory/Coverage/$ProjectNameLiteral.xml"
-    dotnet test $ProjectPath --configuration $BuildConfiguration --results-directory "$SourcesDirectory\TestResults" -l trx --no-build --no-restore --filter "TestCategory!=NoWindows" "/p:$msbuildProperties"
+    # Built as its own variable and passed as a single quoted argument. Interpolating $SourcesDirectory/$ProjectNameLiteral directly inside an unquoted /p:Key=Val,...
+    # token broke under pwsh's native-argument-passing to dotnet, silently.
+    $MsbuildProperties = "AltCover=true,AltCoverForce=true,AltCoverVisibleBranches=true,AltCoverAssemblyFilter=testhost|AltCover|Microsoft|protobuf|Humanizer|GraphQL|StructuredLogger|Test,AltCoverAttributeFilter=ExcludeFromCodeCoverage,AltCoverReport=$SourcesDirectory/Coverage/$ProjectNameLiteral.xml"
+    dotnet test $ProjectPath --configuration $BuildConfiguration --results-directory "$SourcesDirectory\TestResults" -l trx --no-build --no-restore --filter "TestCategory!=NoWindows" "/p:$MsbuildProperties"
     Test-ExitCode "ERROR: Unit tests for '$ProjectPath' FAILED."
 }
 


### PR DESCRIPTION
## Summary
Part of [NET-2037](https://sonarsource.atlassian.net/browse/NET-2037) (Azure DevOps CI migration to GH).

Final review pass on `feature/GHA` before merging it to `master`. Fixes regressions introduced by the Azure Pipelines → GitHub Actions migration:

- **SonarCloud Quality Gate enforcement** was dropped: the old `SonarCloudPublish@3` Azure task polled and failed the build on a failing Quality Gate; no equivalent existed post-migration since `sonar.qualitygate.wait` was never set on the scanner's `begin` step, so a failing QG no longer failed CI.
- Restores the raw OpenCover **coverage report as a downloadable CI artifact**, matching the deleted `PublishBuildArtifacts@1` task's `CoverageReport` publish.
- **Found while wiring up the artifact upload above**: `scripts/run-unit-tests.ps1` has been silently writing every coverage report to the wrong path for the entire migration. `$SourcesDirectory`/`$ProjectNameLiteral` were embedded inside an unquoted `/p:Key=Val,...` token passed straight to the `dotnet` native executable; under `pwsh`'s native-argument-passing this leaves both variables un-interpolated (confirmed empirically — AltCover reported writing to a literal `...\$SourcesDirectory\Coverage\$ProjectNameLiteral...` path), unlike Windows PowerShell 5.1 (what Azure Pipelines used), where this same pattern happened to interpolate correctly. Net effect: `sonar.cs.opencover.reportsPaths` has likely been matching zero files since the migration, so **SonarCloud's coverage numbers for this repo have probably been stale/empty this whole time**, silently. Fixed by building the property list as its own string first, then passing it as a single quoted argument — verified locally with `pwsh` that AltCover now correctly writes to `<repo>\Coverage\...` instead.

## Known gaps not addressed in this PR
Found during review but out of scope here — flagging for the team to decide on separately:
- **`AutomaticBaseBranchDetectionTests.TryGetValue_Failure`** doesn't clear `GITHUB_BASE_REF`, unlike the parallel fix applied elsewhere in this migration. Since `ci.yml`'s UT jobs trigger on `pull_request`, where GitHub Actions genuinely sets `GITHUB_BASE_REF`, this test is likely to fail on PR-triggered runs. A fix was drafted but pulled from this PR pending further discussion on scope.
- GitHub's `schedule:` trigger only ever runs off the default branch (`master`); Azure's old nightly schedule also explicitly covered `branch-*` maintenance/LTA branches. Those branches now silently get no nightly build. Needs a real design (e.g. a master-triggered dispatcher that fans out to `branch-*` via `workflow_dispatch`), not a quick fix.
- `uts_macos`/`its_macos` no longer run on ordinary PRs (only release-branch-like refs or `workflow_dispatch`), unlike the old Azure default of running macOS coverage on every PR. This looks like a deliberate, documented cost tradeoff (GitHub-hosted macOS runners are ~10x the cost of Linux, per the PRs that introduced the gating) rather than an oversight, but worth the team explicitly re-confirming it's still acceptable now that this is merging to master.

## Test plan
- [x] Verified locally with `pwsh`: `Run-Tests-With-Coverage` now writes to `<repo>\Coverage\<Project>.<tfm>.xml` instead of a bogus `...\$SourcesDirectory\Coverage\$ProjectNameLiteral...` path
- [ ] CI green on this PR (validates the Quality Gate wait doesn't introduce a false failure, and the coverage artifact uploads correctly end-to-end on the actual runner)

[NET-2037]: https://sonarsource.atlassian.net/browse/NET-2037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ