### PR TITLE
SCAN4NET-1754 Extract SonarWebServerBase.IsConfigurationValid

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -153,24 +153,6 @@ public class PreprocessorObjectFactoryTests
     public void CreateScannerCliResolver_Success() =>
         new PreprocessorObjectFactory(runtime).CreateScannerCliResolver(MockSonarWebServer.Create(), "sonarUserHome").Should().NotBeNull();
 
-    [TestMethod]
-    public async Task CreateSonarWebService_WithoutOrganizationOnSonarCloud_ReturnsNullAndLogsAnErrorAndWarning()
-    {
-        var downloader = Substitute.For<IDownloader>();
-        downloader.Download(new("api/server/version", UriKind.Relative), Arg.Any<bool>()).Returns(Task.FromResult("8.0")); // SonarCloud
-        downloader.DownloadResource(Arg.Any<Uri>()).Returns(new HttpResponseMessage());
-        var sut = new PreprocessorObjectFactory(runtime);
-
-        var server = await sut.CreateSonarWebServer(CreateValidArguments(hostUrl: "https://sonarcloud.io", organization: null), downloader);
-
-        server.Should().BeNull();
-        runtime.Logger.Should().HaveErrorOnce(@"Organization parameter (/o:""<organization>"") is required and needs to be provided!")
-            .And.HaveWarningOnce("""
-            In version 7 of the scanner, the default value for the sonar.host.url changed from "http://localhost:9000" to "https://sonarcloud.io".
-            If the intention was to connect to the local SonarQube instance, please add the parameter: /d:sonar.host.url="http://localhost:9000"
-            """);
-    }
-
     [DataRow(HttpStatusCode.Forbidden)]
     [DataRow(HttpStatusCode.Unauthorized)]
     [TestMethod]

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServerTest.cs
@@ -41,12 +41,6 @@ public class SonarCloudWebServerTest
     private static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(42);
 
     [TestMethod]
-    public void Ctor_OrganizationNull_ShouldThrow() =>
-        ((Func<SonarCloudWebServer>)(() => new SonarCloudWebServer(Substitute.For<IDownloader>(), Substitute.For<IDownloader>(), Version, new TestLogger(), null, HttpTimeout)))
-            .Should().Throw<ArgumentNullException>()
-            .And.ParamName.Should().Be("organization");
-
-    [TestMethod]
     public void Ctor_LogsServerType()
     {
         var logger = new TestLogger();
@@ -55,12 +49,27 @@ public class SonarCloudWebServerTest
     }
 
     [TestMethod]
-    public async Task IsAllValid_AlwaysTrue()
+    public async Task IsAllValid_Valid()
     {
         var context = new Context();
         (await context.Server.IsAllValid()).Should().BeTrue();
         context.Logger.Should().HaveDebugs("SonarCloud detected, skipping server version check.");
         context.Logger.Should().HaveDebugs("SonarCloud detected, skipping license check.");
+    }
+
+    [TestMethod]
+    [DataRow(null)]
+    [DataRow("")]
+    [DataRow(" \t ")]
+    public async Task IsAllValid_WithoutOrganization(string organization)
+    {
+        var context = new Context(organization: organization);
+        (await context.Server.IsAllValid()).Should().BeFalse();
+        context.Logger.Should().HaveErrors(@"Organization parameter (/o:""<organization>"") is required and needs to be provided!")
+            .And.HaveWarningOnce("""
+            In version 7 of the scanner, the default value for the sonar.host.url changed from "http://localhost:9000" to "https://sonarcloud.io".
+            If the intention was to connect to the local SonarQube instance, please add the parameter: /d:sonar.host.url="http://localhost:9000"
+            """);
     }
 
     [TestMethod]
@@ -449,10 +458,10 @@ public class SonarCloudWebServerTest
 
         public SonarCloudWebServer Server => server.Value;
 
-        public Context(HttpMessageHandlerMock handler = null, string cacheBase = null)
+        public Context(HttpMessageHandlerMock handler = null, string cacheBase = null, string organization = Organization)
         {
             MockDownloaderServerSettings(cacheBase);
-            server = new Lazy<SonarCloudWebServer>(() => new SonarCloudWebServer(WebDownloader, ApiDownloader, Version, Logger, Organization, HttpTimeout, handler));
+            server = new Lazy<SonarCloudWebServer>(() => new SonarCloudWebServer(WebDownloader, ApiDownloader, Version, Logger, organization, HttpTimeout, handler));
         }
 
         private void MockDownloaderServerSettings(string cacheBase)

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
@@ -911,6 +911,9 @@ public class SonarWebServerTest
         public override Task<Stream> DownloadJreAsync(JreMetadata metadata) =>
             throw new NotSupportedException();
 
+        protected override bool IsConfigurationValid() =>
+            throw new NotSupportedException();
+
         protected override bool IsServerVersionSupported() =>
             throw new NotSupportedException();
 

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -55,7 +55,7 @@ public class PreprocessorObjectFactory : IPreprocessorObjectFactory
         }
         webDownloader ??= CreateDownloader(args.ServerInfo.ServerUrl);
         apiDownloader ??= CreateDownloader(args.ServerInfo.ApiBaseUrl);
-        if (!await CanAuthenticate(webDownloader))
+        if (!await VerifyCredentials(webDownloader))
         {
             return null;
         }
@@ -65,20 +65,9 @@ public class PreprocessorObjectFactory : IPreprocessorObjectFactory
         {
             return null;
         }
-        if (args.ServerInfo.IsSonarCloud)
-        {
-            if (string.IsNullOrWhiteSpace(args.Organization))
-            {
-                runtime.LogError(Resources.ERR_MissingOrganization);
-                runtime.LogWarning(Resources.WARN_DefaultHostUrlChanged);
-                return null;
-            }
-            return new SonarCloudWebServer(webDownloader, apiDownloader, serverVersion, runtime.Logger, args.Organization, args.HttpTimeout);
-        }
-        else
-        {
-            return new SonarQubeWebServer(webDownloader, apiDownloader, serverVersion, runtime, args.Organization);
-        }
+        return args.ServerInfo.IsSonarCloud
+            ? new SonarCloudWebServer(webDownloader, apiDownloader, serverVersion, runtime.Logger, args.Organization, args.HttpTimeout)
+            : new SonarQubeWebServer(webDownloader, apiDownloader, serverVersion, runtime, args.Organization);
 
         IDownloader CreateDownloader(string baseUrl) =>
             new WebClientDownloaderBuilder(baseUrl, args.HttpTimeout, runtime.Logger)
@@ -174,7 +163,7 @@ public class PreprocessorObjectFactory : IPreprocessorObjectFactory
     /// <summary>
     /// Makes a throw-away request to the server to ensure we can properly authenticate.
     /// </summary>
-    private async Task<bool> CanAuthenticate(IDownloader downloader)
+    private async Task<bool> VerifyCredentials(IDownloader downloader)
     {
         var response = await downloader.DownloadResource(new("api/settings/values?component=unknown", UriKind.Relative));
         if (response.StatusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized)

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarCloudWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarCloudWebServer.cs
@@ -41,8 +41,6 @@ internal class SonarCloudWebServer : SonarWebServerBase
                                HttpMessageHandler handler = null)
         : base(webDownloader, apiDownloader, serverVersion, logger, organization)
     {
-        Contract.ThrowIfNullOrWhitespace(organization, nameof(organization));
-
         unauthenticatedClient = handler is null ? new HttpClient() : new HttpClient(handler, true);
         unauthenticatedClient.Timeout = httpTimeout;
         logger.LogInfo(Resources.MSG_UsingSonarCloud);
@@ -112,6 +110,20 @@ internal class SonarCloudWebServer : SonarWebServerBase
 
     protected override RuleSearchPaging ParseRuleSearchPaging(JObject json) =>
         new(json["total"].ToObject<int>(), json["ps"].ToObject<int>());
+
+    protected override bool IsConfigurationValid()
+    {
+        if (string.IsNullOrWhiteSpace(organization))
+        {
+            logger.LogError(Resources.ERR_MissingOrganization);
+            logger.LogWarning(Resources.WARN_DefaultHostUrlChanged);
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
 
     protected override bool IsServerVersionSupported()
     {

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
@@ -86,6 +86,9 @@ internal class SonarQubeWebServer : SonarWebServerBase
     protected override RuleSearchPaging ParseRuleSearchPaging(JObject json) =>
         new(json["paging"]["total"].ToObject<int>(), json["paging"]["pageSize"].ToObject<int>());
 
+    protected override bool IsConfigurationValid() =>
+        true;
+
     protected override bool IsServerVersionSupported()
     {
         Version failHardBelowVersion;

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServerBase.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServerBase.cs
@@ -35,16 +35,17 @@ public abstract class SonarWebServerBase : IDisposable
     protected readonly IDownloader webDownloader;
     protected readonly IDownloader apiDownloader;
     protected readonly Version serverVersion;
+    protected readonly string organization;
     protected readonly ILogger logger;
 
     private readonly Dictionary<string, IDictionary<string, string>> propertiesCache = new();
-    private readonly string organization;
     private bool disposed;
 
     public abstract Task<IList<SensorCacheEntry>> DownloadCache(ProcessedArgs localSettings);
     public abstract Task<Stream> DownloadEngineAsync(EngineMetadata metadata);
     public abstract Task<Stream> DownloadJreAsync(JreMetadata metadata);
     protected abstract bool IsServerVersionSupported();
+    protected abstract bool IsConfigurationValid();
     protected abstract Task<bool> IsServerLicenseValid();
     protected abstract RuleSearchPaging ParseRuleSearchPaging(JObject json);
 
@@ -60,7 +61,8 @@ public abstract class SonarWebServerBase : IDisposable
     }
 
     public virtual async Task<bool> IsAllValid() =>
-        IsServerVersionSupported()
+        IsConfigurationValid()
+        && IsServerVersionSupported()
         && await IsServerLicenseValid();
 
     public virtual async Task<string> DownloadQualityProfile(string projectKey, string projectBranch, string language)


### PR DESCRIPTION
Part of SCAN4NET-1722

----
## Summary by Gitar

- **Refactoring:**
    - Extracted `IsConfigurationValid` into `SonarWebServerBase` and implemented it in `SonarCloudWebServer` and `SonarQubeWebServer`
    - Renamed `CanAuthenticate` to `VerifyCredentials` in `PreprocessorObjectFactory`
- **Error Handling:**
    - Validates organization parameter via `IsConfigurationValid` instead of throwing during constructor initialization

<sub>This will update automatically on new commits.</sub>