### PR TITLE
SCAN4NET-1788 Fix Cloud IT

### DIFF
--- a/its/src/test/java/com/sonar/it/scanner/msbuild/cloud/CloudProvisioningTest.java
+++ b/its/src/test/java/com/sonar/it/scanner/msbuild/cloud/CloudProvisioningTest.java
@@ -52,7 +52,7 @@ class CloudProvisioningTest {
     assertFalse(result.isSuccess());
     assertThat(result.getLogs()).contains(
       "The arguments 'sonar.host.url' and 'sonar.scanner.sonarcloudUrl' are both set and are different." +
-        " Please set either 'sonar.host.url' for SonarQube or 'sonar.scanner.sonarcloudUrl' for SonarQube Cloud.");
+        " Please set either 'sonar.host.url' for SonarQube Server or 'sonar.scanner.sonarcloudUrl' for SonarQube Cloud.");
   }
 
   @Test


### PR DESCRIPTION
SCAN4NET-1722

----
## Summary by Gitar

- **Tests:**
    - Updated `CloudProvisioningTest` to expect `SonarQube Server` instead of `SonarQube` in log assertions

<sub>This will update automatically on new commits.</sub>