### PR TITLE
SCAN4NET-1721 Adjust ITs to support only versions above 2025.1

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/CodeCoverageTest.java
@@ -41,18 +41,13 @@ class CodeCoverageTest {
   void whenRunningOutsideAzureDevops_coverageIsNotImported() {
     try (var buildDirectory = new TempDirectory("junit-CodeCoverage.BuildDirectory.Local-")) {
       var logs = createContextWithCoverage(buildDirectory, ScannerClassifier.NET).runAnalysis().end().getLogs();
-
-      if (ORCHESTRATOR.getServer().version().isGreaterThan(9, 9)) {
-        assertThat(logs).contains(
-          "'C# Tests Coverage Report Import' skipped because of missing configuration requirements.",
-          "Accessed configuration:",
-          "- sonar.cs.dotcover.reportsPaths: <empty>",
-          "- sonar.cs.ncover3.reportsPaths: <empty>",
-          "- sonar.cs.vscoveragexml.reportsPaths: <empty>",
-          "- sonar.cs.opencover.reportsPaths: <empty>");
-      } else {
-        assertThat(logs).contains("C# Tests Coverage Report Import' skipped because one of the required properties is missing");
-      }
+      assertThat(logs).contains(
+        "'C# Tests Coverage Report Import' skipped because of missing configuration requirements.",
+        "Accessed configuration:",
+        "- sonar.cs.dotcover.reportsPaths: <empty>",
+        "- sonar.cs.ncover3.reportsPaths: <empty>",
+        "- sonar.cs.vscoveragexml.reportsPaths: <empty>",
+        "- sonar.cs.opencover.reportsPaths: <empty>");
     }
   }
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/IncrementalPRAnalysisTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/IncrementalPRAnalysisTest.java
@@ -57,19 +57,13 @@ class IncrementalPRAnalysisTest {
     assertThat(unexpectedUnchangedFiles).doesNotExist();
     assertThat(result.getLogs()).contains("Processing analysis cache");
 
-    if (ORCHESTRATOR.getServer().version().isGreaterThanOrEquals(9, 9)) {
-      assertThat(result.getLogs()).contains("Cache data is empty. A full analysis will be performed.");
-    } else {
-      assertThat(result.getLogs()).contains("Incremental PR analysis is available starting with SonarQube 9.9 or later.");
-    }
+    assertThat(result.getLogs()).contains("Cache data is empty. A full analysis will be performed.");
   }
 
   @Test
-  // Public cache API was introduced in 9.9
-  @ServerMinVersion("9.9")
   void withCache_ProducesUnchangedFiles() throws IOException {
     var context = AnalysisContext.forServer("IncrementalPRAnalysis");
-    String baseBranch = TestUtils.getDefaultBranchName(ORCHESTRATOR);
+    String baseBranch = "main";
     context.runAnalysis();  // First analysis to populate the cache
     waitForCacheInitialization(context.projectKey, baseBranch);
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
@@ -45,8 +45,6 @@ import static com.sonar.it.scanner.msbuild.utils.SonarAssertions.assertThat;
 class MultiLanguageTest {
 
   @Test
-  // SonarQube 10.8 changed the way the numbers are reported. To keep the test simple we only run the test on the latest versions.
-  @ServerMinVersion("10.8")
   void bothRoslynLanguages() {
     var context = AnalysisContext.forServer("ConsoleMultiLanguage")
       .setQualityProfile(QualityProfile.CS_S1134)
@@ -68,8 +66,6 @@ class MultiLanguageTest {
 
   @Test
   @EnabledOnOs({OS.WINDOWS, OS.LINUX}) // macOS fails with ERR_SSL_CIPHER_OPERATION_FAILED during npm install - see SCAN4NET-1142
-  // SonarQube 10.8 changed the way the numbers are reported. To keep the test simple we only run the test on the latest versions.
-  @ServerMinVersion("10.8")
   // This test is not supported on versions older than Visual Studio 2026
   @MSBuildMinVersion(18)
   @DisableOnEdition(Edition.COMMUNITY)
@@ -123,35 +119,26 @@ class MultiLanguageTest {
       assertLanguageExists(issues, "php");
       assertLanguageExists(issues, "go");
       assertLanguageExists(issues, "css");
-      if (version.getMajor() != 9) {
-        assertLanguageExists(issues, "typescript");
-      }
-      if (version.isGreaterThan(8, 9)) {
-        // JS test files are picked up
-        assertThat(issues).extracting(Issue::getComponent).contains(context.projectKey + ":frontend/Test.test.js");
-        assertLanguageExists(issues, "terraform");
+      assertLanguageExists(issues, "typescript");
+      // JS test files are picked up
+      assertThat(issues).extracting(Issue::getComponent).contains(context.projectKey + ":frontend/Test.test.js");
+      assertLanguageExists(issues, "terraform");
 
-        // Docker patterns `**/Dockerfile` and `**/Dockerfile.*` are detected; MyDockerfile.production is not.
-        var dockerFiles = new ArrayList<>(List.of(
-          context.projectKey + ":Dockerfile",
-          context.projectKey + ":src/MultiLanguageSupport/Dockerfile",
-          context.projectKey + ":src/MultiLanguageSupport/Dockerfile.production"));
-        if (version.isGreaterThan(9, 9)) {
-          // `**/*.dockerfile` is always detected by scanner but only recognized by the IAC plugin in >9.9
-          dockerFiles.add(context.projectKey + ":src/MultiLanguageSupport/MultiLangSupport.dockerfile");
-        }
-        assertThat(issues).filteredOn(x -> x.getRule().startsWith("docker")).extracting(Issue::getComponent)
-          .contains(dockerFiles.toArray(new String[]{}))
-          .doesNotContain(context.projectKey + ":src/MultiLanguageSupport/MyDockerfile.production");
-      }
-      if (version.isGreaterThan(9, 9)) {
-        assertLanguageExists(issues, "secrets");
-        // `java` is matched by `sonar.java.jvmframeworkconfig.file.patterns`; `sonar.java.file.suffixes` is not supported.
-        assertLanguageExists(issues, "java");
-        assertLanguageExists(issues, "azureresourcemanager");
-        assertLanguageExists(issues, "cloudformation");
-        assertLanguageExists(issues, "ipython");
-      }
+      // Docker patterns `**/Dockerfile` and `**/Dockerfile.*` are detected; MyDockerfile.production is not.
+      var dockerFiles = new ArrayList<>(List.of(
+        context.projectKey + ":Dockerfile",
+        context.projectKey + ":src/MultiLanguageSupport/Dockerfile",
+        context.projectKey + ":src/MultiLanguageSupport/Dockerfile.production"));
+      dockerFiles.add(context.projectKey + ":src/MultiLanguageSupport/MultiLangSupport.dockerfile");
+      assertThat(issues).filteredOn(x -> x.getRule().startsWith("docker")).extracting(Issue::getComponent)
+        .contains(dockerFiles.toArray(new String[]{}))
+        .doesNotContain(context.projectKey + ":src/MultiLanguageSupport/MyDockerfile.production");
+      assertLanguageExists(issues, "secrets");
+      // `java` is matched by `sonar.java.jvmframeworkconfig.file.patterns`; `sonar.java.file.suffixes` is not supported.
+      assertLanguageExists(issues, "java");
+      assertLanguageExists(issues, "azureresourcemanager");
+      assertLanguageExists(issues, "cloudformation");
+      assertLanguageExists(issues, "ipython");
       if (version.isGreaterThan(2026, 1)) {
         assertLanguageExists(issues, "groovydre");
         assertLanguageExists(issues, "powershelldre");
@@ -179,12 +166,9 @@ class MultiLanguageTest {
     context.runAnalysis();
 
     var issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
-    var version = ORCHESTRATOR.getServer().version();
     assertLanguageExists(issues, "csharpsquid");
     assertLanguageExists(issues, "javascript");
-    if (version.isGreaterThan(8, 9)) {
-      assertLanguageExists(issues, "python");
-    }
+    assertLanguageExists(issues, "python");
   }
 
   @Test
@@ -205,24 +189,13 @@ class MultiLanguageTest {
     assertLanguageExists(issues, "javascript");
     assertLanguageExists(issues, "python");
     assertLanguageExists(issues, "php");
-    if (version.isGreaterThan(8, 9)) {
-      assertLanguageExists(issues, "typescript");
-    }
+    assertLanguageExists(issues, "typescript");
     if (version.isGreaterThanOrEquals(2025, 5)) {
       assertLanguageExists(issues, "githubactions");
-    }
-    if (version.getMajor() == 8) {
-      // In version 8.9 css files are handled by a dedicated plugin and node_modules are not filtered in that plugin.
-      // This is because the IT are running without scm support. Normally these files are excluded by the scm ignore settings.
-      assertThat(issues)
-        .filteredOn(x -> x.getRule().startsWith("css") && x.getComponent().contains("/node_modules/"))
-        .isNotEmpty();
     }
   }
 
   @Test
-  // Multi-language unsupported in SQ99
-  @ServerMinVersion("10.0")
   @EnabledOnOs(OS.WINDOWS)
   @DisableOnEdition(Edition.COMMUNITY)
   void nonSdkFormat() {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/MultiLanguageTest.java
@@ -24,7 +24,6 @@ import com.sonar.it.scanner.msbuild.utils.ContextExtension;
 import com.sonar.it.scanner.msbuild.utils.DisableOnEdition;
 import com.sonar.it.scanner.msbuild.utils.MSBuildMinVersion;
 import com.sonar.it.scanner.msbuild.utils.QualityProfile;
-import com.sonar.it.scanner.msbuild.utils.ServerMinVersion;
 import com.sonar.it.scanner.msbuild.utils.TestUtils;
 import com.sonar.it.scanner.msbuild.utils.Timeout;
 import com.sonar.orchestrator.container.Edition;

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ParameterTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ParameterTest.java
@@ -165,12 +165,7 @@ class ParameterTest {
       .setProperty("sonar.tests", "Program.cs");   // If they were passed, it results to double-indexing error.
     context.build.useDotNet();
     context.runAnalysis();
-
-    if (ORCHESTRATOR.getServer().version().isGreaterThan(9, 9)) {
-      assertThat(TestUtils.projectIssues(ORCHESTRATOR, context.projectKey)).hasSize(4);
-    } else {
-      assertThat(TestUtils.projectIssues(ORCHESTRATOR, context.projectKey)).hasSize(3);
-    }
+    assertThat(TestUtils.projectIssues(ORCHESTRATOR, context.projectKey)).hasSize(4);
   }
 
   @ParameterizedTest
@@ -186,7 +181,7 @@ class ParameterTest {
     context.build.useDotNet();
 
     var logs = context.runFailedAnalysis().end().getLogs();
-      assertThat(logs).contains("ERROR: File Program.cs can't be indexed twice. Please check that inclusion/exclusion patterns produce disjoint sets for main and test files");
+    assertThat(logs).contains("ERROR: File Program.cs can't be indexed twice. Please check that inclusion/exclusion patterns produce disjoint sets for main and test files");
   }
 
 

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ProvisioningTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/ProvisioningTest.java
@@ -51,9 +51,6 @@ class ProvisioningTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  // provisioning does not exist before 10.6, and all newer versions support the scanner-engine download. We need to make sure the
-  // combination of JRE cache miss with scanner-cli invocation and scanner-engine download both work as expected
-  @ServerMinVersion("10.6")
   void cacheMiss_DownloadsCache(Boolean useSonarScannerCLI) {
     var userHome = ContextExtension.currentTempDir().resolve(".sonar").toAbsolutePath();
     var context = createContext(userHome);
@@ -69,8 +66,6 @@ class ProvisioningTest {
   }
 
   @Test
-  // provisioning does not exist before 10.6
-  @ServerMinVersion("10.6")
   void cacheHit_ReusesCachedFiles() {
     var userHome = ContextExtension.currentTempDir().resolve(".sonar").toAbsolutePath();
     var context = createContext(userHome);
@@ -86,8 +81,6 @@ class ProvisioningTest {
   }
 
   @Test
-  // provisioning does not exist before 10.6
-  @ServerMinVersion("10.6")
   void scannerEngineJarPathSet_DoesNotDownloadFromServer() throws IOException {
     var userHome = ContextExtension.currentTempDir().resolve(".sonar").toAbsolutePath();
     var context = createContext(userHome);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SQLServerTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SQLServerTest.java
@@ -46,11 +46,7 @@ class SQLServerTest {
     context.runAnalysis();
 
     List<Issue> issues = TestUtils.projectIssues(ORCHESTRATOR, context.projectKey);
-    if (ORCHESTRATOR.getServer().version().isGreaterThan(9, 9)) {
-      assertThat(issues).hasSize(4);
-    } else {
-      assertThat(issues).hasSize(3);
-    }
+    assertThat(issues).hasSize(4);
     var fileKey = context.projectKey + ":Database1/util/SqlStoredProcedure1.cs";
     assertThat(TestUtils.getMeasureAsInteger(context.projectKey, "ncloc", ORCHESTRATOR)).isEqualTo(36);
     assertThat(TestUtils.getMeasureAsInteger(fileKey, "ncloc", ORCHESTRATOR)).isEqualTo(19);

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SolutionKindTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/sonarqube/SolutionKindTest.java
@@ -108,10 +108,7 @@ class SolutionKindTest {
     context.build.addArgument("CSharpAllFlat.sln");
     context.runAnalysis();
     var expectedComponent = new ArrayList<>(List.of(context.projectKey + ":Common.cs"));
-    if (ORCHESTRATOR.getServer().version().isGreaterThan(9, 9)) {
-      // Multilanguage support is enabled and NuGet.Config is also picked up
-      expectedComponent.add(context.projectKey + ":NuGet.Config");
-    }
+    expectedComponent.add(context.projectKey + ":NuGet.Config");
     assertThat(TestUtils.listComponents(ORCHESTRATOR, context.projectKey))
       .extracting(Components.Component::getKey)
       .containsExactlyInAnyOrder(expectedComponent.toArray(new String[]{}));

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/ScannerCommand.java
@@ -148,10 +148,7 @@ public class ScannerCommand extends BaseCommand<ScannerCommand> {
     } else {
       command.addArgument(step.toString());
       if (token != null) {
-        var tokenProperty = orchestrator == null || orchestrator.getServer().version().isGreaterThanOrEquals(10, 0)
-          ? "/d:sonar.token=" + token   // The `sonar.token` property was introduced in SonarQube 10.0
-          : "/d:sonar.login=" + token;  // sonar.login is obsolete
-        command.addArgument(tokenProperty);
+        command.addArgument("/d:sonar.token=" + token);
       }
     }
     if (step == Step.begin) {

--- a/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/utils/TestUtils.java
@@ -128,16 +128,7 @@ public class TestUtils {
       results.addAll(issues.getIssuesList());
       page++;
     } while (results.size() < issues.getPaging().getTotal());
-    if (!orchestrator.getServer().version().isGreaterThan(9, 9)) {
-      // The filtering per component key does not work with SQ 9.9 and below
-      // We get all issues and filter by hand instead
-      results.removeIf(x -> !StringUtils.equalsAny(projectKey, x.getProject(), x.getComponent()));
-    }
     return results;
-  }
-
-  public static String getDefaultBranchName(Orchestrator orchestrator) {
-    return orchestrator.getServer().version().isGreaterThanOrEquals(9, 8) ? "main" : "master";
   }
 
   public static WsClient newWsClient(Orchestrator orchestrator) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Testing:**
    - Removed version checks for SonarQube versions older than 2025.1 in integration tests
    - Simplified `ScannerCommand` to always use `sonar.token` instead of legacy `sonar.login`

<sub>This will update automatically on new commits.</sub>