### PR TITLE
SCAN4NET-1749 Remove the logic that forces Scanner CLI for TFS Classic

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/AnalysisConfigGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/AnalysisConfigGeneratorTests.cs
@@ -702,10 +702,7 @@ public class AnalysisConfigGeneratorTests
         }
     }
 
-    private static ProcessedArgs CreateProcessedArgs(
-        IAnalysisPropertyProvider cmdLineProperties = null,
-        IAnalysisPropertyProvider globalFileProperties = null,
-        IRuntime runtime = null)
+    private static ProcessedArgs CreateProcessedArgs(IAnalysisPropertyProvider cmdLineProperties = null, IAnalysisPropertyProvider globalFileProperties = null, IRuntime runtime = null)
     {
         cmdLineProperties ??= EmptyPropertyProvider.Instance;
         globalFileProperties ??= EmptyPropertyProvider.Instance;

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/AnalysisConfigGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/AnalysisConfigGeneratorTests.cs
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using SonarScanner.MSBuild.Common.TFS;
 using Path = System.IO.Path;
 
 namespace SonarScanner.MSBuild.PreProcessor.AnalysisConfigProcessing.Test;
@@ -142,50 +141,6 @@ public class AnalysisConfigGeneratorTests
         actualConfig.ScanAllAnalysis.Should().BeFalse();
         actualConfig.UseSonarScannerCli.Should().BeTrue();
         AssertExpectedLocalSetting(SonarProperties.Organization, "organization", actualConfig);
-    }
-
-    [TestMethod]
-    public void AnalysisConfGen_LegacyTeamBuildContext_UseScannerCliFallback()
-    {
-        var runtime = new TestRuntime();
-        var analysisDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
-        // Set the build environment to TFS Legacy. This forces the AnalysisConfig.UseSonarScannerCli property to be set to true
-        var settings = BuildSettings.CreateSettingsForTesting(analysisDir, BuildEnvironment.LegacyTeamBuild);
-        var args = CreateProcessedArgs(EmptyPropertyProvider.Instance, EmptyPropertyProvider.Instance, runtime, settings);
-
-        var actualConfig = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "9.9", null, null, null, runtime);
-
-        AssertConfigFileExists(actualConfig);
-        runtime.Logger.Should()
-            .HaveNoErrors()
-            .And.HaveNoWarnings();
-#if NETFRAMEWORK
-        runtime.Logger.Should().HaveDebugs("Falling back to SonarScannerCLI to guarantee TFS Legacy support.");
-        actualConfig.UseSonarScannerCli.Should().BeTrue();
-#else
-        runtime.Logger.Should().NotHaveDebug("Falling back to SonarScannerCLI to guarantee TFS Legacy support.");
-        actualConfig.UseSonarScannerCli.Should().BeFalse();
-#endif
-    }
-
-    [TestMethod]
-    public void AnalysisConfGen_LegacyTeamBuildContext_UserSettingTakesPrecedence()
-    {
-        var runtime = new TestRuntime();
-        var analysisDir = TestUtils.CreateTestSpecificFolderWithSubPaths(TestContext);
-        // Set the build environment to TFS Legacy. This forces the AnalysisConfig.UseSonarScannerCli property to be set to true
-        var settings = BuildSettings.CreateSettingsForTesting(analysisDir, BuildEnvironment.LegacyTeamBuild);
-        // Explicit set sonar.scanner.useSonarScannerCLI argument to false. This overrides the TFS Legacy context which would set it to true.
-        var args = CreateProcessedArgs(new ListPropertiesProvider { { SonarProperties.UseSonarScannerCLI, "false" } }, EmptyPropertyProvider.Instance, runtime, settings);
-
-        var actualConfig = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "9.9", null, null, null, runtime);
-
-        AssertConfigFileExists(actualConfig);
-        runtime.Logger.Should()
-            .HaveNoErrors()
-            .And.HaveNoWarnings()
-            .And.NotHaveDebug("Falling back to SonarScannerCLI to guarantee TFS Legacy support.");
-        actualConfig.UseSonarScannerCli.Should().BeFalse();
     }
 
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/AnalysisConfigGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/AnalysisConfigGeneratorTests.cs
@@ -702,18 +702,15 @@ public class AnalysisConfigGeneratorTests
         }
     }
 
-    private static ProcessedArgs CreateProcessedArgs() =>
-        CreateProcessedArgs(EmptyPropertyProvider.Instance, EmptyPropertyProvider.Instance, new TestRuntime(), null);
-
-    private static ProcessedArgs CreateProcessedArgs(IAnalysisPropertyProvider cmdLineProperties) =>
-        CreateProcessedArgs(cmdLineProperties, EmptyPropertyProvider.Instance, new TestRuntime(), null);
-
     private static ProcessedArgs CreateProcessedArgs(
-        IAnalysisPropertyProvider cmdLineProperties,
-        IAnalysisPropertyProvider globalFileProperties,
-        IRuntime runtime,
-        BuildSettings buildSettings = null) =>
-        new(
+        IAnalysisPropertyProvider cmdLineProperties = null,
+        IAnalysisPropertyProvider globalFileProperties = null,
+        IRuntime runtime = null)
+    {
+        cmdLineProperties ??= EmptyPropertyProvider.Instance;
+        globalFileProperties ??= EmptyPropertyProvider.Instance;
+        runtime ??= new TestRuntime();
+        return new(
             "valid.key",
             "valid.name",
             "1.0",
@@ -722,6 +719,6 @@ public class AnalysisConfigGeneratorTests
             cmdLineProperties,
             globalFileProperties,
             EmptyPropertyProvider.Instance,
-            buildSettings,
             runtime);
+    }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/Processors/TruststorePropertiesProcessorTests.cs
@@ -511,6 +511,5 @@ public class TruststorePropertiesProcessorTests
             cmdLineProvider ?? EmptyPropertyProvider.Instance,
             Substitute.For<IAnalysisPropertyProvider>(),
             EmptyPropertyProvider.Instance,
-            null,
             new TestRuntime { File = fileWrapper ?? Substitute.For<IFileWrapper>() });
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ArgumentProcessorTests.cs
@@ -33,7 +33,7 @@ public class ArgumentProcessorTests
 
     [TestMethod]
     public void PreArgProc_NullRuntimeThrows() =>
-        FluentActions.Invoking(() => ArgumentProcessor.TryProcessArgs(null, null, null)).Should().ThrowExactly<ArgumentNullException>().WithParameterName("runtime");
+        FluentActions.Invoking(() => ArgumentProcessor.TryProcessArgs(null, null)).Should().ThrowExactly<ArgumentNullException>().WithParameterName("runtime");
 
     [TestMethod]
     public void PreArgProc_RequiredArguments_ProcessingSucceeds()
@@ -945,7 +945,7 @@ public class ArgumentProcessorTests
 
     private static void CheckProcessingFails(TestRuntime runtime, params string[] commandLineArgs)
     {
-        var result = ArgumentProcessor.TryProcessArgs(commandLineArgs, null, runtime);
+        var result = ArgumentProcessor.TryProcessArgs(commandLineArgs, runtime);
 
         result.Should().BeNull();
         runtime.Logger.Should().HaveErrors();
@@ -956,7 +956,7 @@ public class ArgumentProcessorTests
 
     private static ProcessedArgs CheckProcessingSucceeds(TestRuntime runtime, params string[] commandLineArgs)
     {
-        var result = ArgumentProcessor.TryProcessArgs(commandLineArgs, null, runtime);
+        var result = ArgumentProcessor.TryProcessArgs(commandLineArgs, runtime);
         result.Should().NotBeNull();
         runtime.Logger.Should().HaveNoErrors();
         return result;

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/CacheProcessorTests.cs
@@ -96,7 +96,7 @@ public class CacheProcessorTests
     {
         var workingDirectory = TestContext.ResultsDirectory;
         using var scope = new WorkingDirectoryScope(workingDirectory);
-        var localSettings = ArgumentProcessor.TryProcessArgs(["/k:key", "/d:sonar.projectBaseDir=Custom"], null, new TestRuntime { Logger = logger });
+        var localSettings = ArgumentProcessor.TryProcessArgs(["/k:key", "/d:sonar.projectBaseDir=Custom"], new TestRuntime { Logger = logger });
         var buildSettings = Substitute.For<IBuildSettings>();
         buildSettings.SourcesDirectory.Returns(@"C:\Sources\Directory");
         buildSettings.SonarScannerWorkingDirectory.Returns(@"C:\SonarScanner\WorkingDirectory");
@@ -273,7 +273,7 @@ public class CacheProcessorTests
     {
         // When CI is run for a PR, AzureDevOps extension sets this to the actual PR analysis of S4NET project.
         using var scope = new EnvironmentVariableScope().SetVariable("SONARQUBE_SCANNER_PARAMS", null);
-        var processedArgs = ArgumentProcessor.TryProcessArgs(commandLineArgs.Split(' '), null, new TestRuntime { Logger = logger });
+        var processedArgs = ArgumentProcessor.TryProcessArgs(commandLineArgs.Split(' '), new TestRuntime { Logger = logger });
         processedArgs.Should().NotBeNull();
         return processedArgs;
     }
@@ -322,10 +322,10 @@ public class CacheProcessorTests
                 var fullFilePath = Path.GetFullPath(CreateFile(Root, relativeFilePath, content, Encoding.UTF8));
                 Paths.Add(fullFilePath);
                 cache.Add(new SensorCacheEntry
-                          {
-                              Key = relativeFilePath,
-                              Data = ByteString.CopyFrom(Sut.ContentHash(fullFilePath))
-                          });
+                {
+                    Key = relativeFilePath,
+                    Data = ByteString.CopyFrom(Sut.ContentHash(fullFilePath))
+                });
             }
             Factory.Server.DownloadCache(null).ReturnsForAnyArgs(cache);
             Sut.PullRequestCacheBasePath.Should().Be(Root, "Cache files must exist on expected path.");

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/LocalJreTruststoreResolverTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/JreResolution/LocalJreTruststoreResolverTests.cs
@@ -323,6 +323,5 @@ public class LocalJreTruststoreResolverTests
             cmdLineProvider ?? EmptyPropertyProvider.Instance,
             Substitute.For<IAnalysisPropertyProvider>(),
             EmptyPropertyProvider.Instance,
-            null,
             runtime with { Logger = new() }); // new logger to avoid log pollution
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
@@ -240,44 +240,6 @@ public partial class PreProcessorTests
             """);
     }
 
-#if NETFRAMEWORK
-
-    [TestMethod]
-    public async Task Execute_EndToEnd_LegacyTFS_UsesScannerCli()
-    {
-        using var context = new Context(TestContext);
-        using (var env = new EnvironmentVariableScope())
-        {
-            env.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "true");
-            env.SetVariable(EnvironmentVariables.BuildUriLegacy, "LegacyBuildUri");
-            context.Factory.ScannerCliResolver.ResolvePath(null).ReturnsForAnyArgs("some/path/to/sonar-scanner");
-
-            (await context.Execute()).Should().BeTrue();
-        }
-        context.AssertDirectoriesCreated();
-        context.AssertDownloadMethodsCalled(properties: 1, allLanguages: 1, qualityProfile: 2, rules: 2);
-        context.AssertAnalysisConfig(2).SonarScannerCliPath.Should().Be("some/path/to/sonar-scanner");
-        await context.Factory.EngineResolver.DidNotReceiveWithAnyArgs().ResolvePath(null);
-    }
-
-    [TestMethod]
-    public async Task Execute_EndToEnd_LegacyTFS_ScannerCliDownloadFails()
-    {
-        using var context = new Context(TestContext);
-        using var env = new EnvironmentVariableScope();
-        env.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "true");
-        env.SetVariable(EnvironmentVariables.BuildUriLegacy, "LegacyBuildUri");
-        context.Factory.ScannerCliResolver.ResolvePath(null).ReturnsForAnyArgs((string)null);
-
-        (await context.Execute()).Should().BeFalse();
-        context.Factory.Runtime.Logger.Should().HaveErrors("""
-            SonarScanner CLI could not be downloaded. Turn on verbose logging to see more details.
-            Make sure 'https://binaries.sonarsource.com/' is reachable or roll back to a previous version of the Scanner (< 11.0).
-            """);
-    }
-
-#endif
-
     [TestMethod]
     public async Task Execute_EndToEnd_EngineNotResolved_FallbackToCli()
     {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -208,7 +208,6 @@ public class PreprocessorObjectFactoryTests
             cmdLineArgs,
             new ListPropertiesProvider(),
             EmptyPropertyProvider.Instance,
-            null,
             runtime);
     }
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
@@ -76,7 +76,6 @@ public class ProcessedArgsTests
                     cmdLineProperties: null,
                     EmptyPropertyProvider.Instance,
                     EmptyPropertyProvider.Instance,
-                    buildSettings: null,
                     runtime))
             .Should().Throw<ArgumentNullException>()
             .WithParameterName("cmdLineProperties");
@@ -93,7 +92,6 @@ public class ProcessedArgsTests
                     EmptyPropertyProvider.Instance,
                     globalFileProperties: null,
                     EmptyPropertyProvider.Instance,
-                    buildSettings: null,
                     runtime))
             .Should().Throw<ArgumentNullException>()
             .WithParameterName("globalFileProperties");
@@ -110,7 +108,6 @@ public class ProcessedArgsTests
                     EmptyPropertyProvider.Instance,
                     EmptyPropertyProvider.Instance,
                     scannerEnvProperties: null,
-                    buildSettings: null,
                     runtime))
             .Should().Throw<ArgumentNullException>()
             .WithParameterName("scannerEnvProperties");
@@ -363,7 +360,6 @@ public class ProcessedArgsTests
             : EmptyPropertyProvider.Instance,
             globalFileProperties: invalidOrganization ? new ListPropertiesProvider([new Property(SonarProperties.Organization, "organization")]) : EmptyPropertyProvider.Instance,
             scannerEnvProperties: new ListPropertiesProvider([new Property(SonarProperties.UserHome, "NotADirectory")]),
-            buildSettings: null,
             runtime);
         runtime.Logger.Errors.Should().HaveCount(errors);
         sut.IsValid.Should().Be(errors == 0);
@@ -494,7 +490,6 @@ public class ProcessedArgsTests
     private ProcessedArgs CreateDefaultArgs(IAnalysisPropertyProvider cmdLineProperties = null,
                                             IAnalysisPropertyProvider globalFileProperties = null,
                                             IAnalysisPropertyProvider scannerEnvProperties = null,
-                                            BuildSettings buildSettings = null,
                                             string key = "key",
                                             string organization = "organization") =>
         new(
@@ -506,7 +501,6 @@ public class ProcessedArgsTests
             cmdLineProperties: cmdLineProperties ?? EmptyPropertyProvider.Instance,
             globalFileProperties: globalFileProperties ?? EmptyPropertyProvider.Instance,
             scannerEnvProperties: scannerEnvProperties ?? EmptyPropertyProvider.Instance,
-            buildSettings: buildSettings,
             runtime);
 
     private static void AssertExpectedValue(string key, string expectedValue, ProcessedArgs args)

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/ProcessedArgsTests.cs
@@ -484,38 +484,6 @@ public class ProcessedArgsTests
         runtime.AnalysisWarnings.Messages.Should().ContainSingle(expectedMessage);
     }
 
-    [TestMethod]
-    public void ProcessedArgs_TfsLegacy_SetUseCliTrue()
-    {
-        using var env = new EnvironmentVariableScope();
-        env.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "true");
-        env.SetVariable(EnvironmentVariables.BuildUriLegacy, "legacy build uri");
-        var sut = CreateDefaultArgs(buildSettings: BuildSettings.GetSettingsFromEnvironment());
-        sut.IsValid.Should().BeTrue();
-#if NETFRAMEWORK
-        sut.UseSonarScannerCli.Should().BeTrue();
-        runtime.Logger.Should().HaveDebugs("Falling back to SonarScannerCLI to guarantee TFS Legacy support.");
-#else
-        sut.UseSonarScannerCli.Should().BeFalse();
-#endif
-        runtime.Logger.Should().HaveNoWarnings()
-            .And.HaveNoErrors();
-    }
-
-    [TestMethod]
-    public void ProcessedArgs_TfsLegacy_SkipCodeCoverage_SetUseCliFalse()
-    {
-        using var env = new EnvironmentVariableScope();
-        env.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "true");
-        env.SetVariable(EnvironmentVariables.BuildUriLegacy, "legacy build uri");
-        env.SetVariable(EnvironmentVariables.SkipLegacyCodeCoverage, "true");
-        var sut = CreateDefaultArgs(buildSettings: BuildSettings.GetSettingsFromEnvironment());
-        sut.IsValid.Should().BeTrue();
-        sut.UseSonarScannerCli.Should().BeFalse();
-        runtime.Logger.Should().HaveNoWarnings()
-            .And.HaveNoErrors();
-    }
-
     private static IEnumerable<object[]> ProcessedArgs_SourcesOrTests_Warning_DataSource() =>
     [
         [new Property(SonarProperties.Sources, "src")],

--- a/src/SonarScanner.MSBuild.PreProcessor/ArgumentProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ArgumentProcessor.cs
@@ -56,7 +56,7 @@ public static class ArgumentProcessor
     /// reports any errors using the logger.
     /// Returns null unless all the properties are valid.
     /// </summary>
-    public static ProcessedArgs TryProcessArgs(IEnumerable<string> commandLineArgs, BuildSettings buildSettings, IRuntime runtime)
+    public static ProcessedArgs TryProcessArgs(IEnumerable<string> commandLineArgs, IRuntime runtime)
     {
         _ = runtime ?? throw new ArgumentNullException(nameof(runtime));
 
@@ -93,7 +93,6 @@ public static class ArgumentProcessor
                 cmdLineProperties,
                 globalFileProperties,
                 scannerEnvProperties,
-                buildSettings,
                 runtime);
 
             if (!processed.IsValid)

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -44,7 +44,7 @@ public class PreProcessor
     {
         runtime.Logger.SuspendOutput(); // Wait for the correct verbosity to be calculated
         var buildSettings = BuildSettings.GetSettingsFromEnvironment();
-        var processedArgs = ArgumentProcessor.TryProcessArgs(args, buildSettings, runtime);
+        var processedArgs = ArgumentProcessor.TryProcessArgs(args, runtime);
 
         if (processedArgs is null)
         {

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -240,15 +240,6 @@ public class ProcessedArgs
         else
         {
             UseSonarScannerCli = false;
-#if NETFRAMEWORK
-            // If the TFS legacy coverage processor is called, we cannot use the scanner engine because it writes information to the properties file,
-            // which would be missing from the ScannerEngineInput.
-            if (buildSettings?.BuildEnvironment is BuildEnvironment.LegacyTeamBuild && !BuildSettings.SkipLegacyCodeCoverageProcessing)
-            {
-                UseSonarScannerCli = true;
-                runtime.LogDebug(Resources.MSG_SonarScannerCliFallbackForTfsLegacySupport);
-            }
-#endif
         }
 
         if (AggregateProperties.TryGetProperty(SonarProperties.Sources, out _) || AggregateProperties.TryGetProperty(SonarProperties.Tests, out _))

--- a/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/ProcessedArgs.cs
@@ -20,9 +20,6 @@
 
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-#if NETFRAMEWORK
-using SonarScanner.MSBuild.Common.TFS;
-#endif
 
 namespace SonarScanner.MSBuild.PreProcessor;
 
@@ -149,7 +146,6 @@ public class ProcessedArgs
         IAnalysisPropertyProvider cmdLineProperties,
         IAnalysisPropertyProvider globalFileProperties,
         IAnalysisPropertyProvider scannerEnvProperties,
-        BuildSettings buildSettings,
         IRuntime runtime)
     {
         IsValid = true;

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.Designer.cs
@@ -257,7 +257,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
                 return ResourceManager.GetString("ERR_JavaExeNotFoundAtExpectedLocation", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to JreResolver: Download failure. {0}
         ///The analysis will continue with the Java runtime environment found in JAVA_HOME or on the PATH. If you already have a compatible Java version installed, please add either the parameter &quot;/d:sonar.scanner.skipJreProvisioning=true&quot; or &quot;/d:sonar.scanner.javaExePath=&lt;PATH&gt;&quot;..
@@ -267,7 +267,7 @@ namespace SonarScanner.MSBuild.PreProcessor {
                 return ResourceManager.GetString("ERR_JreResolver_DownloadFailure", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Organization parameter (/o:&quot;&lt;organization&gt;&quot;) is required and needs to be provided!.
         /// </summary>
@@ -1144,15 +1144,6 @@ namespace SonarScanner.MSBuild.PreProcessor {
         internal static string MSG_SonarCloudDetected_SkipVersionCheck {
             get {
                 return ResourceManager.GetString("MSG_SonarCloudDetected_SkipVersionCheck", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Falling back to SonarScannerCLI to guarantee TFS Legacy support..
-        /// </summary>
-        internal static string MSG_SonarScannerCliFallbackForTfsLegacySupport {
-            get {
-                return ResourceManager.GetString("MSG_SonarScannerCliFallbackForTfsLegacySupport", resourceCulture);
             }
         }
         

--- a/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
+++ b/src/SonarScanner.MSBuild.PreProcessor/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -574,9 +574,6 @@ Check the certificates in the truststore file '{1}' specified via the {2} parame
   </data>
   <data name="ERROR_InvalidUseSonarScannerCli" xml:space="preserve">
     <value>The argument 'sonar.scanner.useSonarScannerCLI' has an invalid value. Please ensure it is set to either 'true' or 'false'.</value>
-  </data>
-  <data name="MSG_SonarScannerCliFallbackForTfsLegacySupport" xml:space="preserve">
-    <value>Falling back to SonarScannerCLI to guarantee TFS Legacy support.</value>
   </data>
   <data name="ERR_ArchiveFormatNotSupported" xml:space="preserve">
     <value>The archive format of `{0}` is not supported.</value>


### PR DESCRIPTION
Part of SCAN4NET-1725

----
## Summary by Gitar

- **Refactoring:**
    - Removed logic forcing `Scanner CLI` for TFS Classic in `ProcessedArgs.cs`
- **Tests:**
    - Cleaned up unit tests in `AnalysisConfigGeneratorTests.cs`

<sub>This will update automatically on new commits.</sub>