### PR TITLE
SCAN4NET-1730 Remove Analysis-cache availability check

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
@@ -392,12 +392,11 @@ public class SonarQubeWebServerTest
         (await new Context().Server.Invoking(x => x.DownloadCache(null)).Should().ThrowAsync<ArgumentNullException>()).And.ParamName.Should().Be("localSettings");
 
     [TestMethod]
-    [DataRow("9.8", "", "", "Incremental PR analysis is available starting with SonarQube 9.9 or later.")]
-    [DataRow("9.9", "", "", "Incremental PR analysis: ProjectKey parameter was not provided.")]
-    [DataRow("9.9", "BestProject", "", "Incremental PR analysis: Base branch parameter was not provided.")]
-    public async Task DownloadCache_InvalidArguments(string version, string projectKey, string branch, string debugMessage)
+    [DataRow("", "", "Incremental PR analysis: ProjectKey parameter was not provided.")]
+    [DataRow("BestProject", "", "Incremental PR analysis: Base branch parameter was not provided.")]
+    public async Task DownloadCache_InvalidArguments(string projectKey, string branch, string debugMessage)
     {
-        var context = new Context(version);
+        var context = new Context();
         var result = await context.Server.DownloadCache(CreateLocalSettings(projectKey, branch));
 
         result.Should().BeEmpty();

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -790,15 +790,6 @@ namespace SonarScanner.MSBuild.PreProcessor {
         internal static string MSG_GeneratingRulesets {
             get {
                 return ResourceManager.GetString("MSG_GeneratingRulesets", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Incremental PR analysis is available starting with SonarQube 9.9 or later..
-        /// </summary>
-        internal static string MSG_IncrementalPRAnalysisUpdateSonarQube {
-            get {
-                return ResourceManager.GetString("MSG_IncrementalPRAnalysisUpdateSonarQube", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -332,9 +332,6 @@ Use '/?' or '/h' to see the help message.</value>
   </data>
   <data name="MSG_UnchangedFilesStats" xml:space="preserve">
     <value>Incremental PR analysis: {0} files out of {1} are unchanged.</value>
-  </data>
-  <data name="MSG_IncrementalPRAnalysisUpdateSonarQube" xml:space="preserve">
-    <value>Incremental PR analysis is available starting with SonarQube 9.9 or later.</value>
   </data>
   <data name="MSG_Processing_PullRequest_NoCacheBaseUrl" xml:space="preserve">
     <value>Incremental PR analysis: CacheBaseUrl was not successfully retrieved.</value>

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
@@ -99,37 +99,32 @@ internal class SonarQubeWebServer : SonarWebServerBase, ISonarWebServer
 
     public async Task<IList<SensorCacheEntry>> DownloadCache(ProcessedArgs localSettings)
     {
-        var empty = Array.Empty<SensorCacheEntry>();
         _ = localSettings ?? throw new ArgumentNullException(nameof(localSettings));
-
-        // SonarQube cache web API is available starting with v9.9
-        if (ServerVersion.CompareTo(new Version(9, 9)) < 0)
-        {
-            runtime.LogInfo(Resources.MSG_IncrementalPRAnalysisUpdateSonarQube);
-            return empty;
-        }
+        var empty = Array.Empty<SensorCacheEntry>();
         if (string.IsNullOrWhiteSpace(localSettings.ProjectKey))
         {
             runtime.LogInfo(Resources.MSG_Processing_PullRequest_NoProjectKey);
             return empty;
         }
-        if (!TryGetBaseBranch(localSettings, out var branch))
+        else if (TryGetBaseBranch(localSettings, out var branch))
+        {
+            try
+            {
+                runtime.LogInfo(Resources.MSG_DownloadingCache, localSettings.ProjectKey, branch);
+                var uri = WebUtils.EscapedUri("api/analysis_cache/get?project={0}&branch={1}", localSettings.ProjectKey, branch);
+                using var stream = await webDownloader.DownloadStream(uri);
+                return ParseCacheEntries(stream);
+            }
+            catch (Exception e)
+            {
+                runtime.LogWarning(Resources.WARN_IncrementalPRCacheEntryRetrieval_Error, e.Message);
+                runtime.LogDebug(e.ToString());
+                return empty;
+            }
+        }
+        else
         {
             runtime.LogInfo(Resources.MSG_Processing_PullRequest_NoBranch);
-            return empty;
-        }
-
-        try
-        {
-            runtime.LogInfo(Resources.MSG_DownloadingCache, localSettings.ProjectKey, branch);
-            var uri = WebUtils.EscapedUri("api/analysis_cache/get?project={0}&branch={1}", localSettings.ProjectKey, branch);
-            using var stream = await webDownloader.DownloadStream(uri);
-            return ParseCacheEntries(stream);
-        }
-        catch (Exception e)
-        {
-            runtime.LogWarning(Resources.WARN_IncrementalPRCacheEntryRetrieval_Error, e.Message);
-            runtime.LogDebug(e.ToString());
             return empty;
         }
     }


### PR DESCRIPTION
----
## Summary by Gitar

- **Cache updates:**
    - Removed the server version check for SonarQube v9.9 in `SonarQubeWebServer.cs`
    - Cleaned up obsolete resource strings and test data for older versions

<sub>This will update automatically on new commits.</sub>