### PR TITLE
SCAN4NET-1729 Remove SupportsJreProvisioning flag

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/EngineResolution/EngineResolverTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/EngineResolution/EngineResolverTests.cs
@@ -47,7 +47,6 @@ public class EngineResolverTests
 
     public EngineResolverTests()
     {
-        server.SupportsJreProvisioning.Returns(true);
         args.EngineJarPath.ReturnsNull();
         server.DownloadEngineMetadataAsync().Returns(metadata);
         resolver = new EngineResolver(server, "sonarUserHome", runtime, checksum);
@@ -69,25 +68,6 @@ public class EngineResolverTests
 
         runtime.Telemetry.Should().HaveMessage(TelemetryKeys.ScannerEngineBootstrapping, TelemetryValues.ScannerEngineBootstrapping.Disabled)
             .And.HaveMessage(TelemetryKeys.ScannerEngineDownload, TelemetryValues.ScannerEngineDownload.UserSupplied);
-    }
-
-    [TestMethod]
-    public async Task ResolveEngine_JreProvisioningNotSupported_LogsAndReturnsNull()
-    {
-        server.SupportsJreProvisioning.Returns(false);
-        args.EngineJarPath.ReturnsNull();
-
-        var result = await resolver.ResolvePath(args);
-
-        result.Should().BeNull();
-        await server.DidNotReceive().DownloadEngineMetadataAsync();
-        await server.DidNotReceiveWithAnyArgs().DownloadEngineAsync(null);
-        AssertDebugMessages(
-            "EngineResolver: Resolving Scanner Engine path.",
-            "EngineResolver: Skipping Sonar Engine provisioning because this version of SonarQube does not support it.");
-
-        runtime.Telemetry.Should().HaveMessage(TelemetryKeys.ScannerEngineBootstrapping, TelemetryValues.ScannerEngineBootstrapping.Unsupported)
-            .And.NotHaveKey(TelemetryKeys.ScannerEngineDownload);
     }
 
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreResolverTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/JreResolverTests.cs
@@ -51,7 +51,6 @@ public class JreResolverTests
         provider.AddProperty("sonar.scanner.os", "linux");
         server = Substitute.For<ISonarWebServer>();
         server.DownloadJreMetadataAsync(null, null).ReturnsForAnyArgs(metadata);
-        server.SupportsJreProvisioning.Returns(true);
         runtime = new();
 
         sut = new JreResolver(server, checksum, SonarUserHome, runtime, Substitute.For<UnpackerFactory>(runtime));
@@ -341,20 +340,6 @@ public class JreResolverTests
     }
 
     [TestMethod]
-    public async Task ResolveJrePath_SkipProvisioningOnUnsupportedServers()
-    {
-        server.SupportsJreProvisioning.Returns(false);
-        await sut.ResolvePath(Args());
-
-        runtime.Logger.Should().HaveNoInfos();
-        AssertDebugMessages(
-            "JreResolver: Resolving JRE path.",
-            "JreResolver: Skipping Java runtime environment provisioning because this version of SonarQube does not support it.");
-        runtime.Telemetry.Should().HaveMessage(TelemetryKeys.JreBootstrapping, TelemetryValues.JreBootstrapping.UnsupportedByServer)
-            .And.NotHaveKey(TelemetryKeys.JreDownload);
-    }
-
-    [TestMethod]
     public async Task Args_IsValid_Priority()
     {
         var args = Args();
@@ -363,7 +348,6 @@ public class JreResolverTests
         {
             (Valid: () => args.JavaExePath.Returns(string.Empty), Invalid: () => args.JavaExePath.Returns("path"), Message: Resources.MSG_JreResolver_JavaExePathSet),
             (Valid: () => args.SkipJreProvisioning.Returns(false), Invalid: () => args.SkipJreProvisioning.Returns(true), Message: Resources.MSG_JreResolver_SkipJreProvisioningSet),
-            (Valid: () => server.SupportsJreProvisioning.Returns(true), Invalid: () => server.SupportsJreProvisioning.Returns(false), Message: Resources.MSG_JreResolver_NotSupportedByServer),
             (Valid: () => args.OperatingSystem.Returns("os"), Invalid: () => args.OperatingSystem.Returns(string.Empty), Message: Resources.MSG_JreResolver_OperatingSystemMissing),
             (Valid: () => args.Architecture.Returns("arch"), Invalid: () => args.Architecture.Returns(string.Empty), Message: Resources.MSG_JreResolver_ArchitectureMissing),
         };

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
@@ -175,18 +175,6 @@ public class SonarQubeWebServerTest
     }
 
     [TestMethod]
-    [DataRow("7.9.0.5545", false)]
-    [DataRow("8.0.0.18670", false)]
-    [DataRow("8.8.0.1121", false)]
-    [DataRow("8.9.0.0", false)]
-    [DataRow("9.0.0.1121", false)]
-    [DataRow("10.5.1.90531", false)]
-    [DataRow("10.6.0.92166", true)] // First version with JRE provisioning
-    [DataRow("10.15.0.1121", true)]
-    public void SupportsJreProvisioningVersionSupported(string sqVersion, bool expected) =>
-        new Context(sqVersion).Server.SupportsJreProvisioning.Should().Be(expected);
-
-    [TestMethod]
     [DataRow("someKey", "my org")]
     public async Task DownloadQualityProfile_OrganizationProfile_QualityProfileUrlContainsOrganization(string projectKey, string organization)
     {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
@@ -879,10 +879,6 @@ public class SonarWebServerTest
     }
 
     [TestMethod]
-    public void SupportsJreProvisioning_Defaults_True() =>
-        sut.SupportsJreProvisioning.Should().BeTrue("it defaults to true");
-
-    [TestMethod]
     public async Task DownloadAllLanguages_RequestUrl()
     {
         downloader

--- a/src/SonarScanner.MSBuild.Common/Telemetry/TelemetryValues.cs
+++ b/src/SonarScanner.MSBuild.Common/Telemetry/TelemetryValues.cs
@@ -24,7 +24,6 @@ public static class TelemetryValues
 {
     public static class JreBootstrapping
     {
-        public static readonly string UnsupportedByServer = nameof(UnsupportedByServer);
         public static readonly string UnsupportedNoOS = nameof(UnsupportedNoOS);
         public static readonly string UnsupportedNoArch = nameof(UnsupportedNoArch);
         public static readonly string Enabled = nameof(Enabled);
@@ -41,7 +40,6 @@ public static class TelemetryValues
 
     public static class ScannerEngineBootstrapping
     {
-        public static readonly string Unsupported = nameof(Unsupported);
         public static readonly string Enabled = nameof(Enabled);
         public static readonly string Disabled = nameof(Disabled);
     }

--- a/src/SonarScanner.MSBuild.PreProcessor/EngineResolution/EngineResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/EngineResolution/EngineResolver.cs
@@ -53,12 +53,6 @@ public class EngineResolver : IResolver
             runtime.Telemetry[TelemetryKeys.ScannerEngineDownload] = TelemetryValues.ScannerEngineDownload.UserSupplied;
             return localEngine;
         }
-        if (!server.SupportsJreProvisioning) // JRE and sonar engine provisioning were introduced by the same version of SQ Server
-        {
-            runtime.LogDebug(Resources.MSG_EngineResolver_NotSupportedByServer);
-            runtime.Telemetry[TelemetryKeys.ScannerEngineBootstrapping] = TelemetryValues.ScannerEngineBootstrapping.Unsupported;
-            return null;
-        }
         runtime.Telemetry[TelemetryKeys.ScannerEngineBootstrapping] = TelemetryValues.ScannerEngineBootstrapping.Enabled;
 
         if (await ResolveEnginePath() is { } enginePath)

--- a/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Interfaces/ISonarWebServer.cs
@@ -36,11 +36,6 @@ public interface ISonarWebServer : IDisposable
     Version ServerVersion { get; }
 
     /// <summary>
-    /// Returns <see langword="true"/> if the <see cref="ISonarWebServer"> supports the JRE provisioning API.
-    /// </summary>
-    bool SupportsJreProvisioning { get; }
-
-    /// <summary>
     /// Retrieves rules from the quality profile with the given ID, including their parameters and template keys.
     /// </summary>
     /// <param name="qProfile">Quality profile id.</param>

--- a/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/JreResolution/JreResolver.cs
@@ -110,31 +110,28 @@ public class JreResolver : IResolver
             runtime.Telemetry[TelemetryKeys.JreDownload] = TelemetryValues.JreDownload.UserSupplied;
             return false;
         }
-        if (args.SkipJreProvisioning)
+        else if (args.SkipJreProvisioning)
         {
             runtime.LogDebug(Resources.MSG_JreResolver_SkipJreProvisioningSet);
             runtime.Telemetry[TelemetryKeys.JreBootstrapping] = TelemetryValues.JreBootstrapping.Disabled;
             return false;
         }
-        if (!server.SupportsJreProvisioning)
-        {
-            runtime.LogDebug(Resources.MSG_JreResolver_NotSupportedByServer);
-            runtime.Telemetry[TelemetryKeys.JreBootstrapping] = TelemetryValues.JreBootstrapping.UnsupportedByServer;
-            return false;
-        }
-        if (string.IsNullOrWhiteSpace(args.OperatingSystem))
+        else if (string.IsNullOrWhiteSpace(args.OperatingSystem))
         {
             runtime.LogDebug(Resources.MSG_JreResolver_OperatingSystemMissing);
             runtime.Telemetry[TelemetryKeys.JreBootstrapping] = TelemetryValues.JreBootstrapping.UnsupportedNoOS;
             return false;
         }
-        if (string.IsNullOrWhiteSpace(args.Architecture))
+        else if (string.IsNullOrWhiteSpace(args.Architecture))
         {
             runtime.LogDebug(Resources.MSG_JreResolver_ArchitectureMissing);
             runtime.Telemetry[TelemetryKeys.JreBootstrapping] = TelemetryValues.JreBootstrapping.UnsupportedNoArch;
             return false;
         }
-        runtime.Telemetry[TelemetryKeys.JreBootstrapping] = TelemetryValues.JreBootstrapping.Enabled;
-        return true;
+        else
+        {
+            runtime.Telemetry[TelemetryKeys.JreBootstrapping] = TelemetryValues.JreBootstrapping.Enabled;
+            return true;
+        }
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -650,15 +650,6 @@ namespace SonarScanner.MSBuild.PreProcessor {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to EngineResolver: Skipping Sonar Engine provisioning because this version of SonarQube does not support it..
-        /// </summary>
-        internal static string MSG_EngineResolver_NotSupportedByServer {
-            get {
-                return ResourceManager.GetString("MSG_EngineResolver_NotSupportedByServer", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Using local sonar engine provided by sonar.scanner.engineJarPath={0}.
         /// </summary>
         internal static string MSG_EngineResolver_UsingLocalEngine {
@@ -927,15 +918,6 @@ namespace SonarScanner.MSBuild.PreProcessor {
         internal static string MSG_JreResolver_JavaExePathSet {
             get {
                 return ResourceManager.GetString("MSG_JreResolver_JavaExePathSet", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to JreResolver: Skipping Java runtime environment provisioning because this version of SonarQube does not support it..
-        /// </summary>
-        internal static string MSG_JreResolver_NotSupportedByServer {
-            get {
-                return ResourceManager.GetString("MSG_JreResolver_NotSupportedByServer", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -462,9 +462,6 @@ If you already have a compatible Java version installed, please add either the p
   <data name="ERROR_InvalidScanAllAnalysis" xml:space="preserve">
     <value>The argument 'sonar.scanner.scanAll' has an invalid value. Please ensure it is set to either 'true' or 'false'.</value>
   </data>
-  <data name="MSG_JreResolver_NotSupportedByServer" xml:space="preserve">
-    <value>JreResolver: Skipping Java runtime environment provisioning because this version of SonarQube does not support it.</value>
-  </data>
   <data name="ERROR_SonarSourcesAndTestsNotSupported" xml:space="preserve">
     <value>The arguments 'sonar.sources' and 'sonar.tests' are not supported. Please remove them and invoke the scanner again.</value>
   </data>
@@ -561,9 +558,6 @@ Check the certificates in the truststore file '{1}' specified via the {2} parame
   </data>
   <data name="WARN_EngineMetadataNotRetrieved" xml:space="preserve">
     <value>Sonar Engine Metadata could not be retrieved from {0}.</value>
-  </data>
-  <data name="MSG_EngineResolver_NotSupportedByServer" xml:space="preserve">
-    <value>EngineResolver: Skipping Sonar Engine provisioning because this version of SonarQube does not support it.</value>
   </data>
   <data name="MSG_EngineResolver_MetadataFailure" xml:space="preserve">
     <value>EngineResolver: Metadata could not be retrieved.</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
@@ -30,8 +30,6 @@ internal class SonarQubeWebServer : SonarWebServerBase, ISonarWebServer
 {
     private readonly IRuntime runtime;
 
-    public override bool SupportsJreProvisioning => serverVersion >= new Version(10, 6);
-
     public SonarQubeWebServer(IDownloader webDownloader, IDownloader apiDownloader, Version serverVersion, IRuntime runtime, string organization)
         : base(webDownloader, apiDownloader, serverVersion, runtime.Logger, organization)
     {

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServerBase.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServerBase.cs
@@ -42,7 +42,6 @@ public abstract class SonarWebServerBase : IDisposable
     private bool disposed;
 
     public Version ServerVersion => serverVersion;
-    public virtual bool SupportsJreProvisioning => true;
 
     protected SonarWebServerBase(IDownloader webDownloader, IDownloader apiDownloader, Version serverVersion, ILogger logger, string organization)
     {


### PR DESCRIPTION
----
## Summary by Gitar

- **Code cleanup:**
    - Removed the obsolete `SupportsJreProvisioning` flag and related server support checks from `JreResolver` and `EngineResolver`
    - Cleaned up corresponding unused resource strings and test cases

<sub>This will update automatically on new commits.</sub>