### PR TITLE
SCAN4NET-1773 Move runtime to SonarQubeBase

### DIFF
--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockSonarQube.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/Infrastructure/MockSonarQube.cs
@@ -25,5 +25,5 @@ namespace SonarScanner.MSBuild.PreProcessor.Test;
 public static class MockSonarQube
 {
     public static SonarQubeBase Create() =>
-        Substitute.For<SonarQubeBase>(Substitute.For<IDownloader>(), Substitute.For<IDownloader>(), new TestLogger(), null);
+        Substitute.For<SonarQubeBase>(Substitute.For<IDownloader>(), Substitute.For<IDownloader>(), new TestRuntime(), null);
 }

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeClient/SonarQubeBaseTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeClient/SonarQubeBaseTest.cs
@@ -30,14 +30,14 @@ public class SonarQubeBaseTest
 {
     private const string ProjectKey = "project-key";
 
-    private TestLogger logger;
+    private TestRuntime runtime;
     private IDownloader downloader;
     private SonarQubeStub sut;
 
     [TestInitialize]
     public void Init()
     {
-        logger = new();
+        runtime = new();
         downloader = Substitute.For<IDownloader>();
         sut = CreateClient();
     }
@@ -49,16 +49,16 @@ public class SonarQubeBaseTest
     [TestMethod]
     public void Ctor_Null_Throws()
     {
-        ((Func<SonarQubeStub>)(() => new SonarQubeStub(null, null, logger, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("webDownloader");
-        ((Func<SonarQubeStub>)(() => new SonarQubeStub(downloader, null, logger, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("apiDownloader");
-        ((Func<SonarQubeStub>)(() => new SonarQubeStub(downloader, downloader, null, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("logger");
+        ((Func<SonarQubeStub>)(() => new SonarQubeStub(null, null, runtime, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("webDownloader");
+        ((Func<SonarQubeStub>)(() => new SonarQubeStub(downloader, null, runtime, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("apiDownloader");
+        ((Func<SonarQubeStub>)(() => new SonarQubeStub(downloader, downloader, null, null))).Should().Throw<ArgumentNullException>().And.ParamName.Should().Be("runtime");
     }
 
     [TestMethod]
     public async Task IsAllValid_Throws_LogsError()
     {
         (await sut.IsAllValidPublic()).Should().BeFalse();
-        logger.Should().HaveErrors("Specified method is not supported.");   // NotSupportedException in the stub
+        runtime.Logger.Should().HaveErrors("Specified method is not supported.");   // NotSupportedException in the stub
     }
 
     [TestMethod]
@@ -85,7 +85,7 @@ public class SonarQubeBaseTest
         Func<Task> act = async () => await CreateClient("ThisIsInvalidValue").DownloadQualityProfile(ProjectKey, null, "cs");
 
         await act.Should().ThrowAsync<AnalysisException>().WithMessage("Cannot download quality profile. Check scanner arguments and the reported URL for more information.");
-        logger.Should().HaveErrors("Cannot download quality profile. Check scanner arguments and the reported URL for more information.");
+        runtime.Logger.Should().HaveErrors("Cannot download quality profile. Check scanner arguments and the reported URL for more information.");
     }
 
     [TestMethod]
@@ -721,7 +721,7 @@ public class SonarQubeBaseTest
             .Throw(new InvalidOperationException("Connection failed", new IOException("SSL handshake failed")));
 
         (await sut.DownloadJreMetadataAsync("what", "ever")).Should().BeNull();
-        logger.Should().HaveWarnings("JRE Metadata could not be retrieved from analysis/jres?os=what&arch=ever. Connection failed -> SSL handshake failed");
+        runtime.Logger.Should().HaveWarnings("JRE Metadata could not be retrieved from analysis/jres?os=what&arch=ever. Connection failed -> SSL handshake failed");
     }
 
     [TestMethod]
@@ -735,7 +735,7 @@ public class SonarQubeBaseTest
             .Returns(jresResponse);
 
         (await sut.DownloadJreMetadataAsync("what", "ever")).Should().BeNull();
-        logger.Warnings.Should().ContainSingle().Which.Should().StartWith("JRE Metadata could not be retrieved from analysis/jres?os=what&arch=ever. ");
+        runtime.Logger.Warnings.Should().ContainSingle().Which.Should().StartWith("JRE Metadata could not be retrieved from analysis/jres?os=what&arch=ever. ");
     }
 
     [TestMethod]
@@ -762,7 +762,7 @@ public class SonarQubeBaseTest
         jreMetadata.Sha256.Should().Be("42==");
         jreMetadata.JavaPath.Should().Be("best/language/java.exe");
         jreMetadata.DownloadUrl.Should().BeNull();
-        logger.Should().HaveNoWarnings();
+        runtime.Logger.Should().HaveNoWarnings();
     }
 
     [TestMethod]
@@ -781,7 +781,7 @@ public class SonarQubeBaseTest
 
         jreMetadata.Should().NotBeNull();
         jreMetadata.Id.Should().Be("first");
-        logger.Should().HaveNoWarnings();
+        runtime.Logger.Should().HaveNoWarnings();
     }
 
     [TestMethod]
@@ -792,7 +792,7 @@ public class SonarQubeBaseTest
             .Returns("[]");
 
         (await sut.DownloadJreMetadataAsync("what", "ever")).Should().BeNull();
-        logger.Should().HaveNoWarnings();
+        runtime.Logger.Should().HaveNoWarnings();
     }
 
     [TestMethod]
@@ -804,8 +804,8 @@ public class SonarQubeBaseTest
             .Throw(exception);
 
         (await sut.DownloadEngineMetadataAsync()).Should().BeNull();
-        logger.Should().HaveWarnings("Sonar Engine Metadata could not be retrieved from analysis/engine. Connection failed -> SSL handshake failed");
-        logger.DebugMessages.Should().ContainSingle().Which.Should().StartWith("System.InvalidOperationException: Connection failed").And.Contain("SSL handshake failed");
+        runtime.Logger.Should().HaveWarnings("Sonar Engine Metadata could not be retrieved from analysis/engine. Connection failed -> SSL handshake failed");
+        runtime.Logger.DebugMessages.Should().ContainSingle().Which.Should().StartWith("System.InvalidOperationException: Connection failed").And.Contain("SSL handshake failed");
     }
 
     [TestMethod]
@@ -825,7 +825,7 @@ public class SonarQubeBaseTest
             .Returns(jresResponse);
 
         (await sut.DownloadEngineMetadataAsync()).Should().BeNull();
-        logger.Warnings.Should().ContainSingle().Which.Should().StartWith("Sonar Engine Metadata could not be retrieved from analysis/engine. ");
+        runtime.Logger.Warnings.Should().ContainSingle().Which.Should().StartWith("Sonar Engine Metadata could not be retrieved from analysis/engine. ");
     }
 
     [TestMethod]
@@ -849,7 +849,7 @@ public class SonarQubeBaseTest
             Sha256 = "907f676d488af266431bafd3bc26f58408db2d9e73efc66c882c203f275c739b",
             DownloadUrl = new Uri("https://scanner.sonarcloud.io/engines/sonarcloud-scanner-engine-11.14.1.763.jar")
         });
-        logger.Should().HaveNoWarnings();
+        runtime.Logger.Should().HaveNoWarnings();
     }
 
     [TestMethod]
@@ -872,7 +872,7 @@ public class SonarQubeBaseTest
             Sha256 = "907f676d488af266431bafd3bc26f58408db2d9e73efc66c882c203f275c739b",
             DownloadUrl = (Uri)null,
         });
-        logger.Should().HaveNoWarnings();
+        runtime.Logger.Should().HaveNoWarnings();
     }
 
     [TestMethod]
@@ -888,14 +888,14 @@ public class SonarQubeBaseTest
     }
 
     private SonarQubeStub CreateClient(string organization = null) =>
-        new(downloader, downloader, logger, organization);
+        new(downloader, downloader, runtime, organization);
 
     private class SonarQubeStub : SonarQubeBase
     {
         public override string ServerVersion => throw new NotSupportedException();
 
-        public SonarQubeStub(IDownloader webDownloader, IDownloader apiDownloader, ILogger logger, string organization)
-            : base(webDownloader, apiDownloader, logger, organization)
+        public SonarQubeStub(IDownloader webDownloader, IDownloader apiDownloader, IRuntime runtime, string organization)
+            : base(webDownloader, apiDownloader, runtime, organization)
         { }
 
         public Task<bool> IsAllValidPublic() =>

--- a/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeClient/SonarQubeCloudTest.cs
+++ b/Tests/SonarScanner.MSBuild.PreProcessor.Test/SonarQubeClient/SonarQubeCloudTest.cs
@@ -442,10 +442,12 @@ public class SonarQubeCloudTest
     {
         public readonly IDownloader WebDownloader = Substitute.For<IDownloader>();
         public readonly IDownloader ApiDownloader = Substitute.For<IDownloader>();
-        public readonly TestLogger Logger = new();
         private readonly HttpMessageHandlerMock handler;
         private readonly string organization;
+        private readonly TestRuntime runtime = new();
         private SonarQubeCloud client;
+
+        public TestLogger Logger => runtime.Logger;
 
         public SonarQubeCloud Client => client ??= CreateClient().Result;
 
@@ -457,7 +459,7 @@ public class SonarQubeCloudTest
         }
 
         public Task<SonarQubeCloud> CreateClient() =>
-            SonarQubeCloud.Create(WebDownloader, ApiDownloader, Logger, organization, HttpTimeout, handler);
+            SonarQubeCloud.Create(WebDownloader, ApiDownloader, runtime, organization, HttpTimeout, handler);
 
         private void MockDownloaderServerSettings(string cacheBase)
         {

--- a/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/PreprocessorObjectFactory.cs
@@ -61,7 +61,7 @@ public class PreprocessorObjectFactory
         }
 
         return args.ServerInfo.IsCloud
-            ? await SonarQubeCloud.Create(webDownloader, apiDownloader, runtime.Logger, args.Organization, args.HttpTimeout)
+            ? await SonarQubeCloud.Create(webDownloader, apiDownloader, runtime, args.Organization, args.HttpTimeout)
             : await SonarQubeServer.Create(webDownloader, apiDownloader, runtime, args.Organization);
 
         IDownloader CreateDownloader(string baseUrl) =>

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarQubeClient/SonarQubeBase.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarQubeClient/SonarQubeBase.cs
@@ -35,7 +35,7 @@ public abstract class SonarQubeBase : IDisposable
     protected readonly IDownloader webDownloader;
     protected readonly IDownloader apiDownloader;
     protected readonly string organization;
-    protected readonly ILogger logger;
+    protected readonly IRuntime runtime;
 
     private readonly Dictionary<string, IDictionary<string, string>> propertiesCache = new();
     private bool disposed;
@@ -49,11 +49,11 @@ public abstract class SonarQubeBase : IDisposable
     protected abstract Task<bool> IsServerLicenseValid();
     protected abstract RuleSearchPaging ParseRuleSearchPaging(JObject json);
 
-    protected SonarQubeBase(IDownloader webDownloader, IDownloader apiDownloader, ILogger logger, string organization)
+    protected SonarQubeBase(IDownloader webDownloader, IDownloader apiDownloader, IRuntime runtime, string organization)
     {
         this.webDownloader = webDownloader ?? throw new ArgumentNullException(nameof(webDownloader));
         this.apiDownloader = apiDownloader ?? throw new ArgumentNullException(nameof(apiDownloader));
-        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
         this.organization = organization;
     }
 
@@ -61,7 +61,7 @@ public abstract class SonarQubeBase : IDisposable
     {
         var component = ComponentIdentifier(projectKey, projectBranch);
         var uri = AddOrganization(WebUtils.EscapedUri("api/qualityprofiles/search?project={0}", component));
-        logger.LogDebug(Resources.MSG_FetchingQualityProfile, component);
+        runtime.LogDebug(Resources.MSG_FetchingQualityProfile, component);
 
         var result = await webDownloader.TryDownloadIfExists(uri);
         var contents = result.Item2;
@@ -71,7 +71,7 @@ public abstract class SonarQubeBase : IDisposable
             contents = await webDownloader.Download(uri);
             if (contents is null)
             {
-                logger.LogError(Resources.ERROR_DownloadingQualityProfileFailed);
+                runtime.LogError(Resources.ERROR_DownloadingQualityProfileFailed);
                 throw new AnalysisException(Resources.ERROR_DownloadingQualityProfileFailed);
             }
         }
@@ -88,7 +88,7 @@ public abstract class SonarQubeBase : IDisposable
         while (fetched < total && fetched < limit)
         {
             var uri = WebUtils.EscapedUri("api/rules/search?f=repo,name,severity,lang,internalKey,templateKey,params,actives&ps=500&qprofile={0}&p={1}", qProfile, page.ToString());
-            logger.LogDebug(Resources.MSG_FetchingRules, qProfile);
+            runtime.LogDebug(Resources.MSG_FetchingRules, qProfile);
 
             var contents = await webDownloader.Download(uri);
             var json = JObject.Parse(contents);
@@ -121,7 +121,7 @@ public abstract class SonarQubeBase : IDisposable
         var uri = WebUtils.EscapedUri("static/{0}/{1}", pluginKey, embeddedFileName);
         var targetFilePath = Path.Combine(targetDirectory, embeddedFileName);
 
-        logger.LogDebug(Resources.MSG_DownloadingZip, embeddedFileName, targetDirectory);
+        runtime.LogDebug(Resources.MSG_DownloadingZip, embeddedFileName, targetDirectory);
         return await webDownloader.TryDownloadFileIfExists(uri, targetFilePath);
     }
 
@@ -140,8 +140,8 @@ public abstract class SonarQubeBase : IDisposable
         }
         catch (Exception e)
         {
-            logger.LogWarning(Resources.WARN_JreMetadataNotRetrieved, uri, e.MessageChain());
-            logger.LogDebug(e.ToString());
+            runtime.LogWarning(Resources.WARN_JreMetadataNotRetrieved, uri, e.MessageChain());
+            runtime.LogDebug(e.ToString());
             return null;
         }
     }
@@ -155,8 +155,8 @@ public abstract class SonarQubeBase : IDisposable
         }
         catch (Exception e)
         {
-            logger.LogWarning(Resources.WARN_EngineMetadataNotRetrieved, api, e.MessageChain());
-            logger.LogDebug(e.ToString());
+            runtime.LogWarning(Resources.WARN_EngineMetadataNotRetrieved, api, e.MessageChain());
+            runtime.LogDebug(e.ToString());
             return null;
         }
     }
@@ -200,8 +200,8 @@ public abstract class SonarQubeBase : IDisposable
         }
         catch (Exception ex)
         {
-            logger.LogError(ex.Message);
-            logger.LogDebug(ex.StackTrace);
+            runtime.LogError(ex.Message);
+            runtime.LogDebug(ex.StackTrace);
             return false;
         }
     }
@@ -214,7 +214,7 @@ public abstract class SonarQubeBase : IDisposable
             var value = settings[TestProjectPattern];
             if (value != OldDefaultProjectTestPattern)
             {
-                logger.LogWarning(Resources.WARN_TestProjectPattern, TestProjectPattern);
+                runtime.LogWarning(Resources.WARN_TestProjectPattern, TestProjectPattern);
             }
             settings["sonar.msbuild.testProjectPattern"] = value;
             settings.Remove(TestProjectPattern);
@@ -231,7 +231,7 @@ public abstract class SonarQubeBase : IDisposable
         if (AutomaticBaseBranchDetection.Current() is { } ciProperty)
         {
             branch = ciProperty.Value;
-            logger.LogInfo(Resources.MSG_Processing_PullRequest_AutomaticBranchDetection, ciProperty.Value, ciProperty.Provider);
+            runtime.LogInfo(Resources.MSG_Processing_PullRequest_AutomaticBranchDetection, ciProperty.Value, ciProperty.Provider);
             return true;
         }
         return false;
@@ -259,13 +259,13 @@ public abstract class SonarQubeBase : IDisposable
         }
         else
         {
-            logger.LogDebug(Resources.MSG_FetchingProjectProperties, component);
+            runtime.LogDebug(Resources.MSG_FetchingProjectProperties, component);
             var uri = WebUtils.EscapedUri("api/settings/values?component={0}", component);
             var projectFound = await webDownloader.TryDownloadIfExists(uri, true);
             var contents = projectFound.Item2;
             if (projectFound is { Item1: false })
             {
-                logger.LogDebug("No settings for project {0}. Getting global settings...", component);
+                runtime.LogDebug("No settings for project {0}. Getting global settings...", component);
                 contents = await webDownloader.Download(new("api/settings/values", UriKind.Relative));
             }
             result = ParseSettingsResponse(contents);

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarQubeClient/SonarQubeCloud.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarQubeClient/SonarQubeCloud.cs
@@ -34,20 +34,20 @@ internal class SonarQubeCloud : SonarQubeBase
 
     public override string ServerVersion => "Cloud";    // Well-known value recognized by the analyzer
 
-    private SonarQubeCloud(IDownloader webDownloader, IDownloader apiDownloader, ILogger logger, string organization, HttpClient unauthenticatedClient)
-        : base(webDownloader, apiDownloader, logger, organization) =>
+    private SonarQubeCloud(IDownloader webDownloader, IDownloader apiDownloader, IRuntime runtime, string organization, HttpClient unauthenticatedClient)
+        : base(webDownloader, apiDownloader, runtime, organization) =>
         this.unauthenticatedClient = unauthenticatedClient;
 
     public static async Task<SonarQubeCloud> Create(IDownloader webDownloader,
                                                     IDownloader apiDownloader,
-                                                    ILogger logger,
+                                                    IRuntime runtime,
                                                     string organization,
                                                     TimeSpan httpTimeout,
                                                     HttpMessageHandler handler = null)
     {
         var unauthenticatedClient = handler is null ? new HttpClient { Timeout = httpTimeout } : new HttpClient(handler, true) { Timeout = httpTimeout };
-        var ret = new SonarQubeCloud(webDownloader, apiDownloader, logger, organization, unauthenticatedClient);
-        logger.LogInfo(Resources.MSG_UsingSonarQubeCloud);
+        var ret = new SonarQubeCloud(webDownloader, apiDownloader, runtime, organization, unauthenticatedClient);
+        runtime.LogInfo(Resources.MSG_UsingSonarQubeCloud);
         return await ret.IsAllValid() ? ret : null;     // No dispose for ret or downloaders for simplicity. The program ends soon.
     }
 
@@ -56,12 +56,12 @@ internal class SonarQubeCloud : SonarQubeBase
         _ = localSettings ?? throw new ArgumentNullException(nameof(localSettings));
         if (string.IsNullOrWhiteSpace(localSettings.ProjectKey))
         {
-            logger.LogInfo(Resources.MSG_Processing_PullRequest_NoProjectKey);
+            runtime.LogInfo(Resources.MSG_Processing_PullRequest_NoProjectKey);
             return [];
         }
         if (!TryGetBaseBranch(localSettings, out var branch))
         {
-            logger.LogInfo(Resources.MSG_Processing_PullRequest_NoBranch);
+            runtime.LogInfo(Resources.MSG_Processing_PullRequest_NoBranch);
             return [];
         }
         if (AuthToken(localSettings) is { } token)
@@ -69,13 +69,13 @@ internal class SonarQubeCloud : SonarQubeBase
             var serverSettings = await DownloadProperties(localSettings.ProjectKey, branch);
             if (!serverSettings.TryGetValue(SonarProperties.CacheBaseUrl, out var cacheBaseUrl))
             {
-                logger.LogInfo(Resources.MSG_Processing_PullRequest_NoCacheBaseUrl);
+                runtime.LogInfo(Resources.MSG_Processing_PullRequest_NoCacheBaseUrl);
                 return [];
             }
 
             try
             {
-                logger.LogInfo(Resources.MSG_DownloadingCache, localSettings.ProjectKey, branch);
+                runtime.LogInfo(Resources.MSG_DownloadingCache, localSettings.ProjectKey, branch);
                 var ephemeralUrl = await DownloadEphemeralUrl(localSettings.Organization, localSettings.ProjectKey, branch, token, cacheBaseUrl);
                 if (ephemeralUrl is null)
                 {
@@ -86,14 +86,14 @@ internal class SonarQubeCloud : SonarQubeBase
             }
             catch (Exception e)
             {
-                logger.LogWarning(Resources.WARN_IncrementalPRCacheEntryRetrieval_Error, e.Message);
-                logger.LogDebug(e.ToString());
+                runtime.LogWarning(Resources.WARN_IncrementalPRCacheEntryRetrieval_Error, e.Message);
+                runtime.LogDebug(e.ToString());
                 return [];
             }
         }
         else
         {
-            logger.LogInfo(Resources.MSG_Processing_PullRequest_NoToken);
+            runtime.LogInfo(Resources.MSG_Processing_PullRequest_NoToken);
             return [];
         }
     }
@@ -102,14 +102,14 @@ internal class SonarQubeCloud : SonarQubeBase
     public override async Task<Stream> DownloadJreAsync(JreMetadata metadata)
     {
         _ = metadata.DownloadUrl ?? throw new AnalysisException($"{nameof(JreMetadata)} must contain a valid download URL.");
-        logger.LogDebug(Resources.MSG_JreDownloadUri, metadata.DownloadUrl);
+        runtime.LogDebug(Resources.MSG_JreDownloadUri, metadata.DownloadUrl);
         return await unauthenticatedClient.GetStreamAsync(metadata.DownloadUrl);
     }
 
     public override async Task<Stream> DownloadEngineAsync(EngineMetadata metadata)
     {
         _ = metadata.DownloadUrl ?? throw new AnalysisException($"{nameof(EngineMetadata)} must contain a valid download URL.");
-        logger.LogDebug(Resources.MSG_EngineDownloadUri, metadata.DownloadUrl);
+        runtime.LogDebug(Resources.MSG_EngineDownloadUri, metadata.DownloadUrl);
         return await unauthenticatedClient.GetStreamAsync(metadata.DownloadUrl);
     }
 
@@ -120,8 +120,8 @@ internal class SonarQubeCloud : SonarQubeBase
     {
         if (string.IsNullOrWhiteSpace(organization))
         {
-            logger.LogError(Resources.ERR_MissingOrganization);
-            logger.LogWarning(Resources.WARN_DefaultHostUrlChanged);
+            runtime.LogError(Resources.ERR_MissingOrganization);
+            runtime.LogWarning(Resources.WARN_DefaultHostUrlChanged);
             return false;
         }
         else
@@ -132,13 +132,13 @@ internal class SonarQubeCloud : SonarQubeBase
 
     protected override bool IsServerVersionSupported()
     {
-        logger.LogDebug(Resources.MSG_CloudDetected_SkipVersionCheck);
+        runtime.LogDebug(Resources.MSG_CloudDetected_SkipVersionCheck);
         return true;
     }
 
     protected override Task<bool> IsServerLicenseValid()
     {
-        logger.LogDebug(Resources.MSG_CloudDetected_SkipLicenseCheck);
+        runtime.LogDebug(Resources.MSG_CloudDetected_SkipLicenseCheck);
         return Task.FromResult(true);
     }
 
@@ -157,24 +157,24 @@ internal class SonarQubeCloud : SonarQubeBase
         var uri = new Uri(WebUtils.CreateUri(cacheBaseUrl), WebUtils.EscapedUri("sensor-cache/prepare-read?organization={0}&project={1}&branch={2}", organization, projectKey, branch));
         using var request = new HttpRequestMessage(HttpMethod.Get, uri);
         request.Headers.Add("Authorization", $"Bearer {token}");
-        logger.LogDebug(Resources.MSG_Processing_PullRequest_RequestPrepareRead, uri);
+        runtime.LogDebug(Resources.MSG_Processing_PullRequest_RequestPrepareRead, uri);
 
         using var response = await unauthenticatedClient.SendAsync(request);
         if (!response.IsSuccessStatusCode)
         {
-            logger.LogDebug(Resources.WARN_IncrementalPRCacheEntryRetrieval_Error, "'prepare_read' did not respond successfully.");
+            runtime.LogDebug(Resources.WARN_IncrementalPRCacheEntryRetrieval_Error, "'prepare_read' did not respond successfully.");
             return null;
         }
         var content = await response.Content.ReadAsStringAsync();
         if (string.IsNullOrWhiteSpace(content))
         {
-            logger.LogDebug(Resources.WARN_IncrementalPRCacheEntryRetrieval_Error, "'prepare_read' response was empty.");
+            runtime.LogDebug(Resources.WARN_IncrementalPRCacheEntryRetrieval_Error, "'prepare_read' response was empty.");
             return null;
         }
         var deserialized = JsonConvert.DeserializeAnonymousType(content, new { Enabled = false, Url = string.Empty });
         if (!deserialized.Enabled || string.IsNullOrWhiteSpace(deserialized.Url))
         {
-            logger.LogDebug(Resources.WARN_IncrementalPRCacheEntryRetrieval_Error, $"'prepare_read' response: {deserialized}.");
+            runtime.LogDebug(Resources.WARN_IncrementalPRCacheEntryRetrieval_Error, $"'prepare_read' response: {deserialized}.");
             return null;
         }
 

--- a/src/SonarScanner.MSBuild.PreProcessor/SonarQubeClient/SonarQubeServer.cs
+++ b/src/SonarScanner.MSBuild.PreProcessor/SonarQubeClient/SonarQubeServer.cs
@@ -28,17 +28,13 @@ namespace SonarScanner.MSBuild.PreProcessor.SonarQubeClient;
 
 internal class SonarQubeServer : SonarQubeBase
 {
-    private readonly IRuntime runtime;
     private readonly Version serverVersion;
 
     public override string ServerVersion => serverVersion.ToString();
 
     private SonarQubeServer(IDownloader webDownloader, IDownloader apiDownloader, Version serverVersion, IRuntime runtime, string organization)
-        : base(webDownloader, apiDownloader, runtime.Logger, organization)
-    {
+        : base(webDownloader, apiDownloader, runtime, organization) =>
         this.serverVersion = serverVersion;
-        this.runtime = runtime;
-    }
 
     public static async Task<SonarQubeServer> Create(IDownloader webDownloader, IDownloader apiDownloader, IRuntime runtime, string organization)
     {


### PR DESCRIPTION
Part of  SCAN4NET-1722

**Old:**
Base contains logger and persists it for Cloud and Server.
Server contains runtime and persists it itself.

**New:**
Base contains runtime and persists it for Cloud and Server. It's not used in Cloud yet, but still simplifies the design.