### PR TITLE
SCAN4NET-1755 Enable binary to XML coverage report conversion for all environments

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
@@ -76,7 +76,7 @@ internal class MockObjectFactory : IPreprocessorObjectFactory
 
     public BuildSettings ReadSettings()
     {
-        var settings = BuildSettings.GetSettingsFromEnvironment();
+        var settings = BuildSettings.SettingsFromEnvironment();
         settings.Should().NotBeNull("Test setup error: TFS environment variables have not been set correctly");
         settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild, "Test setup error: build environment was not set correctly");
         return settings;

--- a/Tests/SonarScanner.MSBuild.TFS.Test/BuildSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/BuildSettingsTests.cs
@@ -26,45 +26,6 @@ namespace SonarScanner.MSBuild.TFS.Test;
 public class BuildSettingsTests
 {
     [TestMethod]
-    public void TBSettings_IsInTeamBuild()
-    {
-        // 0. Setup
-        bool result;
-
-        // 1. Env var not set
-        using (var scope = new EnvironmentVariableScope())
-        {
-            scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, null);
-            result = BuildSettings.IsInTeamBuild;
-            result.Should().BeFalse();
-        }
-
-        // 2. Env var set to a non-boolean -> false
-        using (var scope = new EnvironmentVariableScope())
-        {
-            scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "wibble");
-            result = BuildSettings.IsInTeamBuild;
-            result.Should().BeFalse();
-        }
-
-        // 3. Env var set to false -> false
-        using (var scope = new EnvironmentVariableScope())
-        {
-            scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "false");
-            result = BuildSettings.IsInTeamBuild;
-            result.Should().BeFalse();
-        }
-
-        // 4. Env var set to true -> true
-        using (var scope = new EnvironmentVariableScope())
-        {
-            scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "TRUE");
-            result = BuildSettings.IsInTeamBuild;
-            result.Should().BeTrue();
-        }
-    }
-
-    [TestMethod]
     public void TBSettings_NotTeamBuild()
     {
         // 0. Setup
@@ -107,6 +68,22 @@ public class BuildSettingsTests
                 null,
                 null,
                 null);
+        }
+
+        // 3. Env var set to a non-boolean -> false
+        using (var scope = new EnvironmentVariableScope())
+        {
+            scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "wibble");
+            settings = BuildSettings.GetSettingsFromEnvironment();
+            settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild);
+        }
+
+        // 4. Env var set to false -> false
+        using (var scope = new EnvironmentVariableScope())
+        {
+            scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "false");
+            settings = BuildSettings.GetSettingsFromEnvironment();
+            settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild);
         }
     }
 

--- a/Tests/SonarScanner.MSBuild.TFS.Test/BuildSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/BuildSettingsTests.cs
@@ -28,108 +28,71 @@ public class BuildSettingsTests
     [TestMethod]
     public void SettingsFromEnvironment_NoTFSVariable_NotTeamBuild()
     {
-        // 0. Setup
-        BuildSettings settings;
+        using var scope = new EnvironmentVariableScope();
+        scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, null);
 
-        // 1. No environment vars set
-        using (var scope = new EnvironmentVariableScope())
-        {
-            scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, null);
-
-            settings = BuildSettings.GetSettingsFromEnvironment();
-
-            // Check the environment properties
-            CheckExpectedSettings(
-                settings,
-                BuildEnvironment.NotTeamBuild,
-                Directory.GetCurrentDirectory(),
-                null,
-                null,
-                null,
-                null);
-        }
+        var settings = BuildSettings.SettingsFromEnvironment();
+        CheckExpectedSettings(
+            settings,
+            BuildEnvironment.NotTeamBuild,
+            Directory.GetCurrentDirectory(),
+            null,
+            null,
+            null,
+            null);
     }
 
     [TestMethod]
     public void SettingsFromEnvironment_IncompleteTFSVariableSet_NotTeamBuild()
     {
-        // 0. Setup
-        BuildSettings settings;
+        using var scope = new EnvironmentVariableScope();
+        scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, null);
+        scope.SetVariable(EnvironmentVariables.BuildUriLegacy, "build uri");
+        scope.SetVariable(EnvironmentVariables.TfsCollectionUriLegacy, "collection uri");
+        scope.SetVariable(EnvironmentVariables.BuildDirectoryLegacy, "should be ignored");
+        scope.SetVariable(EnvironmentVariables.BuildDirectoryTfs2015, "should be ignored");
 
-        // 2. Some Team build settings provided, but not marked as in team build
-        using (var scope = new EnvironmentVariableScope())
-        {
-            scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, null);
-            scope.SetVariable(EnvironmentVariables.BuildUriLegacy, "build uri");
-            scope.SetVariable(EnvironmentVariables.TfsCollectionUriLegacy, "collection uri");
-            scope.SetVariable(EnvironmentVariables.BuildDirectoryLegacy, "should be ignored");
-            scope.SetVariable(EnvironmentVariables.BuildDirectoryTfs2015, "should be ignored");
-
-            settings = BuildSettings.GetSettingsFromEnvironment();
-
-            CheckExpectedSettings(
-                settings,
-                BuildEnvironment.NotTeamBuild,
-                Directory.GetCurrentDirectory(),
-                null,
-                null,
-                null,
-                null);
-        }
+        var settings = BuildSettings.SettingsFromEnvironment();
+        CheckExpectedSettings(
+            settings,
+            BuildEnvironment.NotTeamBuild,
+            Directory.GetCurrentDirectory(),
+            null,
+            null,
+            null,
+            null);
     }
 
     [TestMethod]
     public void SettingsFromEnvironment_InvalidTFSVariable_NotTeamBuild()
     {
-        // 0. Setup
-        BuildSettings settings;
+        using var scope = new EnvironmentVariableScope();
+        scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "wibble");
 
-        // 3. Env var set to a non-boolean -> false
-        using (var scope = new EnvironmentVariableScope())
-        {
-            scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "wibble");
-            settings = BuildSettings.GetSettingsFromEnvironment();
-            settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild);
-        }
+        BuildSettings.SettingsFromEnvironment().BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild);
     }
 
     [TestMethod]
     public void SettingsFromEnvironment_TFSVariableFalse_NotTeamBuild()
     {
-        // 0. Setup
-        BuildSettings settings;
+        using var scope = new EnvironmentVariableScope();
+        scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "false");
 
-        // 4. Env var set to false -> false
-        using (var scope = new EnvironmentVariableScope())
-        {
-            scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "false");
-            settings = BuildSettings.GetSettingsFromEnvironment();
-            settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild);
-        }
+        BuildSettings.SettingsFromEnvironment().BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild);
     }
 
     [TestMethod]
     public void SettingsFromEnvironment_TFSVariableTrue_TeamBuild()
     {
-        // Arrange
-        BuildSettings settings;
+        using var scope = new EnvironmentVariableScope();
+        scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "TRUE");
+        scope.SetVariable(EnvironmentVariables.BuildUriTfs2015, "http://builduri");
+        scope.SetVariable(EnvironmentVariables.TfsCollectionUriTfs2015, "http://collectionUri");
+        scope.SetVariable(EnvironmentVariables.BuildDirectoryTfs2015, "non-legacy team build");
+        scope.SetVariable(EnvironmentVariables.SourcesDirectoryTfs2015, @"c:\agent\_work\1");
 
-        using (var scope = new EnvironmentVariableScope())
-        {
-            scope.SetVariable(EnvironmentVariables.IsInTeamFoundationBuild, "TRUE");
-            scope.SetVariable(EnvironmentVariables.BuildUriTfs2015, "http://builduri");
-            scope.SetVariable(EnvironmentVariables.TfsCollectionUriTfs2015, "http://collectionUri");
-            scope.SetVariable(EnvironmentVariables.BuildDirectoryTfs2015, "non-legacy team build");
-            scope.SetVariable(EnvironmentVariables.SourcesDirectoryTfs2015, @"c:\agent\_work\1");
-
-            // Act
-            settings = BuildSettings.GetSettingsFromEnvironment();
-        }
-
-        // Assert
+        var settings = BuildSettings.SettingsFromEnvironment();
         settings.Should().NotBeNull("Failed to create the BuildSettings");
-
-        // Check the environment properties
         CheckExpectedSettings(
             settings,
             BuildEnvironment.TeamBuild,

--- a/Tests/SonarScanner.MSBuild.TFS.Test/BuildSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.TFS.Test/BuildSettingsTests.cs
@@ -26,7 +26,7 @@ namespace SonarScanner.MSBuild.TFS.Test;
 public class BuildSettingsTests
 {
     [TestMethod]
-    public void TBSettings_NotTeamBuild()
+    public void SettingsFromEnvironment_NoTFSVariable_NotTeamBuild()
     {
         // 0. Setup
         BuildSettings settings;
@@ -48,6 +48,13 @@ public class BuildSettingsTests
                 null,
                 null);
         }
+    }
+
+    [TestMethod]
+    public void SettingsFromEnvironment_IncompleteTFSVariableSet_NotTeamBuild()
+    {
+        // 0. Setup
+        BuildSettings settings;
 
         // 2. Some Team build settings provided, but not marked as in team build
         using (var scope = new EnvironmentVariableScope())
@@ -69,6 +76,13 @@ public class BuildSettingsTests
                 null,
                 null);
         }
+    }
+
+    [TestMethod]
+    public void SettingsFromEnvironment_InvalidTFSVariable_NotTeamBuild()
+    {
+        // 0. Setup
+        BuildSettings settings;
 
         // 3. Env var set to a non-boolean -> false
         using (var scope = new EnvironmentVariableScope())
@@ -77,6 +91,13 @@ public class BuildSettingsTests
             settings = BuildSettings.GetSettingsFromEnvironment();
             settings.BuildEnvironment.Should().Be(BuildEnvironment.NotTeamBuild);
         }
+    }
+
+    [TestMethod]
+    public void SettingsFromEnvironment_TFSVariableFalse_NotTeamBuild()
+    {
+        // 0. Setup
+        BuildSettings settings;
 
         // 4. Env var set to false -> false
         using (var scope = new EnvironmentVariableScope())
@@ -88,7 +109,7 @@ public class BuildSettingsTests
     }
 
     [TestMethod]
-    public void TBSettings_TeamBuild()
+    public void SettingsFromEnvironment_TFSVariableTrue_TeamBuild()
     {
         // Arrange
         BuildSettings settings;

--- a/src/SonarScanner.MSBuild.Common/TFS/BuildEnvironment.cs
+++ b/src/SonarScanner.MSBuild.Common/TFS/BuildEnvironment.cs
@@ -21,11 +21,10 @@
 namespace SonarScanner.MSBuild.Common.TFS;
 
 /// <summary>
-/// Lists the recognized build environments
+/// Lists the recognized build environments.
 /// </summary>
 public enum BuildEnvironment
 {
     NotTeamBuild,
-    LegacyTeamBuild,
     TeamBuild
 }

--- a/src/SonarScanner.MSBuild.Common/TFS/BuildSettings.cs
+++ b/src/SonarScanner.MSBuild.Common/TFS/BuildSettings.cs
@@ -69,7 +69,7 @@ public class BuildSettings : IBuildSettings
     /// calculated from environment variables.
     /// Returns null if all the required environment variables are not present.
     /// </summary>
-    public static BuildSettings GetSettingsFromEnvironment()
+    public static BuildSettings SettingsFromEnvironment()
     {
         var settings = IsTeamBuild
             ? new BuildSettings

--- a/src/SonarScanner.MSBuild.Common/TFS/BuildSettings.cs
+++ b/src/SonarScanner.MSBuild.Common/TFS/BuildSettings.cs
@@ -29,7 +29,6 @@ namespace SonarScanner.MSBuild.Common;
 /// </summary>
 public class BuildSettings : IBuildSettings
 {
-    public static bool IsInTeamBuild => TryGetBoolEnvironmentVariable(EnvironmentVariables.IsInTeamFoundationBuild, false);
     public BuildEnvironment BuildEnvironment { get; private set; }
     public string TfsUri { get; private set; }
     public string BuildUri { get; private set; }
@@ -56,6 +55,10 @@ public class BuildSettings : IBuildSettings
     /// </summary>
     public string SonarScannerWorkingDirectory { get; private set; }
 
+    private static bool IsTeamBuild => TryGetBoolEnvironmentVariable(EnvironmentVariables.IsInTeamFoundationBuild, false)
+                                        && (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariables.BuildUriLegacy))
+                                            || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(EnvironmentVariables.BuildUriTfs2015)));
+
     /// <summary>
     /// Private constructor to prevent direct creation.
     /// </summary>
@@ -68,33 +71,22 @@ public class BuildSettings : IBuildSettings
     /// </summary>
     public static BuildSettings GetSettingsFromEnvironment()
     {
-        var env = GetBuildEnvironment();
-        var settings = env switch
-        {
-            BuildEnvironment.LegacyTeamBuild => new BuildSettings
+        var settings = IsTeamBuild
+            ? new BuildSettings
             {
-                BuildEnvironment = env,
-                BuildUri = Environment.GetEnvironmentVariable(EnvironmentVariables.BuildUriLegacy),
-                TfsUri = Environment.GetEnvironmentVariable(EnvironmentVariables.TfsCollectionUriLegacy),
-                BuildDirectory = Environment.GetEnvironmentVariable(EnvironmentVariables.BuildDirectoryLegacy),
-                SourcesDirectory = Environment.GetEnvironmentVariable(EnvironmentVariables.SourcesDirectoryLegacy),
-            },
-            BuildEnvironment.TeamBuild => new BuildSettings
-            {
-                BuildEnvironment = env,
+                BuildEnvironment = BuildEnvironment.TeamBuild,
                 BuildUri = Environment.GetEnvironmentVariable(EnvironmentVariables.BuildUriTfs2015),
                 TfsUri = Environment.GetEnvironmentVariable(EnvironmentVariables.TfsCollectionUriTfs2015),
                 BuildDirectory = Environment.GetEnvironmentVariable(EnvironmentVariables.BuildDirectoryTfs2015),
                 SourcesDirectory = Environment.GetEnvironmentVariable(EnvironmentVariables.SourcesDirectoryTfs2015),
                 CoverageToolUserSuppliedPath = Environment.GetEnvironmentVariable(EnvironmentVariables.VsTestToolCustomInstall)
-            },
-            _ => new BuildSettings
+            }
+            : new BuildSettings
             {
-                BuildEnvironment = env,
+                BuildEnvironment = BuildEnvironment.NotTeamBuild,
                 // there's no reliable of way of finding the SourcesDirectory, except after the build
                 CoverageToolUserSuppliedPath = Environment.GetEnvironmentVariable(EnvironmentVariables.VsTestToolCustomInstall)
-            }
-        };
+            };
 
         // We expect the bootstrapper to have set the WorkingDir of the processors to be the temp dir (i.e. .sonarqube)
         settings.AnalysisBaseDirectory = Directory.GetCurrentDirectory();
@@ -126,33 +118,6 @@ public class BuildSettings : IBuildSettings
             SonarScannerWorkingDirectory = workingDirectory,
             SourcesDirectory = workingDirectory,
         };
-    }
-
-    /// <summary>
-    /// Returns the type of the current build environment: not under TeamBuild, legacy TeamBuild, "new" TeamBuild.
-    /// </summary>
-    private static BuildEnvironment GetBuildEnvironment()
-    {
-        var env = BuildEnvironment.NotTeamBuild;
-
-        if (IsInTeamBuild)
-        {
-            // Work out which flavor of TeamBuild
-            var buildUri = Environment.GetEnvironmentVariable(EnvironmentVariables.BuildUriLegacy);
-            if (string.IsNullOrEmpty(buildUri))
-            {
-                buildUri = Environment.GetEnvironmentVariable(EnvironmentVariables.BuildUriTfs2015);
-                if (!string.IsNullOrEmpty(buildUri))
-                {
-                    env = BuildEnvironment.TeamBuild;
-                }
-            }
-            else
-            {
-                env = BuildEnvironment.LegacyTeamBuild;
-            }
-        }
-        return env;
     }
 
     private static bool TryGetBoolEnvironmentVariable(string envVar, bool defaultValue) =>

--- a/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
@@ -198,22 +198,14 @@ public class PostProcessor
 
     private bool ProcessCoverageReport(AnalysisConfig config, IBuildSettings settings, AnalysisResult analysisResult)
     {
-#if NETFRAMEWORK
-        if (settings.BuildEnvironment is BuildEnvironment.TeamBuild)
-        {
-            runtime.LogInfo(Resources.MSG_ConvertingCoverageReports);
-            var additionalProperties = coverageReportProcessor.ProcessCoverageReports(config, settings);
-            WriteProperty(analysisResult.FullPropertiesFilePath, SonarProperties.VsTestReportsPaths, additionalProperties.VsTestReportsPaths);
-            WriteProperty(analysisResult.FullPropertiesFilePath, SonarProperties.VsCoverageXmlReportsPaths, additionalProperties.VsCoverageXmlReportsPaths);
-            analysisResult.ScannerEngineInput.AddVsTestReportPaths(additionalProperties.VsTestReportsPaths);
-            analysisResult.ScannerEngineInput.AddVsXmlCoverageReportPaths(additionalProperties.VsCoverageXmlReportsPaths);
-            return additionalProperties.CoverageConversionPerformed;
-        }
-#endif
-        return false;
+        runtime.LogInfo(Resources.MSG_ConvertingCoverageReports);
+        var additionalProperties = coverageReportProcessor.ProcessCoverageReports(config, settings);
+        WriteProperty(analysisResult.FullPropertiesFilePath, SonarProperties.VsTestReportsPaths, additionalProperties.VsTestReportsPaths);
+        WriteProperty(analysisResult.FullPropertiesFilePath, SonarProperties.VsCoverageXmlReportsPaths, additionalProperties.VsCoverageXmlReportsPaths);
+        analysisResult.ScannerEngineInput.AddVsTestReportPaths(additionalProperties.VsTestReportsPaths);
+        analysisResult.ScannerEngineInput.AddVsXmlCoverageReportPaths(additionalProperties.VsCoverageXmlReportsPaths);
+        return additionalProperties.CoverageConversionPerformed;
     }
-
-#if NETFRAMEWORK
 
     private void WriteProperty(string propertiesFilePath, string property, string[] paths)
     {
@@ -222,8 +214,6 @@ public class PostProcessor
             runtime.File.AppendAllText(propertiesFilePath, $"{Environment.NewLine}{property}={string.Join(",", paths.Select(x => x.Replace(@"\", @"\\")))}");
         }
     }
-
-#endif
 
     private bool InvokeSonarScanner(IAnalysisPropertyProvider cmdLineArgs, AnalysisConfig config, string propertiesFilePath)
     {

--- a/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
+++ b/src/SonarScanner.MSBuild.PostProcessor/PostProcessor.cs
@@ -119,7 +119,6 @@ public class PostProcessor
     {
         var environmentMessage = settings.BuildEnvironment switch
         {
-            BuildEnvironment.LegacyTeamBuild => Resources.SETTINGS_InLegacyTeamBuild,
             BuildEnvironment.TeamBuild => Resources.SETTINGS_InTeamBuild,
             BuildEnvironment.NotTeamBuild => Resources.SETTINGS_NotInTeamBuild,
             _ => throw new InvalidOperationException($"Unexpected BuildEnvironment: {settings.BuildEnvironment}")

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -42,7 +42,7 @@ public class PreProcessor
     public virtual async Task<bool> Execute(IEnumerable<string> args)
     {
         runtime.Logger.SuspendOutput(); // Wait for the correct verbosity to be calculated
-        var buildSettings = BuildSettings.GetSettingsFromEnvironment();
+        var buildSettings = BuildSettings.SettingsFromEnvironment();
         var processedArgs = ArgumentProcessor.TryProcessArgs(args, runtime);
 
         if (processedArgs is null)

--- a/src/SonarScanner.MSBuild/BootstrapperClass.cs
+++ b/src/SonarScanner.MSBuild/BootstrapperClass.cs
@@ -150,7 +150,7 @@ public class BootstrapperClass
         }
 
         Directory.SetCurrentDirectory(bootstrapSettings.TempDirectory);
-        IBuildSettings teamBuildSettings = BuildSettings.GetSettingsFromEnvironment();
+        IBuildSettings teamBuildSettings = BuildSettings.SettingsFromEnvironment();
         var config = GetAnalysisConfig(teamBuildSettings.AnalysisConfigFilePath);
 
         bool succeeded;


### PR DESCRIPTION
Part of SCAN4NET-1725

----
## Summary by Gitar

- **Coverage processing:**
    - Enabled binary to XML coverage report conversion for all environments in `PostProcessor.cs`

<sub>This will update automatically on new commits.</sub>