### PR TITLE
SCAN4NET-1698 Fix ITs: Update Node.js version from 20 to 24

### DIFF
--- a/.github/actions/its-unix/action.yml
+++ b/.github/actions/its-unix/action.yml
@@ -34,7 +34,7 @@ runs:
           java temurin-21
           maven 3.9.15
           dotnet 10.0.100 9 8
-          node 20
+          node 22
 
     - name: Download Binaries artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/actions/its-unix/action.yml
+++ b/.github/actions/its-unix/action.yml
@@ -34,7 +34,7 @@ runs:
           java temurin-21
           maven 3.9.15
           dotnet 10.0.100 9 8
-          node 22
+          node 24
 
     - name: Download Binaries artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD Configuration:**
    - Updated Node.js version from `20` to `24` in unix ITs action configuration

<sub>This will update automatically on new commits.</sub>