### PR TITLE
SCAN4NET-1733 Remove legacy pagination

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
@@ -454,9 +454,9 @@ public class SonarQubeWebServerTest
     }
 
     [TestMethod]
-    public async Task DownloadRules_SonarQubeVersion98()
+    public async Task DownloadRules()
     {
-        var context = new Context("9.8");
+        var context = new Context();
         context.WebDownloader
             .Download(new("api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile=qp&p=1", UriKind.Relative))
             .Returns("""
@@ -472,35 +472,6 @@ public class SonarQubeWebServerTest
                             "repo": "csharpsquid",
                             "type": "BUG"
                     }]
-                }
-                """);
-        var rules = await context.Server.DownloadRules("qp");
-
-        rules.Should().ContainSingle();
-        rules[0].RepoKey.Should().Be("csharpsquid");
-        rules[0].RuleKey.Should().Be("S2757");
-        rules[0].InternalKeyOrKey.Should().Be("S2757");
-        rules[0].Parameters.Should().BeNull();
-        rules[0].IsActive.Should().BeFalse();
-    }
-
-    [TestMethod]
-    public async Task DownloadRules_SonarQubeVersion89()
-    {
-        var context = new Context("8.9");
-        context.WebDownloader
-            .Download(new("api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile=qp&p=1", UriKind.Relative))
-            .Returns("""
-                {
-                    "total": 3,
-                    "p": 1,
-                    "ps": 500,
-                    "rules": [
-                        {
-                            "key": "csharpsquid:S2757",
-                            "repo": "csharpsquid",
-                            "type": "BUG"
-                        }]
                 }
                 """);
         var rules = await context.Server.DownloadRules("qp");

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+using Newtonsoft.Json.Linq;
 using SonarScanner.MSBuild.PreProcessor.EngineResolution;
 using SonarScanner.MSBuild.PreProcessor.JreResolution;
 using SonarScanner.MSBuild.PreProcessor.Protobuf;
@@ -912,5 +913,8 @@ public class SonarWebServerTest
         public Task<Stream> DownloadJreAsync(JreMetadata metadata) => throw new NotImplementedException();
 
         public Task<Stream> DownloadEngineAsync(EngineMetadata metadata) => throw new NotImplementedException();
+
+        protected override RuleSearchPaging ParseRuleSearchPaging(JObject json) =>
+            new(json["total"].ToObject<int>(), json["ps"].ToObject<int>()); // Cloud version, Server uses different format
     }
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarCloudWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarCloudWebServer.cs
@@ -21,6 +21,7 @@
 using System.IO.Compression;
 using System.Net.Http;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using SonarScanner.MSBuild.PreProcessor.EngineResolution;
 using SonarScanner.MSBuild.PreProcessor.JreResolution;
 using SonarScanner.MSBuild.PreProcessor.Protobuf;
@@ -120,6 +121,9 @@ internal class SonarCloudWebServer : SonarWebServerBase, ISonarWebServer
         logger.LogDebug(Resources.MSG_EngineDownloadUri, metadata.DownloadUrl);
         return await unauthenticatedClient.GetStreamAsync(metadata.DownloadUrl);
     }
+
+    protected override RuleSearchPaging ParseRuleSearchPaging(JObject json) =>
+        new(json["total"].ToObject<int>(), json["ps"].ToObject<int>());
 
     protected override void Dispose(bool disposing)
     {

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
@@ -152,7 +152,5 @@ internal class SonarQubeWebServer : SonarWebServerBase, ISonarWebServer
         serverVersion.CompareTo(new Version(6, 3)) < 0 ? uri : base.AddOrganization(uri);
 
     protected override RuleSearchPaging ParseRuleSearchPaging(JObject json) =>
-        serverVersion.CompareTo(new Version(9, 8)) < 0
-            ? base.ParseRuleSearchPaging(json)
-            : new(json["paging"]["total"].ToObject<int>(), json["paging"]["pageSize"].ToObject<int>());
+        new(json["paging"]["total"].ToObject<int>(), json["paging"]["pageSize"].ToObject<int>());
 }

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServerBase.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServerBase.cs
@@ -41,6 +41,8 @@ public abstract class SonarWebServerBase : IDisposable
     private readonly string organization;
     private bool disposed;
 
+    protected abstract RuleSearchPaging ParseRuleSearchPaging(JObject json);
+
     public Version ServerVersion => serverVersion;
     public virtual bool SupportsJreProvisioning => true;
 
@@ -235,9 +237,6 @@ public abstract class SonarWebServerBase : IDisposable
         }
         return cacheEntries;
     }
-
-    protected virtual RuleSearchPaging ParseRuleSearchPaging(JObject json) =>
-        new(json["total"].ToObject<int>(), json["ps"].ToObject<int>());
 
     private async Task<IDictionary<string, string>> DownloadComponentProperties(string component)
     {


### PR DESCRIPTION
SQ-C uses the old format.
SQ-S uses the new format.

So the SQ-C was moved from base to the Cloud file, as it is not a common reusable base anymore.