### PR TITLE
SCAN4NET-756 Fail hard for versions below 2025.1 or 25.1

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
@@ -38,28 +38,37 @@ public class SonarQubeWebServerTest
     {
         var context = new Context();
         _ = context.Server;
-        context.Runtime.Logger.Should().HaveInfos("Using SonarQube v9.9.");
+        context.Runtime.Logger.Should().HaveInfos("Using SonarQube v2026.1.");
     }
 
     [TestMethod]
     [DataRow("7.9.0.5545")]
     [DataRow("8.0.0.18670")]
     [DataRow("8.8.9.999")]
-    public void IsServerVersionSupported_FailHard_LogError(string sqVersion)
+    [DataRow("9.9.9.999")]
+    [DataRow("10.9.9.999")]
+    [DataRow("2025.0.9.999")]   // Fake number, as there are no hardfail commercial editions with 2025.x version (yet)
+    public void IsServerVersionSupported_FailHard_CommercialEdition(string sqVersion)
     {
         var context = new Context(sqVersion);
         context.Server.IsServerVersionSupported().Should().BeFalse();
-        context.Runtime.Logger.Should().HaveErrors("SonarQube versions below 8.9 are not supported anymore by the SonarScanner for .NET. Please upgrade your SonarQube version to 8.9 or above or use an older version of the scanner (< 6.0.0), to be able to run the analysis.");
+        context.Runtime.Logger.Should().HaveErrors("SonarQube versions below 2025.1 are not supported anymore by the SonarScanner for .NET. Please upgrade your SonarQube version or use an older version of the scanner.");
     }
 
     [TestMethod]
-    [DataRow("8.9.0.0")]
-    [DataRow("9.0.0.1121")]
-    [DataRow("9.8.9.999")]
-    [DataRow("9.9.0.0")]
-    [DataRow("10.15.0.1121")]
     [DataRow("24.12.0.100206")]
-    [DataRow("2025.0.0.111222")] // There isn't any real release with the new versioning scheme that is out of support yet 2025.0 is a fake version.
+    [DataRow("24.12.1.100206")]
+    public void IsServerVersionSupported_FailHard_CommunityEdition(string sqVersion)
+    {
+        var context = new Context(sqVersion);
+        context.Server.IsServerVersionSupported().Should().BeFalse();
+        context.Runtime.Logger.Should().HaveErrors("SonarQube versions below 25.1 are not supported anymore by the SonarScanner for .NET. Please upgrade your SonarQube version or use an older version of the scanner.");
+    }
+
+    [TestMethod]
+    [DataRow("25.1.0.1121")]
+    [DataRow("25.12.0.9999")]
+    [DataRow("2025.1.8.123366")]
     public void IsServerVersionSupported_OutOfSupport_LogWarning(string sqVersion)
     {
         var context = new Context(sqVersion);
@@ -69,8 +78,13 @@ public class SonarQubeWebServerTest
     }
 
     [TestMethod]
-    [DataRow("25.1.0.102122")]
-    [DataRow("2025.1.0.102418")]
+    [DataRow("26.1.0.111")]
+    [DataRow("27.1.0.111")]
+    [DataRow("28.1.0.111")]
+    [DataRow("2025.4.0.111")]
+    [DataRow("2026.1.0.111")]
+    [DataRow("2027.1.0.111")]
+    [DataRow("2028.1.0.111")]
     public void IsServerVersionSupported_Supported_NoLogs(string sqVersion)
     {
         var context = new Context(sqVersion);
@@ -676,7 +690,7 @@ public class SonarQubeWebServerTest
 
         public SonarQubeWebServer Server => server.Value;
 
-        public Context(string version = "9.9", string organization = null)
+        public Context(string version = "2026.1", string organization = null)
         {
             server = new Lazy<SonarQubeWebServer>(() => new SonarQubeWebServer(WebDownloader, ApiDownloader, new(version), Runtime, organization));
         }

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SolutionKindTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SolutionKindTest.java
@@ -19,14 +19,21 @@
  */
 package com.sonar.it.scanner.msbuild.sonarqube;
 
+import com.sonar.it.scanner.msbuild.utils.AnalysisContext;
+import com.sonar.it.scanner.msbuild.utils.AnalysisResult;
+import com.sonar.it.scanner.msbuild.utils.ContextExtension;
+import com.sonar.it.scanner.msbuild.utils.MSBuildMaxVersion;
+import com.sonar.it.scanner.msbuild.utils.MSBuildMinVersion;
+import com.sonar.it.scanner.msbuild.utils.TestUtils;
+import com.sonar.it.scanner.msbuild.utils.Workload;
+import com.sonar.it.scanner.msbuild.utils.WorkloadPrerequisite;
+import com.sonar.orchestrator.container.Edition;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import com.sonar.it.scanner.msbuild.utils.*;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -202,19 +209,15 @@ class SolutionKindTest {
   }
 
   private void assertUIWarnings(AnalysisResult result) {
-    // AnalysisWarningsSensor was implemented starting from analyzer version 8.39.0.47922 (https://github.com/SonarSource/sonar-dotnet-enterprise/commit/39baabb01799aa1945ac5c80d150f173e6ada45f)
-    // So it's available from SQ 9.9 onwards
     var version = ORCHESTRATOR.getServer().version();
-    if (version.isGreaterThanOrEquals(9, 9)) {
-      var warnings = TestUtils.getAnalysisWarningsTask(ORCHESTRATOR, result.end());
-      assertThat(warnings.getStatus()).isEqualTo(Ce.TaskStatus.SUCCESS);
-      if (version.getMajor() == 9) {
-        assertThat(warnings.getWarningsList())
-          .singleElement()
-          .isEqualTo("You're using an unsupported version of SonarQube. The next major version release of SonarScanner for .NET will not work with this version. Please upgrade to a newer SonarQube version.");
-      } else {
-        assertThat(warnings.getWarningsList()).isEmpty();
-      }
+    var warnings = TestUtils.getAnalysisWarningsTask(ORCHESTRATOR, result.end());
+    assertThat(warnings.getStatus()).isEqualTo(Ce.TaskStatus.SUCCESS);
+    if (ORCHESTRATOR.getServer().getEdition() == Edition.COMMUNITY || version.isGreaterThanOrEquals(2025, 4)) {
+      assertThat(warnings.getWarningsList()).isEmpty();
+    } else {
+      assertThat(warnings.getWarningsList())
+        .singleElement()
+        .isEqualTo("You're using an unsupported version of SonarQube. The next major version release of SonarScanner for .NET will not work with this version. Please upgrade to a newer SonarQube version.");
     }
   }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -287,7 +287,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarQube versions below 8.9 are not supported anymore by the SonarScanner for .NET. Please upgrade your SonarQube version to 8.9 or above or use an older version of the scanner (&lt; 6.0.0), to be able to run the analysis..
+        ///   Looks up a localized string similar to SonarQube versions below {0} are not supported anymore by the SonarScanner for .NET. Please upgrade your SonarQube version or use an older version of the scanner..
         /// </summary>
         internal static string ERR_SonarQubeUnsupported {
             get {

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -355,7 +355,7 @@ Use '/?' or '/h' to see the help message.</value>
     <value>Incremental PR Analysis: Requesting 'prepare_read' from {0}</value>
   </data>
   <data name="ERR_SonarQubeUnsupported" xml:space="preserve">
-    <value>SonarQube versions below 8.9 are not supported anymore by the SonarScanner for .NET. Please upgrade your SonarQube version to 8.9 or above or use an older version of the scanner (&lt; 6.0.0), to be able to run the analysis.</value>
+    <value>SonarQube versions below {0} are not supported anymore by the SonarScanner for .NET. Please upgrade your SonarQube version or use an older version of the scanner.</value>
   </data>
   <data name="MSG_CheckingVersionSupported" xml:space="preserve">
     <value>Checking if the server version is supported...</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
@@ -31,9 +31,6 @@ internal class SonarQubeWebServer : SonarWebServerBase, ISonarWebServer
     private readonly IRuntime runtime;
 
     public override bool SupportsJreProvisioning => serverVersion >= new Version(10, 6);
-    private bool IsLegacyVersionBuild => serverVersion.Major < 11; // Remove this once we fail hard for 2025.1 https://sonarsource.atlassian.net/browse/SCAN4NET-979
-    private bool IsCommunityEdition => !IsLegacyVersionBuild && !IsCommercialEdition;
-    private bool IsCommercialEdition => !IsLegacyVersionBuild && serverVersion.Major >= 2025; // First release with year-based versioning was 2025.1 at 2025-01-23
 
     public SonarQubeWebServer(IDownloader webDownloader, IDownloader apiDownloader, Version serverVersion, IRuntime runtime, string organization)
         : base(webDownloader, apiDownloader, serverVersion, runtime.Logger, organization)
@@ -44,17 +41,25 @@ internal class SonarQubeWebServer : SonarWebServerBase, ISonarWebServer
 
     public bool IsServerVersionSupported()
     {
-        // see also https://github.com/SonarSource/sonar-update-center-properties/blob/master/update-center-source.properties
+        Version failHardBelowVersion;
+        Version warningBelowVersion;
         runtime.LogDebug(Resources.MSG_CheckingVersionSupported);
-        if (IsLegacyVersionBuild && serverVersion < new Version(8, 9))
+        if (serverVersion.Major < 11 || serverVersion.Major >= 2025)    // Commercial editions 8.x, 9.x, 10.x, and 2025.1 onwards
         {
-            runtime.LogError(Resources.ERR_SonarQubeUnsupported);
+            failHardBelowVersion = new Version(2025, 1);
+            warningBelowVersion = new Version(2025, 4);
+        }
+        else // Community Edition 25.1 onwards
+        {
+            failHardBelowVersion = new Version(25, 1);
+            warningBelowVersion = new Version(26, 1);
+        }
+        if (serverVersion < failHardBelowVersion)
+        {
+            runtime.LogError(Resources.ERR_SonarQubeUnsupported, failHardBelowVersion.ToString());
             return false;
         }
-        else if (
-            IsLegacyVersionBuild
-            || (IsCommunityEdition && serverVersion < new Version(25, 1)) // Community release 25.1 from 2025-01-07, first unsupported version 24.12 released 2024-12-02
-            || (IsCommercialEdition && serverVersion < new Version(2025, 1))) // 2025.1 release 2025-01-23, first unsupported version 10.8.1 released 2024-12-16
+        else if (serverVersion < warningBelowVersion)
         {
             runtime.AnalysisWarnings.Log(Resources.WARN_UI_SonarQubeUnsupported);
         }


### PR DESCRIPTION
CI is having some random flaky day

----
## Summary by Gitar

- **Version support:**
    - Updated minimum supported SonarQube versions to fail hard for versions below `2025.1` or `25.1` in `SonarQubeWebServer`

<sub>This will update automatically on new commits.</sub>