### PR TITLE
SCAN4NET-1740 Remove unsupported SQ versions from ITs

### DIFF
--- a/.github/workflows/its-windows.yml
+++ b/.github/workflows/its-windows.yml
@@ -24,52 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [LTA-89, LTA-99, LTA-2025-1, LTA-2025-4, LTA-2026-1, LATEST_RELEASE, DEV_MsBuild15, DEV_MsBuild16, DEV_MsBuild17, DEV_MsBuild18, DEV_Community, Cloud, Others]
+        scenario: [ LTA-2025-1, LTA-2025-4, LTA-2026-1, LATEST_RELEASE, DEV_MsBuild15, DEV_MsBuild16, DEV_MsBuild17, DEV_MsBuild18, DEV_Community, Cloud, Others ]
         include:
-          - scenario: LTA-89
-            sqVersion: "LATEST_RELEASE[8.9]"
-            testInclude: "**/sonarqube/*"
-            msbuildPathVar: MSBUILD_18_PATH
-            jdkHomeVar: JAVA_HOME_17_X64
-            cfamilyVersion: "6.20.5.49286"          # Bundled version with SQ 8.9
-            cssVersion: "1.4.2.2002"                # Bundled version with SQ 8.9
-            dotnetVersion: "8.22.0.31243"           # Bundled version with SQ 8.9
-            dreVersion: "NONE"                      # No release before 2026.1
-            goVersion: "1.8.3.2219"                 # Bundled version with SQ 8.9
-            goEnterpriseVersion: "NONE"             # DRE Dependency
-            goGroupId: org.sonarsource.slang
-            iacEnterpriseVersion: "NONE"            # Not present until LTA-2025
-            javaVersion: "NONE"                     # Not required in our ITs for SQ 8.9
-            javascriptVersion: "7.4.4.15624"        # Bundled version with SQ 8.9
-            phpVersion: "3.17.0.7439"               # Bundled version with SQ 8.9
-            plsqlVersion: "3.6.1.3873"              # Bundled version with SQ 8.9
-            pythonVersion: "3.4.1.8066"             # Bundled version with SQ 8.9
-            rubyVersion: "NONE"                     # DRE Dependency
-            textVersion: "NONE"                     # Not release before SQ 9.9, the plug-in should not be loaded
-            tsqlVersion: "1.5.1.4340"               # Bundled version with SQ 8.9
-            xmlVersion: "2.2.0.2973"                # Bundled version with SQ 8.9
-          - scenario: LTA-99
-            sqVersion: "LATEST_RELEASE[9.9]"
-            testInclude: "**/sonarqube/*"
-            msbuildPathVar: MSBUILD_18_PATH
-            jdkHomeVar: JAVA_HOME_17_X64
-            cfamilyVersion: "6.41.0.60884"          # Bundled version with SQ 9.9
-            dotnetVersion: "8.51.0.59060"           # Bundled version with SQ 9.9
-            dreVersion: "NONE"                      # No release before 2026.1
-            goVersion: "1.11.0.3905"                # Bundled version with SQ 9.9
-            goEnterpriseVersion: "NONE"             # DRE Dependency
-            goGroupId: org.sonarsource.slang
-            iacVersion: "1.11.0.2847"               # Bundled version with SQ 9.9
-            iacEnterpriseVersion: "NONE"            # Not present until LTA-2025
-            javaVersion: "NONE"                     # Not required in our ITs for SQ 9.9
-            javascriptVersion: "9.13.0.20537"       # Bundled version with SQ 9.9
-            phpVersion: "3.27.1.9352"               # Bundled version with SQ 9.9
-            plsqlVersion: "3.8.0.4948"              # Bundled version with SQ 9.9
-            pythonVersion: "3.24.0.10784"           # Bundled version with SQ 9.9
-            rubyVersion: "NONE"                     # DRE Dependency
-            textVersion: "NONE"                     # Not required in our ITs for SQ 9.9
-            tsqlVersion: "1.7.0.5449"               # Bundled version with SQ 9.9
-            xmlVersion: "2.7.0.3820"                # Bundled version with SQ 9.9
           - scenario: LTA-2025-1
             sqVersion: "LATEST_RELEASE[2025.1]"
             testInclude: "**/sonarqube/*"

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ServerTests.java
@@ -88,12 +88,8 @@ public class ServerTests implements BeforeAllCallback, AfterAllCallback {
     addPlugin(orchestrator, "com.sonarsource.go", "sonar-go-enterprise-plugin", "sonar.goplugin-enterprise.version");
     addPlugin(orchestrator, System.getProperty("go.groupid", "org.sonarsource.go"), "sonar-go-plugin", "sonar.goplugin.version");
     addPlugin(orchestrator, "com.sonarsource.dre", "sonar-dre-plugin", "sonar.dreplugin.version");
+    orchestrator.addPlugin(FileLocation.of(customRoslynPlugin().toFile()));
 
-    // DO NOT add any additional plugin loading logic here. Everything must be in the YML
-    if (!version.contains("8.9")) {
-      // The latest version of the sonarqube-roslyn-sdk generates packages that are compatible only with SQ 9.9 and above.
-      orchestrator.addPlugin(FileLocation.of(customRoslynPlugin().toFile()));
-    }
     if (edition != Edition.COMMUNITY) {
       orchestrator.activateLicense();
     }


### PR DESCRIPTION
----
## Summary by Gitar

- **Test updates:**
    - Removed unsupported SonarQube versions from the Windows IT workflow and `ServerTests`.

<sub>This will update automatically on new commits.</sub>