### PR TITLE
SCAN4NET-1718 Verify that NuGet package is signed

### DIFF
--- a/Tests/SonarScanner.MSBuild.PackagingTest/ChocolateyTest.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/ChocolateyTest.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.Drawing.Drawing2D;
 using System.Security.Cryptography;
 
 namespace SonarScanner.MSBuild.PackagingTest;
@@ -32,21 +31,19 @@ public class ChocolateyTest
 
     [TestMethod]
     public void ValidateFileList_Net() =>
-        Verifier.UnzippedFileList("Chocolatey", "sonarscanner-net.*.nupkg").Where(x => !x.StartsWith("package/services/metadata/core-properties/")).Should().BeEquivalentTo([
+        Verifier.UnzippedFileList("Chocolatey", "sonarscanner-net.*.nupkg").Where(x => !x.StartsWith("package/services/metadata/core-properties/")).Should().BeEquivalentTo(
             "[Content_Types].xml",
             "sonarscanner-net.nuspec",
             "_rels/.rels",
-            "tools/chocolateyInstall.ps1",
-        ]);
+            "tools/chocolateyInstall.ps1");
 
     [TestMethod]
     public void ValidateFileList_NetFramework() =>
-        Verifier.UnzippedFileList("Chocolatey", "sonarscanner-net-framework.*.nupkg").Where(x => !x.StartsWith("package/services/metadata/core-properties/")).Should().BeEquivalentTo([
+        Verifier.UnzippedFileList("Chocolatey", "sonarscanner-net-framework.*.nupkg").Where(x => !x.StartsWith("package/services/metadata/core-properties/")).Should().BeEquivalentTo(
             "[Content_Types].xml",
             "sonarscanner-net-framework.nuspec",
             "_rels/.rels",
-            "tools/chocolateyInstall.ps1",
-        ]);
+            "tools/chocolateyInstall.ps1");
 
     [TestMethod]
     [DataRow("net")]

--- a/Tests/SonarScanner.MSBuild.PackagingTest/NuGetTest.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/NuGetTest.cs
@@ -59,17 +59,25 @@ public class NuGetTest
             ]));
 
     [TestMethod]
-    public void ValidateSignatures()
+    public void ValidateDllSignatures()
     {
         using var archive = Verifier.UnzipFile("NuGet", "dotnet-sonarscanner.*.nupkg");
         var dlls = archive.Entries.Where(Verifier.IsSonarBinary).ToArray();
         dlls.Should().HaveCount(7);
         foreach (var dll in dlls)
         {
-            Verifier.ValidateSignature(dll);
+            Verifier.ValidateDllSignature(dll);
         }
     }
 
+    [TestMethod]
+    public void NuGetPackage_IsSigned()
+    {
+        TestOrchestration.RequireReleaseBranch();
+        using var archive = Verifier.UnzipFile("NuGet", "dotnet-sonarscanner.*.nupkg");
+        Verifier.ValidatePackageSignature(archive);
+    }
+
     private static string[] NuGetSignatureFiles() =>
-        TestOrchestration.IsReleaseBranch ? [".signature.p7s"] : [];
+        TestOrchestration.IsReleaseBranch ? [Verifier.PackageSignatureEntryName] : [];
 }

--- a/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/TestOrchestration.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/TestOrchestration.cs
@@ -34,4 +34,12 @@ public static class TestOrchestration
             Assert.Inconclusive("This test must run on the CI environment, after the signing.");
         }
     }
+
+    public static void RequireReleaseBranch()
+    {
+        if (!IsReleaseBranch)
+        {
+            Assert.Inconclusive("This test must run on a release branch, after the package has been signed.");
+        }
+    }
 }

--- a/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
@@ -21,7 +21,6 @@
 using System.IO.Compression;
 using System.Reflection.PortableExecutable;
 using System.Security.Cryptography.Pkcs;
-using System.Security.Cryptography.X509Certificates;
 
 namespace SonarScanner.MSBuild.PackagingTest.Utilities;
 
@@ -38,7 +37,7 @@ public static class Verifier
 
     public static string[] UnzippedFileList(string directoryName, string pattern)
     {
-        using var archive = Verifier.UnzipFile(directoryName, pattern);
+        using var archive = UnzipFile(directoryName, pattern);
         return archive.Entries.Select(x => x.FullName).ToArray();
     }
 

--- a/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
@@ -20,12 +20,15 @@
 
 using System.IO.Compression;
 using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.Pkcs;
 
 namespace SonarScanner.MSBuild.PackagingTest.Utilities;
 
 public static class Verifier
 {
+    public const string PackageSignatureEntryName = ".signature.p7s";
+
     private const int HeaderSize = 8; // WIN_CERTIFICATE header: dwLength(4) + wRevision(2) + wCertificateType(2) = 8 bytes, followed by the PKCS#7 blob
 
     public static ZipArchive UnzipFile(string directoryName, string pattern)
@@ -45,25 +48,36 @@ public static class Verifier
         entry.Name.StartsWith("Sonar", StringComparison.OrdinalIgnoreCase)
         && (entry.Name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || entry.Name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
 
-    public static void ValidateSignature(ZipArchiveEntry entry)
+    public static void ValidateDllSignature(ZipArchiveEntry entry)
     {
-        using var stream = ReadStream(entry);
-        using var peReader = new PEReader(stream);
+        using var peReader = new PEReader(ImmutableCollectionsMarshal.AsImmutableArray(ReadBytes(entry)));
         var certificates = peReader.PEHeaders.PEHeader.CertificateTableDirectory;
         certificates.Size.Should().NotBe(0, $"file {entry.FullName} should contain signature");
         var cms = new SignedCms();
         cms.Decode(peReader.GetEntireImage().GetContent().AsSpan(certificates.RelativeVirtualAddress + HeaderSize, certificates.Size - HeaderSize));
-        cms.Certificates.Should().ContainSingle(x =>
-            x.Subject.Contains("O=\"SonarSource US, Inc.\"")        // Azure Trusted Signing
-            || x.Subject.Contains("O=SonarSource SA, L=Vernier"));  // Test certificate
+        ValidateSignerCertificate(cms, entry.FullName);
     }
 
-    private static MemoryStream ReadStream(ZipArchiveEntry entry)
+    public static void ValidatePackageSignature(ZipArchive archive)
     {
-        var contentStream = new MemoryStream();
+        var entry = archive.GetEntry(PackageSignatureEntryName);
+        entry.Should().NotBeNull($"the package should contain the '{PackageSignatureEntryName}' entry");
+        var cms = new SignedCms();
+        cms.Decode(ReadBytes(entry));
+        ValidateSignerCertificate(cms, entry.FullName);
+    }
+
+    private static void ValidateSignerCertificate(SignedCms cms, string entryName) =>
+        cms.Certificates.Should().ContainSingle(
+            x => x.Subject.Contains("O=\"SonarSource US, Inc.\"")          // Azure Trusted Signing (release)
+                    || x.Subject.Contains("O=SonarSource SA, L=Vernier"),  // Test certificate (PR builds)
+            $"'{entryName}' should be signed with a SonarSource certificate.");
+
+    private static byte[] ReadBytes(ZipArchiveEntry entry)
+    {
+        var buffer = new byte[entry.Length];
         using var entryStream = entry.Open();
-        entryStream.CopyTo(contentStream);
-        contentStream.Position = 0;
-        return contentStream;
+        entryStream.ReadExactly(buffer);
+        return buffer;
     }
 }

--- a/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/Utilities/Verifier.cs
@@ -69,8 +69,9 @@ public static class Verifier
 
     private static void ValidateSignerCertificate(SignedCms cms, string entryName) =>
         cms.Certificates.Should().ContainSingle(
-            x => x.Subject.Contains("O=\"SonarSource US, Inc.\"")          // Azure Trusted Signing (release)
-                    || x.Subject.Contains("O=SonarSource SA, L=Vernier"),  // Test certificate (PR builds)
+            x => x.Subject == """CN="SonarSource US, Inc.", O="SonarSource US, Inc.", L=Austin, S=Texas, C=US"""                   // Azure Trusted Signing (release)
+                    || x.Subject == """CN="SonarSource US, Inc.(TEST ONLY)", O="SonarSource US, Inc.", L=Austin, S=Texas, C=US"""  // Azure Trusted Signing (test, PR builds)
+                    || x.Subject == "CN=SonarSource SA, O=SonarSource SA, L=Vernier, S=Genève, C=CH",                              // NuGet package signature (DigiCert-chained release only)
             $"'{entryName}' should be signed with a SonarSource certificate.");
 
     private static byte[] ReadBytes(ZipArchiveEntry entry)

--- a/Tests/SonarScanner.MSBuild.PackagingTest/ZipTest.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/ZipTest.cs
@@ -295,7 +295,7 @@ public class ZipTest
         dlls.Should().HaveCount(expectedFileCount);
         foreach (var dll in dlls)
         {
-            Verifier.ValidateSignature(dll);
+            Verifier.ValidateDllSignature(dll);
         }
     }
 }

--- a/Tests/SonarScanner.MSBuild.PackagingTest/ZipTest.cs
+++ b/Tests/SonarScanner.MSBuild.PackagingTest/ZipTest.cs
@@ -29,7 +29,7 @@ public class ZipTest
 
     [TestMethod]
     public void ValidateFileList_Net() =>
-        Verifier.UnzippedFileList(null, "sonar-scanner-*-net.zip").Should().BeEquivalentTo([
+        Verifier.UnzippedFileList(null, "sonar-scanner-*-net.zip").Should().BeEquivalentTo(
             "Google.Protobuf.dll",
             "ICSharpCode.SharpZipLib.dll",
             "Microsoft.CodeCoverage.IO.dll",
@@ -52,12 +52,11 @@ public class ZipTest
             "Licenses/THIRD_PARTY_LICENSES/Google.Protobuf-LICENSE.txt",
             "Licenses/THIRD_PARTY_LICENSES/Microsoft.CodeCoverage.IO-LICENSE.txt",
             "Licenses/THIRD_PARTY_LICENSES/Newtonsoft.Json-LICENSE.txt",
-            "Licenses/THIRD_PARTY_LICENSES/SharpZipLib-LICENSE.txt"
-        ]);
+            "Licenses/THIRD_PARTY_LICENSES/SharpZipLib-LICENSE.txt");
 
     [TestMethod]
     public void ValidateFileList_NetFramework() =>
-        Verifier.UnzippedFileList(null, "sonar-scanner-*-net-framework.zip").Should().BeEquivalentTo([
+        Verifier.UnzippedFileList(null, "sonar-scanner-*-net-framework.zip").Should().BeEquivalentTo(
             "Google.Protobuf.dll",
             "ICSharpCode.SharpZipLib.dll",
             "Microsoft.CodeCoverage.IO.dll",
@@ -284,8 +283,7 @@ public class ZipTest
             "Licenses/THIRD_PARTY_LICENSES/System.Xml.XmlDocument-LICENSE.txt",
             "Licenses/THIRD_PARTY_LICENSES/System.Xml.XmlSerializer-LICENSE.txt",
             "Licenses/THIRD_PARTY_LICENSES/System.Xml.XPath-LICENSE.txt",
-            "Licenses/THIRD_PARTY_LICENSES/System.Xml.XPath.XDocument-LICENSE.txt",
-        ]);
+            "Licenses/THIRD_PARTY_LICENSES/System.Xml.XPath.XDocument-LICENSE.txt");
 
     [TestMethod]
     [DataRow("sonar-scanner-*-net.zip", 7)]             // 7x dll


### PR DESCRIPTION
----
## Summary by Gitar

- **Tests:**
    - Added `NuGetPackage_IsSigned` test to verify the NuGet package signature in `NuGetTest.cs`
    - Updated signature verification helpers in `Verifier.cs` to validate package-level `.signature.p7s` entries

<sub>This will update automatically on new commits.</sub>