### PR TITLE
SCAN4NET-1696 Reconcile uts_macos/its_macos trigger conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
     name: UTs macOS
     needs: [version, build]
     runs-on: macos-latest-xlarge
-    if: needs.version.outputs.IS_RELEASE_BRANCH == 'true'
+    if: needs.version.outputs.IS_RELEASE_BRANCH == 'true' || startsWith(github.ref_name, 'feature/') || github.event_name == 'workflow_dispatch'
     permissions:
       id-token: write
       contents: read
@@ -347,8 +347,8 @@ jobs:
 
   its_macos:
     name: ITs macOS (${{ matrix.scenario }})
-    needs: build
-    if: github.ref_name == 'master' || startsWith(github.ref_name, 'branch-') || startsWith(github.ref_name, 'feature/') || github.event_name == 'workflow_dispatch'
+    needs: [version, build]
+    if: needs.version.outputs.IS_RELEASE_BRANCH == 'true' || startsWith(github.ref_name, 'feature/') || github.event_name == 'workflow_dispatch'
     runs-on: macos-latest-xlarge
     permissions:
       id-token: write


### PR DESCRIPTION
## What
uts_macos and its_macos are the only two `ci.yml` jobs gated behind an `if:` condition — every other job always runs. The two conditions were written independently in #3277 and #3284 and had drifted apart.

## Why
- `uts_macos` only ran on `master`/`branch-*`.
- `its_macos` additionally ran on `feature/*` pushes and `workflow_dispatch`.

That meant a feature-branch push or manual dispatch could run the pricier macOS ITs while silently skipping the cheaper macOS UTs — backwards from what you'd want.

Widened `uts_macos`'s condition to match `its_macos`, and had both reuse the shared `needs.version.outputs.IS_RELEASE_BRANCH` output instead of `its_macos` hand-rolling its own copy of the `master`/`branch-*` check.

## Test plan
- [ ] CI green on this PR (both macOS jobs should run, since PR heads aren't `feature/*`/`master`/`branch-*` — actually neither will trigger on a PR event; verify via `workflow_dispatch` or by observing behavior on `feature/*`/master pushes going forward)