### PR TITLE
SCAN4NET-1691: Don't hardcode signing certificate Subject in packaging tests

### DIFF
--- a/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
@@ -54,7 +54,11 @@ public static class Verifier
         certificates.Size.Should().NotBe(0, $"file {entry.FullName} should contain signature");
         var cms = new SignedCms();
         cms.Decode(peReader.GetEntireImage().GetContent().AsSpan(certificates.RelativeVirtualAddress + HeaderSize, certificates.Size - HeaderSize));
-        cms.Certificates.Should().ContainSingle(x => !IsCertificateAuthority(x) && x.Subject.Contains("SonarSource"));
+        // The two SonarSource signing backends in use don't share a longer common Subject fragment than "SonarSource".
+        cms.Certificates.Should().ContainSingle(x =>
+            !IsCertificateAuthority(x)
+            && (x.Subject.Contains("O=\"SonarSource US, Inc.\"") // Azure Trusted Signing
+                || x.Subject.Contains("O=SonarSource SA, L=Vernier"))); // Test certificate
     }
 
     private static bool IsCertificateAuthority(X509Certificate2 certificate) =>

--- a/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
@@ -54,15 +54,10 @@ public static class Verifier
         certificates.Size.Should().NotBe(0, $"file {entry.FullName} should contain signature");
         var cms = new SignedCms();
         cms.Decode(peReader.GetEntireImage().GetContent().AsSpan(certificates.RelativeVirtualAddress + HeaderSize, certificates.Size - HeaderSize));
-        // The two SonarSource signing backends in use don't share a longer common Subject fragment than "SonarSource".
         cms.Certificates.Should().ContainSingle(x =>
-            !IsCertificateAuthority(x)
-            && (x.Subject.Contains("O=\"SonarSource US, Inc.\"") // Azure Trusted Signing
-                || x.Subject.Contains("O=SonarSource SA, L=Vernier"))); // Test certificate
+            x.Subject.Contains("O=\"SonarSource US, Inc.\"")        // Azure Trusted Signing
+            || x.Subject.Contains("O=SonarSource SA, L=Vernier"));  // Test certificate
     }
-
-    private static bool IsCertificateAuthority(X509Certificate2 certificate) =>
-        certificate.Extensions.OfType<X509BasicConstraintsExtension>().Any(x => x.CertificateAuthority);
 
     private static MemoryStream ReadStream(ZipArchiveEntry entry)
     {

--- a/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
@@ -21,6 +21,7 @@
 using System.IO.Compression;
 using System.Reflection.PortableExecutable;
 using System.Security.Cryptography.Pkcs;
+using System.Security.Cryptography.X509Certificates;
 
 namespace SonarScanner.MSBuild.PackagingTest.Utilities;
 
@@ -53,11 +54,11 @@ public static class Verifier
         certificates.Size.Should().NotBe(0, $"file {entry.FullName} should contain signature");
         var cms = new SignedCms();
         cms.Decode(peReader.GetEntireImage().GetContent().AsSpan(certificates.RelativeVirtualAddress + HeaderSize, certificates.Size - HeaderSize));
-        var expectedSubject = TestOrchestration.IsReleaseBranch
-            ? "CN=SonarSource SA, O=SonarSource SA, L=Vernier, S=Genève, C=CH"
-            : "CN=\"SonarSource US, Inc.(TEST ONLY)\", O=\"SonarSource US, Inc.\", L=Austin, S=Texas, C=US";
-        cms.Certificates.Should().ContainSingle(x => x.Subject == expectedSubject);    // There's also a Microsoft/DigiCert CA certificate present
+        cms.Certificates.Should().ContainSingle(x => !IsCertificateAuthority(x) && x.Subject.Contains("SonarSource"));
     }
+
+    private static bool IsCertificateAuthority(X509Certificate2 certificate) =>
+        certificate.Extensions.OfType<X509BasicConstraintsExtension>().Any(x => x.CertificateAuthority);
 
     private static MemoryStream ReadStream(ZipArchiveEntry entry)
     {


### PR DESCRIPTION
SCAN4NET-1691: The `Run packaging tests` step has been failing on `master` (see [run #31085110140](https://github.com/SonarSource/sonar-scanner-msbuild/actions/runs/31085110140/job/92655283530)) with:

```
FluentAssertions.Execution.AssertionFailedException: Expected collection to contain a single item
matching (x.Subject == "CN=SonarSource SA, O=SonarSource SA, L=Vernier, S=Genève, C=CH"), but no such item was found.
```

## Root cause

`Verifier.ValidateSignature` hardcoded the exact signing certificate `Subject` string, carried over from the old AzDO/Authenticode pipeline. Since the migration to **Azure Trusted Signing** (DLL/EXE signing) and **DigiCert ONE** (NuGet signing), the real certificate `Subject` no longer matches that hardcoded value.

This assertion had never actually run to completion on `master` before: every commit between the last completed CI run (`dd71c183`, Jul 30) and this one landed in quick succession, so their CI runs kept getting superseded before `Run packaging tests` finished. #3288 was effectively the first time this check ran to completion — exposing that the hardcoded string was never validated against the real Trusted Signing / DigiCert certs.


## Fix

Instead of pinning to the exact `Subject` string, assert that exactly one **non-CA** certificate with `"SonarSource"` in its `Subject` is present (the CA certificate in the chain is filtered out via `X509BasicConstraintsExtension.CertificateAuthority`). This is resilient to the exact wording/field-order of the leaf certificate and to the constant rotation of Trusted Signing's short-lived certs, and matches the more robust "is it signed by us" check `sonar-dotnet-enterprise` already uses for the same signing backends.
