### PR TITLE
SCAN4NET-1742 Fix WebClientDownloaderBuilderTest (Cloudflare status page renamed)

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/WebClientDownloaderBuilderTest.cs
@@ -388,7 +388,7 @@ public partial class WebClientDownloaderBuilderTest
         var result = await client.Download(new("https://www.cloudflarestatus.com/api/v2/status.json"));
 
         // Assert
-        var expected = new { Page = new { Name = "Cloudflare" } };
+        var expected = new { Page = new { Name = "Cloudflare Status" } };
         var converted = JsonConvert.DeserializeAnonymousType(result, expected);
         converted.Should().BeEquivalentTo(expected);
         callbackWasCalled.Should().BeTrue();


### PR DESCRIPTION
## Summary
- `SelfSignedServerCertificate_IgnoredIfServerIsTrusted` asserts on the live response from `https://www.cloudflarestatus.com/api/v2/status.json`, which has been failing on every CI run since Cloudflare renamed the page from "Cloudflare" to "Cloudflare Status".
- Update the expected value to match, restoring the intended coverage (OS-trusted server cert causes the custom truststore to be ignored).

## Test plan
- [ ] CI run passes `UTs Windows and analysis`, `UTs macOS`, `UTs Linux`