### PR TITLE
SCAN4NET-1757 Extract WebServer.Create factory methods

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockObjectFactory.cs
@@ -50,7 +50,6 @@ internal class MockObjectFactory : IPreprocessorObjectFactory
         serverProperties.Add("server.key", "server value 1");
         Server.DownloadProperties(null, null).ReturnsForAnyArgs(serverProperties);
         Server.DownloadAllLanguages().Returns(["cs", "vbnet", "another_plugin"]);
-        Server.IsAllValid().Returns(true);
         if (withDefaultRules)
         {
             Server.DownloadRules("qp1").Returns([new SonarRule("csharpsquid", "cs.rule.id")]);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreProcessorTests.cs
@@ -73,27 +73,6 @@ public partial class PreProcessorTests
     }
 
     [TestMethod]
-    public async Task Execute_InvalidSetup_ReturnsFalse()
-    {
-        using var context = new Context(TestContext);
-        context.Factory.Server.IsAllValid().Returns(false);
-
-        var result = await context.Execute();
-
-        result.Should().BeFalse();
-    }
-
-    [TestMethod]
-    public async Task Execute_ValidationCheckThrows_ReturnsFalseAndLogsError()
-    {
-        using var context = new Context(TestContext);
-        context.Factory.Server.IsAllValid().ThrowsAsync(new InvalidOperationException("Some error was thrown during validation check."));
-
-        (await context.Execute()).Should().BeFalse();
-        context.Factory.Runtime.Logger.Should().HaveErrors("Some error was thrown during validation check.");
-    }
-
-    [TestMethod]
     public async Task Execute_TargetsNotInstalled_ReturnsFalseAndLogsDebugMessage()
     {
         using var context = new Context(TestContext);

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -84,17 +84,18 @@ public class PreprocessorObjectFactoryTests
     [DataRow("https://sonarcloud.io", "8.0", typeof(SonarCloudWebServer))]
     [DataRow("https://sonarcloud.io/", "8.0", typeof(SonarCloudWebServer))]
     [DataRow("https://sonarcloud.io//", "8.0", typeof(SonarCloudWebServer))]
-    [DataRow("https://sonarcloud_other.io//", "8.1", typeof(SonarQubeWebServer))]
-    [DataRow("http://localhost:222", "8.9", typeof(SonarQubeWebServer))]
+    [DataRow("https://sonarcloud_other.io//", "26.1", typeof(SonarQubeWebServer))]
+    [DataRow("http://localhost:222", "26.1", typeof(SonarQubeWebServer))]
     public async Task CreateSonarWebServer_CorrectServiceType(string hostUrl, string version, Type serviceType)
     {
         var sut = new PreprocessorObjectFactory(runtime);
         var downloader = Substitute.For<IDownloader>();
         downloader.Download(Arg.Any<Uri>(), Arg.Any<bool>()).Returns(Task.FromResult(version));
         downloader.DownloadResource(Arg.Any<Uri>()).Returns(new HttpResponseMessage());
+        downloader.DownloadResource(new("api/editions/is_valid_license", UriKind.Relative))
+            .Returns(Task.FromResult(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(@"{ ""isValidLicense"": true }") }));
 
         var service = await sut.CreateSonarWebServer(CreateValidArguments(hostUrl), downloader, downloader);
-
         service.Should().BeOfType(serviceType);
     }
 
@@ -119,16 +120,18 @@ public class PreprocessorObjectFactoryTests
     }
 
     [TestMethod]
-    [DataRow("8.9", "10.3", 8)]
-    [DataRow("10.3", "8.9", 10)]
-    [DataRow(null, "8.3", 8)]
-    [DataRow("10.3", null, 10)]
+    [DataRow("26.1", "27.1", 26)]
+    [DataRow("26.1", "25.1", 26)]
+    [DataRow(null, "26.1", 26)]
+    [DataRow("26.1", null, 26)]
     public async Task CreateSonarWebServer_ValidCallSequence_ValidObjectReturned(string endpointResult, string fallbackResult, int expectedVersion)
     {
         var downloader = Substitute.For<IDownloader>();
         downloader.Download(new("analysis/version", UriKind.Relative), Arg.Any<bool>(), LoggerVerbosity.Debug).Returns(Task.FromResult(endpointResult));
         downloader.Download(new("api/server/version", UriKind.Relative), Arg.Any<bool>(), LoggerVerbosity.Info).Returns(Task.FromResult(fallbackResult));
         downloader.DownloadResource(Arg.Any<Uri>()).Returns(new HttpResponseMessage());
+        downloader.DownloadResource(new("api/editions/is_valid_license", UriKind.Relative))
+            .Returns(Task.FromResult(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(@"{ ""isValidLicense"": true }") }));
         var validArgs = CreateValidArguments();
         var sut = new PreprocessorObjectFactory(runtime);
 

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarCloudWebServerTest.cs
@@ -41,18 +41,18 @@ public class SonarCloudWebServerTest
     private static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(42);
 
     [TestMethod]
-    public void Ctor_LogsServerType()
+    public async Task Ctor_LogsServerType()
     {
-        var logger = new TestLogger();
-        _ = new SonarCloudWebServer(Substitute.For<IDownloader>(), Substitute.For<IDownloader>(), Version, logger, Organization, HttpTimeout);
-        logger.Should().HaveInfos("Using SonarCloud.");
+        var context = new Context();
+        await context.CreateServer();
+        context.Logger.Should().HaveInfos("Using SonarCloud.");
     }
 
     [TestMethod]
     public async Task IsAllValid_Valid()
     {
         var context = new Context();
-        (await context.Server.IsAllValid()).Should().BeTrue();
+        (await context.CreateServer()).Should().NotBeNull();
         context.Logger.Should().HaveDebugs("SonarCloud detected, skipping server version check.");
         context.Logger.Should().HaveDebugs("SonarCloud detected, skipping license check.");
     }
@@ -64,7 +64,7 @@ public class SonarCloudWebServerTest
     public async Task IsAllValid_WithoutOrganization(string organization)
     {
         var context = new Context(organization: organization);
-        (await context.Server.IsAllValid()).Should().BeFalse();
+        (await context.CreateServer()).Should().BeNull();
         context.Logger.Should().HaveErrors(@"Organization parameter (/o:""<organization>"") is required and needs to be provided!")
             .And.HaveWarningOnce("""
             In version 7 of the scanner, the default value for the sonar.host.url changed from "http://localhost:9000" to "https://sonarcloud.io".
@@ -139,9 +139,7 @@ public class SonarCloudWebServerTest
     public async Task DownloadCache_InvalidArguments(string projectKey, string branch, string token, string infoMessage)
     {
         var context = new Context();
-        var res = await context.Server
-            .DownloadCache(CreateLocalSettings(projectKey, branch, Organization, token));
-
+        var res = await context.Server.DownloadCache(CreateLocalSettings(projectKey, branch, Organization, token));
         res.Should().BeEmpty();
         context.Logger.Should().HaveInfoOnce(infoMessage);
     }
@@ -159,9 +157,8 @@ public class SonarCloudWebServerTest
         using var stream = new MemoryStream();
         var handler = MockHttpHandler(CacheFullUrl, "https://www.ephemeralUrl.com", stream);
         var context = new Context(handler, CacheBaseUrl);
-        await context.Server
-            .DownloadCache(CreateLocalSettings(ProjectKey, null, Organization, Token));
 
+        await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, null, Organization, Token));
         context.Logger.Should().HaveInfos($"Incremental PR analysis: Automatically detected base branch 'branch-42' from CI Provider '{provider}'.");
         handler.Requests.Should().NotBeEmpty();
     }
@@ -179,9 +176,8 @@ public class SonarCloudWebServerTest
         using var stream = new MemoryStream();
         var handler = MockHttpHandler(CacheFullUrl, "https://www.ephemeralUrl.com", stream);
         var context = new Context(handler, CacheBaseUrl);
-        await context.Server
-            .DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
 
+        await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
         context.Logger.Should().HaveInfoOnce("Downloading cache. Project key: project-key, branch: project-branch.");
         handler.Requests.Should().NotBeEmpty();
     }
@@ -195,9 +191,8 @@ public class SonarCloudWebServerTest
         using var stream = new MemoryStream();
         var handler = MockHttpHandler(cacheFullUrl, "https://www.ephemeralUrl.com", stream);
         var context = new Context(handler, cacheBaseUrl);
-        var result = await context.Server
-            .DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
         result.Should().BeEmpty();
         context.Logger.Should().HaveDebugOnce($"Incremental PR Analysis: Requesting 'prepare_read' from {cacheFullUrl}");
         handler.Requests.Should().NotBeEmpty();
@@ -211,9 +206,8 @@ public class SonarCloudWebServerTest
         using var stream = CreateCacheStream(new SensorCacheEntry { Key = "key", Data = ByteString.CopyFromUtf8("value") });
         var handler = MockHttpHandler(CacheFullUrl, "https://www.ephemeralUrl.com", stream);
         var context = new Context(handler, CacheBaseUrl);
-        var result = await context.Server
-            .DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token, tokenKey));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token, tokenKey));
         result.Should().ContainSingle();
         result.Single(x => x.Key == "key").Data.ToStringUtf8().Should().Be("value");
         context.Logger.Should().HaveInfos("Downloading cache. Project key: project-key, branch: project-branch.");
@@ -225,9 +219,8 @@ public class SonarCloudWebServerTest
     {
         var handler = MockHttpHandler(CacheFullUrl, "irrelevant", HttpStatusCode.Forbidden);
         var context = new Context(handler, CacheBaseUrl);
-        var result = await context.Server
-            .DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
         result.Should().BeEmpty();
         context.Logger.Should().HaveDebugOnce("Incremental PR analysis: an error occurred while retrieving the cache entries! 'prepare_read' did not respond successfully.");
         handler.Requests.Should().NotBeEmpty();
@@ -238,9 +231,8 @@ public class SonarCloudWebServerTest
     {
         var handler = MockHttpHandler(CacheFullUrl, string.Empty);
         var context = new Context(handler, CacheBaseUrl);
-        var result = await context.Server
-            .DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
         result.Should().BeEmpty();
         context.Logger.Should().HaveDebugOnce("Incremental PR analysis: an error occurred while retrieving the cache entries! 'prepare_read' response was empty.");
         handler.Requests.Should().NotBeEmpty();
@@ -251,9 +243,8 @@ public class SonarCloudWebServerTest
     {
         var handler = MockHttpHandler(CacheFullUrl, @"{ ""enabled"": ""false"", ""url"":""https://www.sonarsource.com"" }");
         var context = new Context(handler, CacheBaseUrl);
-        var result = await context.Server
-            .DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
         result.Should().BeEmpty();
         context.Logger.Should().HaveDebugOnce(
             "Incremental PR analysis: an error occurred while retrieving the cache entries! 'prepare_read' response: { Enabled = False, Url = https://www.sonarsource.com }.");
@@ -265,9 +256,8 @@ public class SonarCloudWebServerTest
     {
         var handler = MockHttpHandler(CacheFullUrl, @"{ ""enabled"": ""true"" }");
         var context = new Context(handler, CacheBaseUrl);
-        var result = await context.Server
-            .DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
         result.Should().BeEmpty();
         context.Logger.Should().HaveDebugOnce("Incremental PR analysis: an error occurred while retrieving the cache entries! 'prepare_read' response: { Enabled = True, Url =  }.");
         handler.Requests.Should().NotBeEmpty();
@@ -279,9 +269,8 @@ public class SonarCloudWebServerTest
         using var stream = new MemoryStream([42, 42]); // this is a random byte array that fails deserialization
         var handler = MockHttpHandler(CacheFullUrl, "https://www.ephemeralUrl.com", stream);
         var context = new Context(handler, CacheBaseUrl);
-        var result = await context.Server
-            .DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch, Organization, Token));
         result.Should().BeEmpty();
         var warningDetails =
 #if NET
@@ -315,7 +304,6 @@ public class SonarCloudWebServerTest
                 }
                 """);
         var rules = await context.Server.DownloadRules("qp");
-
         rules.Should().ContainSingle();
         rules[0].RepoKey.Should().Be("csharpsquid");
         rules[0].RuleKey.Should().Be("S2757");
@@ -330,8 +318,8 @@ public class SonarCloudWebServerTest
         using var responseStream = new MemoryStream([1, 2, 3]);
         var response = new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StreamContent(responseStream) };
         var context = new Context(new HttpMessageHandlerMock((_, _) => Task.FromResult(response)));
-        var actual = await context.Server.DownloadJreAsync(CreateJreMetadata(new("http://localhost/path-to-jre")));
 
+        var actual = await context.Server.DownloadJreAsync(CreateJreMetadata(new("http://localhost/path-to-jre")));
         using var stream = new MemoryStream(); // actual is not a memory stream because of how HttpClient reads it from the handler.
         await actual.CopyToAsync(stream);
         stream.ToArray().Should().BeEquivalentTo([1, 2, 3]);
@@ -360,9 +348,8 @@ public class SonarCloudWebServerTest
         using var responseStream = new MemoryStream([1, 2, 3]);
         var response = new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StreamContent(responseStream) };
         var context = new Context(new HttpMessageHandlerMock((_, _) => Task.FromResult(response)));
-        var actual = await context.Server
-            .DownloadEngineAsync(CreateEngineMetadata(new("http://localhost/path-to-engine")));
 
+        var actual = await context.Server.DownloadEngineAsync(CreateEngineMetadata(new("http://localhost/path-to-engine")));
         using var stream = new MemoryStream(); // actual is not a memory stream because of how HttpClient reads it from the handler.
         await actual.CopyToAsync(stream);
         stream.ToArray().Should().BeEquivalentTo([1, 2, 3]);
@@ -454,15 +441,21 @@ public class SonarCloudWebServerTest
         public readonly IDownloader WebDownloader = Substitute.For<IDownloader>();
         public readonly IDownloader ApiDownloader = Substitute.For<IDownloader>();
         public readonly TestLogger Logger = new();
-        private readonly Lazy<SonarCloudWebServer> server;
+        private readonly HttpMessageHandlerMock handler;
+        private readonly string organization;
+        private SonarCloudWebServer server;
 
-        public SonarCloudWebServer Server => server.Value;
+        public SonarCloudWebServer Server => server ??= CreateServer().Result;
 
         public Context(HttpMessageHandlerMock handler = null, string cacheBase = null, string organization = Organization)
         {
+            this.handler = handler;
+            this.organization = organization;
             MockDownloaderServerSettings(cacheBase);
-            server = new Lazy<SonarCloudWebServer>(() => new SonarCloudWebServer(WebDownloader, ApiDownloader, Version, Logger, organization, HttpTimeout, handler));
         }
+
+        public Task<SonarCloudWebServer> CreateServer() =>
+            SonarCloudWebServer.Create(WebDownloader, ApiDownloader, Version, Logger, organization, HttpTimeout, handler);
 
         private void MockDownloaderServerSettings(string cacheBase)
         {

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeWebServerTest.cs
@@ -24,7 +24,6 @@ using SonarScanner.MSBuild.PreProcessor.EngineResolution;
 using SonarScanner.MSBuild.PreProcessor.JreResolution;
 using SonarScanner.MSBuild.PreProcessor.Protobuf;
 using SonarScanner.MSBuild.PreProcessor.WebServer;
-using static Humanizer.In;
 
 namespace SonarScanner.MSBuild.PreProcessor.Test;
 
@@ -35,10 +34,10 @@ public class SonarQubeWebServerTest
     private const string ProjectBranch = "project-branch";
 
     [TestMethod]
-    public void Ctor_LogsServerTypeAndVersion()
+    public async Task Ctor_LogsServerTypeAndVersion()
     {
         var context = new Context();
-        _ = context.Server;
+        await context.CreateServer();
         context.Runtime.Logger.Should().HaveInfos("Using SonarQube v2026.1.");
     }
 
@@ -52,8 +51,9 @@ public class SonarQubeWebServerTest
     public async Task IsServerVersionSupported_FailHard_CommercialEdition(string sqVersion)
     {
         var context = new Context(sqVersion);
-        (await context.Server.IsAllValid()).Should().BeFalse();
-        context.Runtime.Logger.Should().HaveErrors("SonarQube versions below 2025.1 are not supported anymore by the SonarScanner for .NET. Please upgrade your SonarQube version or use an older version of the scanner.");
+        (await context.CreateServer()).Should().BeNull();
+        context.Runtime.Logger.Should()
+            .HaveErrors("SonarQube versions below 2025.1 are not supported anymore by the SonarScanner for .NET. Please upgrade your SonarQube version or use an older version of the scanner.");
     }
 
     [TestMethod]
@@ -62,8 +62,9 @@ public class SonarQubeWebServerTest
     public async Task IsServerVersionSupported_FailHard_CommunityEdition(string sqVersion)
     {
         var context = new Context(sqVersion);
-        (await context.Server.IsAllValid()).Should().BeFalse();
-        context.Runtime.Logger.Should().HaveErrors("SonarQube versions below 25.1 are not supported anymore by the SonarScanner for .NET. Please upgrade your SonarQube version or use an older version of the scanner.");
+        (await context.CreateServer()).Should().BeNull();
+        context.Runtime.Logger.Should()
+            .HaveErrors("SonarQube versions below 25.1 are not supported anymore by the SonarScanner for .NET. Please upgrade your SonarQube version or use an older version of the scanner.");
     }
 
     [TestMethod]
@@ -73,7 +74,7 @@ public class SonarQubeWebServerTest
     public async Task IsServerVersionSupported_OutOfSupport_LogWarning(string sqVersion)
     {
         var context = new Context(sqVersion);
-        (await context.Server.IsAllValid()).Should().BeTrue();
+        (await context.CreateServer()).Should().NotBeNull();
         context.Runtime.AnalysisWarnings.Should().HaveMessage("You're using an unsupported version of SonarQube. The next major version release of SonarScanner for .NET will not work with this version. Please upgrade to a newer SonarQube version.");
         context.Runtime.Logger.Should().HaveNoErrors();
     }
@@ -89,7 +90,7 @@ public class SonarQubeWebServerTest
     public async Task IsServerVersionSupported_Supported_NoLogs(string sqVersion)
     {
         var context = new Context(sqVersion);
-        (await context.Server.IsAllValid()).Should().BeTrue();
+        (await context.CreateServer()).Should().NotBeNull();
         context.Runtime.AnalysisWarnings.Should().HaveNoMessages();
         context.Runtime.Logger.Should().HaveNoErrors();
     }
@@ -104,7 +105,7 @@ public class SonarQubeWebServerTest
         context.WebDownloader.DownloadResource(Arg.Any<Uri>()).Returns(Task.FromResult(response));
         context.WebDownloader.BaseUrl.Returns(new Uri("host", UriKind.Relative));
 
-        (await context.Server.IsAllValid()).Should().BeFalse();
+        (await context.CreateServer()).Should().BeNull();
         context.Runtime.Logger.Should().HaveErrorOnce("Your SonarQube instance seems to have an invalid license. Please check it. Server url: host")
             .And.HaveNoWarnings();
     }
@@ -114,7 +115,7 @@ public class SonarQubeWebServerTest
     {
         var context = new Context();
 
-        (await context.Server.IsAllValid()).Should().BeTrue();
+        (await context.CreateServer()).Should().NotBeNull();
         context.Runtime.Logger.Should().HaveNoErrors()
             .And.HaveNoWarnings();
     }
@@ -125,7 +126,7 @@ public class SonarQubeWebServerTest
         var context = new Context();
         context.WebDownloader.DownloadResource(new("api/editions/is_valid_license", UriKind.Relative)).Returns(Task.FromResult(new HttpResponseMessage { StatusCode = HttpStatusCode.Unauthorized }));
 
-        (await context.Server.IsAllValid()).Should().BeFalse();
+        (await context.CreateServer()).Should().BeNull();
         context.Runtime.Logger.Should().HaveErrorOnce("Unauthorized: Access is denied due to invalid credentials. Please check the authentication parameters.")
             .And.HaveNoWarnings();
     }
@@ -138,7 +139,7 @@ public class SonarQubeWebServerTest
         context.WebDownloader.DownloadResource(Arg.Any<Uri>()).Returns(Task.FromResult(response));
         context.WebDownloader.BaseUrl.Returns(new Uri("host", UriKind.Relative));
 
-        (await context.Server.IsAllValid()).Should().BeFalse();
+        (await context.CreateServer()).Should().BeNull();
         context.Runtime.Logger.Should().HaveErrorOnce("Your SonarQube instance seems to have an invalid license. Please check it. Server url: host")
             .And.HaveNoWarnings();
     }
@@ -150,7 +151,7 @@ public class SonarQubeWebServerTest
         var response = new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound, Content = new StringContent(@"{""errors"":[{""msg"":""Unknown url: /api/editions/is_valid_license""}]}") };
         context.WebDownloader.DownloadResource(Arg.Any<Uri>()).Returns(Task.FromResult(response));
 
-        (await context.Server.IsAllValid()).Should().BeTrue();
+        (await context.CreateServer()).Should().NotBeNull();
         context.Runtime.Logger.Should().HaveNoErrors()
             .And.HaveNoWarnings();
     }
@@ -162,7 +163,7 @@ public class SonarQubeWebServerTest
         context.WebDownloader.DownloadResource(new("api/editions/is_valid_license", UriKind.Relative))
             .Returns(Task.FromResult(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(@"{ ""isValidLicense"": true }") }));
 
-        (await context.Server.IsAllValid()).Should().BeTrue();
+        (await context.CreateServer()).Should().NotBeNull();
         await context.WebDownloader.Received().DownloadResource(new("api/editions/is_valid_license", UriKind.Relative));
     }
 
@@ -175,8 +176,8 @@ public class SonarQubeWebServerTest
         const string language = "cs";
         var downloadResult = Tuple.Create(true, $$"""{ profiles: [{"key":"{{profileKey}}","name":"profile1","language":"{{language}}"}]}""");
         context.WebDownloader.TryDownloadIfExists(Arg.Any<Uri>(), Arg.Any<bool>()).Returns(Task.FromResult(downloadResult));
-        var result = await context.Server.DownloadQualityProfile(projectKey, null, language);
 
+        var result = await context.Server.DownloadQualityProfile(projectKey, null, language);
         result.Should().Be(profileKey);
     }
 
@@ -233,7 +234,6 @@ public class SonarQubeWebServerTest
                 }
                 """)));
         var result = context.Server.DownloadProperties("componentName", projectBranch).Result;
-
         result.Should().HaveCount(7);
         result["sonar.exclusions"].Should().Be("myfile,myfile2");
         result["sonar.junit.reportsPath"].Should().Be("testing.xml");
@@ -252,8 +252,8 @@ public class SonarQubeWebServerTest
             .Returns(Task.FromResult(Tuple.Create(false, (string)null)));
         context.WebDownloader.Download(new("api/settings/values", UriKind.Relative), Arg.Any<bool>())
             .Returns(Task.FromResult(@"{ settings: [ { key: ""key"", value: ""42"" } ] }"));
-        var result = await context.Server.DownloadProperties(componentName, null);
 
+        var result = await context.Server.DownloadProperties(componentName, null);
         result.Should().ContainSingle().And.ContainKey("key");
         result["key"].Should().Be("42");
     }
@@ -261,16 +261,6 @@ public class SonarQubeWebServerTest
     [TestMethod]
     public async Task DownloadProperties_NullProjectKey_Throws() =>
         (await new Context().Server.Invoking(x => x.DownloadProperties(null, null)).Should().ThrowAsync<ArgumentNullException>()).And.ParamName.Should().Be("projectKey");
-
-    [TestMethod]
-    public async Task DownloadProperties_Sq63plus_Forbidden()
-    {
-        var context = new Context("6.3.0.0");
-        context.WebDownloader.TryDownloadIfExists(Arg.Any<Uri>(), Arg.Any<bool>())
-            .Returns(Task.FromException<Tuple<bool, string>>(new HttpRequestException("Forbidden")));
-
-        await context.Server.Invoking(x => x.DownloadProperties(ProjectKey, null)).Should().ThrowAsync<HttpRequestException>();
-    }
 
     [TestMethod]
     public async Task DownloadProperties_Empty()
@@ -294,7 +284,6 @@ public class SonarQubeWebServerTest
     {
         var context = new Context();
         var result = await context.Server.DownloadCache(CreateLocalSettings(projectKey, branch));
-
         result.Should().BeEmpty();
         context.Runtime.Logger.Should().HaveInfoOnce(debugMessage);
     }
@@ -311,8 +300,8 @@ public class SonarQubeWebServerTest
         var context = new Context();
         using var environment = new EnvironmentVariableScope().SetVariable(variableName, "branch-42");
         context.MockDownloadStream(new MemoryStream());
-        await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, null));
 
+        await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, null));
         context.Runtime.Logger.Should().HaveInfos($"Incremental PR analysis: Automatically detected base branch 'branch-42' from CI Provider '{provider}'.");
     }
 
@@ -328,8 +317,8 @@ public class SonarQubeWebServerTest
         var context = new Context();
         using var environment = new EnvironmentVariableScope().SetVariable(variableName, "wrong_branch");
         context.MockDownloadStream(new MemoryStream());
-        await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
 
+        await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
         context.Runtime.Logger.Should().HaveInfoOnce("Downloading cache. Project key: project-key, branch: project-branch.");
     }
 
@@ -339,8 +328,8 @@ public class SonarQubeWebServerTest
         var context = new Context();
         using Stream stream = new MemoryStream();
         context.WebDownloader.DownloadStream(new("api/analysis_cache/get?project=project-key&branch=project-branch", UriKind.Relative)).Returns(Task.FromResult(stream));
-        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
         result.Should().BeEmpty();
         await context.WebDownloader.Received().DownloadStream(new("api/analysis_cache/get?project=project-key&branch=project-branch", UriKind.Relative));
     }
@@ -351,8 +340,8 @@ public class SonarQubeWebServerTest
         var context = new Context();
         using var stream = CreateCacheStream(new SensorCacheEntry { Key = "key", Data = ByteString.CopyFromUtf8("value") });
         context.MockDownloadStream(stream);
-        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
         result.Should().ContainSingle();
         result.Single(x => x.Key == "key").Data.ToStringUtf8().Should().Be("value");
         context.Runtime.Logger.Should().HaveInfos("Downloading cache. Project key: project-key, branch: project-branch.");
@@ -363,8 +352,8 @@ public class SonarQubeWebServerTest
     {
         var context = new Context();
         context.MockDownloadStream(null);
-        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
         result.Should().BeEmpty();
         context.Runtime.Logger.Should().HaveNoWarnings()
             .And.HaveNoErrors(); // There are no errors or warnings logs but we will display an info message in the caller: "Cache data is empty. A full analysis will be performed."
@@ -375,10 +364,9 @@ public class SonarQubeWebServerTest
     {
         var context = new Context();
         context.MockDownloadStream(new MemoryStream());
-        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
         result.Should().BeEmpty();
-        context.Runtime.Logger.Should().HaveNoDebugs();
     }
 
     [TestMethod]
@@ -386,8 +374,8 @@ public class SonarQubeWebServerTest
     {
         var context = new Context();
         context.WebDownloader.DownloadStream(Arg.Any<Uri>()).Returns(Task.FromException<Stream>(new HttpRequestException()));
-        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
         result.Should().BeEmpty();
         context.Runtime.Logger.Should()
             .HaveWarningOnce("Incremental PR analysis: an error occurred while retrieving the cache entries! Exception of type 'System.Net.Http.HttpRequestException' was thrown.");
@@ -400,8 +388,8 @@ public class SonarQubeWebServerTest
         var stream = Substitute.For<Stream>();
         stream.Length.Returns(x => throw new InvalidOperationException());
         context.MockDownloadStream(stream);
-        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
         result.Should().BeEmpty();
         context.Runtime.Logger.Should()
             .HaveWarningOnce("Incremental PR analysis: an error occurred while retrieving the cache entries! Operation is not valid due to the current state of the object.");
@@ -412,8 +400,8 @@ public class SonarQubeWebServerTest
     {
         var context = new Context();
         context.MockDownloadStream(new MemoryStream([42, 42])); // this is a random byte array that fails deserialization
-        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
 
+        var result = await context.Server.DownloadCache(CreateLocalSettings(ProjectKey, ProjectBranch));
         result.Should().BeEmpty();
         context.Runtime.Logger.Should().HaveWarningOnce("Incremental PR analysis: an error occurred while retrieving the cache entries! While parsing a protocol message, the input ended unexpectedly in the middle of a field.  This could mean either that the input has been truncated or that an embedded message misreported its own length.");
     }
@@ -440,7 +428,6 @@ public class SonarQubeWebServerTest
                 }
                 """);
         var rules = await context.Server.DownloadRules("qp");
-
         rules.Should().ContainSingle();
         rules[0].RepoKey.Should().Be("csharpsquid");
         rules[0].RuleKey.Should().Be("S2757");
@@ -459,8 +446,8 @@ public class SonarQubeWebServerTest
                 new("analysis/jres/someId", UriKind.Relative),
                 Arg.Is<Dictionary<string, string>>(x => x.Single().Key == "Accept" && x.Single().Value == "application/octet-stream"))
             .Returns(Task.FromResult(expected));
-        var actual = await context.Server.DownloadJreAsync(new JreMetadata("someId", null, null, null, null));
 
+        var actual = await context.Server.DownloadJreAsync(new JreMetadata("someId", null, null, null, null));
         ((MemoryStream)actual).ToArray().Should().BeEquivalentTo([1, 2, 3]);
         context.Runtime.Logger.Should().HaveDebugs("Downloading Java JRE from analysis/jres/someId.");
     }
@@ -490,8 +477,8 @@ public class SonarQubeWebServerTest
                 new("analysis/engine", UriKind.Relative),
                 Arg.Is<Dictionary<string, string>>(x => x.Single().Key == "Accept" && x.Single().Value == "application/octet-stream"))
             .Returns(Task.FromResult(expected));
-        var actual = await context.Server.DownloadEngineAsync(new EngineMetadata(null, null, null));
 
+        var actual = await context.Server.DownloadEngineAsync(new EngineMetadata(null, null, null));
         ((MemoryStream)actual).ToArray().Should().BeEquivalentTo([1, 2, 3]);
         context.Runtime.Logger.Should().HaveDebugs("Downloading Scanner Engine from analysis/engine");
     }
@@ -538,16 +525,22 @@ public class SonarQubeWebServerTest
         public readonly IDownloader WebDownloader = Substitute.For<IDownloader>();
         public readonly IDownloader ApiDownloader = Substitute.For<IDownloader>();
         public readonly TestRuntime Runtime = new();
-        private readonly Lazy<SonarQubeWebServer> server;
+        private readonly Version version;
+        private readonly string organization;
+        private SonarQubeWebServer server;
 
-        public SonarQubeWebServer Server => server.Value;
+        public SonarQubeWebServer Server => server ??= CreateServer().Result;
 
         public Context(string version = "2026.1", string organization = null)
         {
-            server = new Lazy<SonarQubeWebServer>(() => new SonarQubeWebServer(WebDownloader, ApiDownloader, new(version), Runtime, organization));
+            this.version = new(version);
+            this.organization = organization;
             var response = new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(@"{ ""isValidLicense"": true }") };
             WebDownloader.DownloadResource(Arg.Any<Uri>()).Returns(Task.FromResult(response));
         }
+
+        public Task<SonarQubeWebServer> CreateServer() =>
+            SonarQubeWebServer.Create(WebDownloader, ApiDownloader, version, Runtime, organization);
 
         public void MockDownloadStream(Stream stream) =>
             WebDownloader.DownloadStream(Arg.Any<Uri>()).Returns(Task.FromResult(stream));

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarWebServerTest.cs
@@ -39,7 +39,7 @@ public class SonarWebServerTest
     [TestInitialize]
     public void Init()
     {
-        version = new Version("9.9");
+        version = new Version("2026.1");
         logger = new();
         downloader = Substitute.For<IDownloader>();
         sut = CreateServer(version);
@@ -56,6 +56,13 @@ public class SonarWebServerTest
         ((Func<SonarWebServerStub>)(() => new SonarWebServerStub(downloader, null, version, logger, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("apiDownloader");
         ((Func<SonarWebServerStub>)(() => new SonarWebServerStub(downloader, downloader, null, logger, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("serverVersion");
         ((Func<SonarWebServerStub>)(() => new SonarWebServerStub(downloader, downloader, version, null, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("logger");
+    }
+
+    [TestMethod]
+    public async Task IsAllValid_Throws_LogsError()
+    {
+        (await sut.IsAllValidPublic()).Should().BeFalse();
+        logger.Should().HaveErrors("Specified method is not supported.");   // NotSupportedException in the stub
     }
 
     [TestMethod]
@@ -901,6 +908,9 @@ public class SonarWebServerTest
         public SonarWebServerStub(IDownloader webDownloader, IDownloader apiDownloader, Version serverVersion, ILogger logger, string organization)
             : base(webDownloader, apiDownloader, serverVersion, logger, organization)
         { }
+
+        public Task<bool> IsAllValidPublic() =>
+            IsAllValid();
 
         public override Task<IList<SensorCacheEntry>> DownloadCache(ProcessedArgs localSettings) =>
             throw new NotSupportedException();

--- a/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreProcessor.cs
@@ -77,19 +77,6 @@ public class PreProcessor
         {
             return false;
         }
-        try
-        {
-            if (!await server.IsAllValid())
-            {
-                return false;
-            }
-        }
-        catch (Exception ex)
-        {
-            runtime.LogError(ex.Message);
-            runtime.LogDebug(ex.StackTrace);
-            return false;
-        }
         runtime.Telemetry[TelemetryKeys.ServerInfoVersion] = server.ServerVersion.ToString();
 
         var jreResolver = factory.CreateJreResolver(server, localSettings.UserHome);

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -66,8 +66,8 @@ public class PreprocessorObjectFactory : IPreprocessorObjectFactory
             return null;
         }
         return args.ServerInfo.IsSonarCloud
-            ? new SonarCloudWebServer(webDownloader, apiDownloader, serverVersion, runtime.Logger, args.Organization, args.HttpTimeout)
-            : new SonarQubeWebServer(webDownloader, apiDownloader, serverVersion, runtime, args.Organization);
+            ? await SonarCloudWebServer.Create(webDownloader, apiDownloader, serverVersion, runtime.Logger, args.Organization, args.HttpTimeout)
+            : await SonarQubeWebServer.Create(webDownloader, apiDownloader, serverVersion, runtime, args.Organization);
 
         IDownloader CreateDownloader(string baseUrl) =>
             new WebClientDownloaderBuilder(baseUrl, args.HttpTimeout, runtime.Logger)

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarCloudWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarCloudWebServer.cs
@@ -32,18 +32,30 @@ internal class SonarCloudWebServer : SonarWebServerBase
 {
     private readonly HttpClient unauthenticatedClient;
 
-    public SonarCloudWebServer(IDownloader webDownloader,
-                               IDownloader apiDownloader,
-                               Version serverVersion,
-                               ILogger logger,
-                               string organization,
-                               TimeSpan httpTimeout,
-                               HttpMessageHandler handler = null)
-        : base(webDownloader, apiDownloader, serverVersion, logger, organization)
+    private SonarCloudWebServer(IDownloader webDownloader, IDownloader apiDownloader, Version serverVersion, ILogger logger, string organization, HttpClient unauthenticatedClient)
+        : base(webDownloader, apiDownloader, serverVersion, logger, organization) =>
+        this.unauthenticatedClient = unauthenticatedClient;
+
+    public static async Task<SonarCloudWebServer> Create(IDownloader webDownloader,
+                                                         IDownloader apiDownloader,
+                                                         Version serverVersion,
+                                                         ILogger logger,
+                                                         string organization,
+                                                         TimeSpan httpTimeout,
+                                                         HttpMessageHandler handler = null)
     {
-        unauthenticatedClient = handler is null ? new HttpClient() : new HttpClient(handler, true);
-        unauthenticatedClient.Timeout = httpTimeout;
+        var unauthenticatedClient = handler is null ? new HttpClient { Timeout = httpTimeout } : new HttpClient(handler, true) { Timeout = httpTimeout };
+        var ret = new SonarCloudWebServer(webDownloader, apiDownloader, serverVersion, logger, organization, unauthenticatedClient);
         logger.LogInfo(Resources.MSG_UsingSonarCloud);
+        if (await ret.IsAllValid())
+        {
+            return ret;
+        }
+        else
+        {
+            ret.Dispose();
+            return null;
+        }
     }
 
     public override async Task<IList<SensorCacheEntry>> DownloadCache(ProcessedArgs localSettings)

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarQubeWebServer.cs
@@ -30,11 +30,23 @@ internal class SonarQubeWebServer : SonarWebServerBase
 {
     private readonly IRuntime runtime;
 
-    public SonarQubeWebServer(IDownloader webDownloader, IDownloader apiDownloader, Version serverVersion, IRuntime runtime, string organization)
-        : base(webDownloader, apiDownloader, serverVersion, runtime.Logger, organization)
-    {
+    private SonarQubeWebServer(IDownloader webDownloader, IDownloader apiDownloader, Version serverVersion, IRuntime runtime, string organization)
+        : base(webDownloader, apiDownloader, serverVersion, runtime.Logger, organization) =>
         this.runtime = runtime;
+
+    public static async Task<SonarQubeWebServer> Create(IDownloader webDownloader, IDownloader apiDownloader, Version serverVersion, IRuntime runtime, string organization)
+    {
+        var ret = new SonarQubeWebServer(webDownloader, apiDownloader, serverVersion, runtime, organization);
         runtime.LogInfo(Resources.MSG_UsingSonarQube, serverVersion);
+        if (await ret.IsAllValid())
+        {
+            return ret;
+        }
+        else
+        {
+            ret.Dispose();
+            return null;
+        }
     }
 
     public override async Task<IList<SensorCacheEntry>> DownloadCache(ProcessedArgs localSettings)

--- a/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServerBase.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/WebServer/SonarWebServerBase.cs
@@ -60,11 +60,6 @@ public abstract class SonarWebServerBase : IDisposable
         this.organization = organization;
     }
 
-    public virtual async Task<bool> IsAllValid() =>
-        IsConfigurationValid()
-        && IsServerVersionSupported()
-        && await IsServerLicenseValid();
-
     public virtual async Task<string> DownloadQualityProfile(string projectKey, string projectBranch, string language)
     {
         var component = ComponentIdentifier(projectKey, projectBranch);
@@ -197,6 +192,20 @@ public abstract class SonarWebServerBase : IDisposable
             webDownloader.Dispose();
             apiDownloader.Dispose();
             disposed = true;
+        }
+    }
+
+    protected virtual async Task<bool> IsAllValid()
+    {
+        try
+        {
+            return IsConfigurationValid() && IsServerVersionSupported() && await IsServerLicenseValid();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex.Message);
+            logger.LogDebug(ex.StackTrace);
+            return false;
         }
     }
 


### PR DESCRIPTION
Part of SCAN4NET-1722

I made this a separate PR, as it creates a log of noise. By calling `IsAllValid` for more scaffolding, more abandoned UTs for old version were found.