### PR TITLE
SCAN4NET-1770 UTs: Cleanup old SQ versions

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/AnalysisConfigGeneratorTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/AnalysisConfigProcessing/AnalysisConfigGeneratorTests.cs
@@ -77,7 +77,7 @@ public class AnalysisConfigGeneratorTests
         var additionalSettings = new Dictionary<string, string> { { "UnchangedFilesPath", @"f:\UnchangedFiles.txt" } };
         Directory.CreateDirectory(localSettings.SonarConfigDirectory); // config directory needs to exist
 
-        var actualConfig = AnalysisConfigGenerator.GenerateFile(args, localSettings, additionalSettings, serverSettings, analyzersSettings, "9.9", null, null, null, runtime);
+        var actualConfig = AnalysisConfigGenerator.GenerateFile(args, localSettings, additionalSettings, serverSettings, analyzersSettings, "2026.1", null, null, null, runtime);
 
         AssertConfigFileExists(actualConfig);
         runtime.Logger.Should().HaveNoErrors()
@@ -124,7 +124,7 @@ public class AnalysisConfigGeneratorTests
         var settings = BuildSettings.CreateSettingsForTesting(analysisDir);
         Directory.CreateDirectory(settings.SonarConfigDirectory); // config directory needs to exist
 
-        var actualConfig = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "9.9", null, null, null, runtime);
+        var actualConfig = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "2026.1", null, null, null, runtime);
 
         AssertConfigFileExists(actualConfig);
         runtime.Logger.Should().HaveNoErrors()
@@ -186,7 +186,7 @@ public class AnalysisConfigGeneratorTests
         var settings = BuildSettings.CreateSettingsForTesting(analysisDir);
         Directory.CreateDirectory(settings.SonarConfigDirectory); // config directory needs to exist
 
-        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], serverProperties, [], "9.9", null, null, null, runtime);
+        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], serverProperties, [], "2026.1", null, null, null, runtime);
 
         AssertConfigFileExists(config);
         runtime.Logger.Should().HaveNoErrors()
@@ -218,7 +218,7 @@ public class AnalysisConfigGeneratorTests
         var runtime = new TestRuntime();
         var args = CreateProcessedArgs(cmdLineArgs, EmptyPropertyProvider.Instance, runtime);
 
-        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "9.9", null, null, null, runtime);
+        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "2026.1", null, null, null, runtime);
 
         AssertConfigFileExists(config);
         config.HasBeginStepCommandLineCredentials.Should().BeTrue();
@@ -235,7 +235,7 @@ public class AnalysisConfigGeneratorTests
         var runtime = new TestRuntime();
         var args = CreateProcessedArgs(cmdLineArgs, EmptyPropertyProvider.Instance, runtime);
 
-        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "9.9", null, null, null, runtime);
+        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "2026.1", null, null, null, runtime);
 
         AssertConfigFileExists(config);
         config.HasBeginStepCommandLineCredentials.Should().BeTrue();
@@ -249,7 +249,7 @@ public class AnalysisConfigGeneratorTests
         var args = CreateProcessedArgs();
         Directory.CreateDirectory(settings.SonarConfigDirectory); // config directory needs to exist
 
-        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "9.9", null, null, null, new TestRuntime());
+        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "2026.1", null, null, null, new TestRuntime());
 
         AssertConfigFileExists(config);
         config.HasBeginStepCommandLineCredentials.Should().BeFalse();
@@ -603,7 +603,7 @@ public class AnalysisConfigGeneratorTests
         AddIfNotEmpty(propertiesProvider, "sonar.scanner.truststorePassword", "password");
         var args = CreateProcessedArgs(propertiesProvider);
 
-        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "9.9", null, null, null, new TestRuntime());
+        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "2026.1", null, null, null, new TestRuntime());
 
         AssertExpectedScannerOptsSettings("javax.net.ssl.trustStore", "\"C:/path/to/truststore.pfx\"", config);
         Property.TryGetProperty("javax.net.ssl.trustStore", config.LocalSettings, out _).Should().BeFalse();
@@ -624,7 +624,7 @@ public class AnalysisConfigGeneratorTests
         propertiesProvider.AddProperty("sonar.scanner.truststorePassword", null);
         var args = CreateProcessedArgs(propertiesProvider);
 
-        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "9.9", null, null, null, new TestRuntime());
+        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "2026.1", null, null, null, new TestRuntime());
         config.ScannerOptsSettings.Should().ContainSingle().Which.Should().BeEquivalentTo(new { Id = "javax.net.ssl.trustStoreType", Value = "Windows-ROOT" });
 
         Property.TryGetProperty("javax.net.ssl.trustStore", config.LocalSettings, out _).Should().BeFalse();
@@ -645,7 +645,7 @@ public class AnalysisConfigGeneratorTests
         var propertiesProvider = new ListPropertiesProvider([new Property(id, value)]);
         var args = CreateProcessedArgs(propertiesProvider);
 
-        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "9.9", null, null, null, new TestRuntime());
+        var config = AnalysisConfigGenerator.GenerateFile(args, settings, [], EmptyProperties, [], "2026.1", null, null, null, new TestRuntime());
 
         AssertExpectedLocalSetting(id, value, config);
     }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/PreprocessorObjectFactoryTests.cs
@@ -65,16 +65,16 @@ public class PreprocessorObjectFactoryTests
     }
 
     [TestMethod]
-    [DataRow("https://sonarcloud.io", "8.0", typeof(SonarQubeCloud))]
-    [DataRow("https://sonarcloud.io/", "8.0", typeof(SonarQubeCloud))]
-    [DataRow("https://sonarcloud.io//", "8.0", typeof(SonarQubeCloud))]
-    [DataRow("https://sonarcloud_other.io//", "26.1", typeof(SonarQubeServer))]
-    [DataRow("http://localhost:222", "26.1", typeof(SonarQubeServer))]
-    public async Task CreateClient_CorrectServiceType(string hostUrl, string version, Type serviceType)
+    [DataRow("https://sonarcloud.io", typeof(SonarQubeCloud))]
+    [DataRow("https://sonarcloud.io/", typeof(SonarQubeCloud))]
+    [DataRow("https://sonarcloud.io//", typeof(SonarQubeCloud))]
+    [DataRow("https://sonarcloud_other.io//", typeof(SonarQubeServer))]
+    [DataRow("http://localhost:222", typeof(SonarQubeServer))]
+    public async Task CreateClient_CorrectServiceType(string hostUrl, Type serviceType)
     {
         var sut = new PreprocessorObjectFactory(runtime);
         var downloader = Substitute.For<IDownloader>();
-        downloader.Download(Arg.Any<Uri>(), Arg.Any<bool>()).Returns(Task.FromResult(version));
+        downloader.Download(Arg.Any<Uri>(), Arg.Any<bool>()).Returns(Task.FromResult("2026.1"));    // Only read by SonarQubeServer
         downloader.DownloadResource(Arg.Any<Uri>()).Returns(new HttpResponseMessage());
         downloader.DownloadResource(new("api/editions/is_valid_license", UriKind.Relative))
             .Returns(Task.FromResult(new HttpResponseMessage { StatusCode = HttpStatusCode.OK, Content = new StringContent(@"{ ""isValidLicense"": true }") }));

--- a/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/RoslynTargetsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.IntegrationTest/TargetsTests/RoslynTargetsTests.cs
@@ -91,13 +91,13 @@ public class RoslynTargetsTests
 
     [TestMethod]
     [Description("Checks existing analysis settings are merged for projects using SonarQube 7.5+")]
-    public void Settings_ValidSetup_NonLegacyServer_MergeSettings()
+    public void Settings_ValidSetup_MergeSettings()
     {
         var context = new TargetsTestsContext(TestContext);
         var dummyQpRulesetPath = TestUtils.CreateValidEmptyRuleset(context.ProjectFolder, "dummyQp");
         var config = new AnalysisConfig
         {
-            SonarQubeVersion = "7.5", // non-legacy version
+            SonarQubeVersion = "2026.1",
             ServerSettings = [new("sonar.cs.roslyn.ignoreIssues", "false")],
             AnalyzersSettings =
             [
@@ -544,7 +544,7 @@ public class RoslynTargetsTests
         var config = new AnalysisConfig
         {
             SonarQubeHostUrl = "http://sonarqube.com",
-            SonarQubeVersion = "8.9", // Latest behavior, test code is analyzed by default.
+            SonarQubeVersion = "2026.1", // Latest behavior, test code is analyzed by default.
             ServerSettings =
             [
                 new("sonar.cs.roslyn.ignoreIssues", "true"),

--- a/Tests/SonarScanner.MSBuild.Tasks.UnitTest/GetAnalyzerSettingsTests.cs
+++ b/Tests/SonarScanner.MSBuild.Tasks.UnitTest/GetAnalyzerSettingsTests.cs
@@ -59,13 +59,11 @@ public class GetAnalyzerSettingsTests
     }
 
     [TestMethod]
-    [DataRow("7.3", DisplayName = "Legacy")]
-    [DataRow("7.4")]
-    public void ConfigExists_NoLanguage_SettingsOverwritten(string sonarQubeVersion)
+    public void ConfigExists_NoLanguage_SettingsOverwritten()
     {
         var config = new AnalysisConfig
         {
-            SonarQubeVersion = sonarQubeVersion,
+            SonarQubeVersion = "2026.1",
             AnalyzersSettings =
             [
                 new AnalyzerSettings
@@ -88,70 +86,6 @@ public class GetAnalyzerSettingsTests
         testSubject.RuleSetFilePath.Should().BeNull();
         testSubject.AnalyzerFilePaths.Should().BeNull();
         testSubject.AdditionalFilePaths.Should().BeEquivalentTo("original.should.be.preserved.txt");
-    }
-
-    // SONARMSBRU-216: non-assembly files should be filtered out
-    [TestMethod]
-    public void ConfigExists_Legacy_SettingsOverwritten()
-    {
-        var filesInConfig = new List<AnalyzerPlugin>
-        {
-            CreateAnalyzerPlugin(Path.Combine(DriveRoot(), "analyzer1.dll")),
-            CreateAnalyzerPlugin(
-                Path.Combine(DriveRoot(), "not_an_assembly.exe"),
-                Path.Combine(DriveRoot(), "not_an_assembly.zip"),
-                Path.Combine(DriveRoot(), "not_an_assembly.txt"),
-                Path.Combine(DriveRoot("d"), "analyzer2.dll")),
-            CreateAnalyzerPlugin(
-                Path.Combine(DriveRoot(), "not_an_assembly.dll.foo"),
-                Path.Combine(DriveRoot(), "not_an_assembly.winmd")),
-            CreateAnalyzerPlugin(Path.Combine(DriveRoot("e"), "analyzer3.dll"))
-        };
-        var config = new AnalysisConfig
-        {
-            SonarQubeHostUrl = "http://sonarqube.com",
-            SonarQubeVersion = "7.3",
-            ServerSettings =
-            [
-                // Setting should be ignored
-                new("sonar.cs.roslyn.ignoreIssues", "true")
-            ],
-            AnalyzersSettings =
-            [
-                new AnalyzerSettings
-                {
-                    Language = "cs",
-                    RulesetPath = Path.Combine(DriveRoot("f"), "yyy.ruleset"),
-                    AnalyzerPlugins = filesInConfig,
-                    AdditionalFilePaths = [Path.Combine(DriveRoot(), "add1.txt"), Path.Combine(DriveRoot("d"), "add2.txt"), Path.Combine(DriveRoot("e"), "subdir", "add3.txt")]
-                },
-
-                new AnalyzerSettings
-                {
-                    Language = "cobol",
-                    RulesetPath = Path.Combine(DriveRoot("f"), "xxx.ruleset"),
-                    AnalyzerPlugins = filesInConfig,
-                    AdditionalFilePaths = [Path.Combine(DriveRoot("e"), "cobol", "add1.txt"), Path.Combine(DriveRoot("d"), "cobol", "add2.txt")]
-                }
-            ]
-        };
-        var testSubject = CreateConfiguredTestSubject(config, "cs", TestContext);
-        testSubject.OriginalAdditionalFiles =
-        [
-            "original.should.be.preserved.txt",
-            Path.Combine("original.should.be.removed", "add2.txt"),
-            Path.Combine(DriveRoot("e"), "foo", "should.be.removed", "add3.txt")
-        ];
-
-        ExecuteAndCheckSuccess(testSubject);
-
-        testSubject.RuleSetFilePath.Should().Be(Path.Combine(DriveRoot("f"), "yyy.ruleset"));
-        testSubject.AnalyzerFilePaths.Should().BeEquivalentTo(Path.Combine(DriveRoot(), "analyzer1.dll"), Path.Combine(DriveRoot("d"), "analyzer2.dll"), Path.Combine(DriveRoot("e"), "analyzer3.dll"));
-        testSubject.AdditionalFilePaths.Should().BeEquivalentTo(
-            Path.Combine(DriveRoot(), "add1.txt"),
-            Path.Combine(DriveRoot("d"), "add2.txt"),
-            Path.Combine(DriveRoot("e"), "subdir", "add3.txt"),
-            "original.should.be.preserved.txt");
     }
 
     // Expecting both the additional files and the analyzers to be merged
@@ -183,7 +117,7 @@ public class GetAnalyzerSettingsTests
 
         var config = new AnalysisConfig
         {
-            SonarQubeVersion = "7.4",
+            SonarQubeVersion = "2026.1",
             ServerSettings = [new("sonar.cs.roslyn.ignoreIssues", "false")],
             AnalyzersSettings =
             [
@@ -246,7 +180,7 @@ public class GetAnalyzerSettingsTests
         var alwaysPresentAnalyzers = new[] { $"sonar.{language}", "Google.Protobuf" };
         var expectedAnalyzers = alwaysPresentAnalyzers.Concat(additionalDlls).Select(x => Path.Combine(DriveRoot(), $"{x}.dll"));
 
-        var sut = Execute_ConfigExists("2026.1", language, false, null);
+        var sut = Execute_ConfigExists(language, false, null);
         sut.RuleSetFilePath.Should().Be(Path.Combine(DriveRoot(), $"{language}-normal.ruleset"));
         sut.AnalyzerFilePaths.Should().BeEquivalentTo(expectedAnalyzers);
         sut.AdditionalFilePaths.Should().BeEquivalentTo(
@@ -256,13 +190,13 @@ public class GetAnalyzerSettingsTests
     }
 
     [TestMethod]
-    [DataRow("8.9", "cs", "true", DisplayName = "SQ 8.9 - needs exclusion parameter CS")]
-    [DataRow("9.0", "cs", "TRUE", DisplayName = "SQ 9.0 - needs exclusion parameter CS")]
-    [DataRow("10.0", "cs", "tRUE", DisplayName = "SQ 10.0 - needs exclusion parameter CS")]
-    [DataRow("8.9", "vbnet", "true", DisplayName = "SQ 8.9 - needs exclusion parameter VB")]
-    public void ConfigExists_ForTestProject_WhenExcluded_DeactivatedSonarAnalyzerSettingsUsed(string sonarQubeVersion, string language, string excludeTestProject)
+    [DataRow("cs", "true")]
+    [DataRow("cs", "TRUE")]
+    [DataRow("cs", "tRUE")]
+    [DataRow("vbnet", "true")]
+    public void ConfigExists_ForTestProject_WhenExcluded_DeactivatedSonarAnalyzerSettingsUsed(string language, string excludeTestProject)
     {
-        var executedTask = Execute_ConfigExists(sonarQubeVersion, language, true, excludeTestProject);
+        var executedTask = Execute_ConfigExists(language, true, excludeTestProject);
 
         executedTask.RuleSetFilePath.Should().Be(Path.Combine(DriveRoot(), $"{language}-deactivated.ruleset"));
         executedTask.AnalyzerFilePaths.Should().BeEquivalentTo(Path.Combine(DriveRoot(), $"sonar.{language}.dll"), Path.Combine(DriveRoot(), "Google.Protobuf.dll"));
@@ -270,17 +204,17 @@ public class GetAnalyzerSettingsTests
     }
 
     [TestMethod]
-    [DataRow("8.9", "cs", null)]
-    [DataRow("8.9", "cs", "false")]
-    [DataRow("9.0", "cs", "FALSE")]
-    [DataRow("10.0", "cs", "UnexpectedParamValue")]
-    [DataRow("8.9", "vbnet", null)]
-    [DataRow("8.9", "vbnet", "false")]
-    [DataRow("9.0", "vbnet", "FALSE")]
-    [DataRow("10.0", "vbnet", "UnexpectedParamValue")]
-    public void ConfigExists_ForTestProject_SonarAnalyzersAndConfigurationMergedWithUserProvided(string sonarQubeVersion, string language, string excludeTestProject)
+    [DataRow("cs", null)]
+    [DataRow("cs", "false")]
+    [DataRow("cs", "FALSE")]
+    [DataRow("cs", "UnexpectedParamValue")]
+    [DataRow("vbnet", null)]
+    [DataRow("vbnet", "false")]
+    [DataRow("vbnet", "FALSE")]
+    [DataRow("vbnet", "UnexpectedParamValue")]
+    public void ConfigExists_ForTestProject_SonarAnalyzersAndConfigurationMergedWithUserProvided(string language, string excludeTestProject)
     {
-        var executedTask = Execute_ConfigExists(sonarQubeVersion, language, true, excludeTestProject);
+        var executedTask = Execute_ConfigExists(language, true, excludeTestProject);
 
         executedTask.RuleSetFilePath.Should().Be(Path.Combine(DriveRoot(), $"{language}-normal.ruleset"));
         executedTask.AnalyzerFilePaths.Should().BeEquivalentTo(
@@ -299,7 +233,7 @@ public class GetAnalyzerSettingsTests
     [TestMethod]
     public void ConfigExists_ForTestProject_WhenUnknownLanguage_SonarAnalyzersAndConfigurationUsed()
     {
-        var executedTask = Execute_ConfigExists("7.4", "unknownLang", true, null);
+        var executedTask = Execute_ConfigExists("unknownLang", true, null);
 
         executedTask.RuleSetFilePath.Should().BeNull();
         executedTask.AnalyzerFilePaths.Should().BeNull();
@@ -311,7 +245,7 @@ public class GetAnalyzerSettingsTests
     {
         var config = new AnalysisConfig
         {
-            SonarQubeVersion = "7.4",
+            SonarQubeVersion = "2026.1",
             AnalyzersSettings =
             [
                 new AnalyzerSettings
@@ -394,13 +328,13 @@ public class GetAnalyzerSettingsTests
         CheckExpectedDiagnosticLevel(actualRuleset, "LocalOnlyRule", MSCA.ReportDiagnostic.Error);
     }
 
-    private GetAnalyzerSettings Execute_ConfigExists(string sonarQubeVersion, string language, bool isTestProject, string excludeTestProject)
+    private GetAnalyzerSettings Execute_ConfigExists(string language, bool isTestProject, string excludeTestProject)
     {
         // Want to test the behaviour with old and new SQ version. Expecting the same results in each case.
         var config = new AnalysisConfig
         {
-            SonarQubeVersion = sonarQubeVersion,
-            SonarQubeHostUrl = "http://localhost:9000", // If any SQ 8.0 version is passed (other than 8.0.0.29455), this will be classified as SonarQube Cloud
+            SonarQubeVersion = "2026.1",
+            SonarQubeHostUrl = "http://localhost:9000",
             ServerSettings =
             [
                 // Server settings should be ignored. "true" value should break existing tests.
@@ -486,7 +420,7 @@ public class GetAnalyzerSettingsTests
     private static AnalysisConfig CreateMergingAnalysisConfig(string language, string qpRulesetFilePath) =>
         new()
         {
-            SonarQubeVersion = "7.4",
+            SonarQubeVersion = "2026.1",
             ServerSettings = [new($"sonar.{language}.roslyn.ignoreIssues", "false")],
             AnalyzersSettings =
             [


### PR DESCRIPTION
[SCAN4NET-1722](https://sonarsource.atlassian.net/browse/SCAN4NET-1722)

[SCAN4NET-1722]: https://sonarsource.atlassian.net/browse/SCAN4NET-1722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **Test cleanups:**
    - Removed legacy SonarQube version test cases and parameters across unit and integration tests in `GetAnalyzerSettingsTests.cs` and `PreprocessorObjectFactoryTests.cs`
    - Updated default SonarQube versions to `2026.1` in generator and target tests

<sub>This will update automatically on new commits.</sub>